### PR TITLE
Handle buffer size limit in get(pw|gr)nam_r

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -140,7 +140,21 @@ static int uid_determine (const char *req_user)
 
 	pwdbuffer = malloc (pwdlinelen);
 
-	if ((getpwnam_r (req_user, pwdptr, pwdbuffer, pwdlinelen, &temp_pwd_pt)) != 0) {
+	while ((getpwnam_r (req_user, pwdptr, pwdbuffer, pwdlinelen, &temp_pwd_pt)) != 0) {
+		if (errno == ERANGE) {
+			char *n;
+
+			pwdlinelen *= 2;
+			if (pwdlinelen <= 32678) {
+				n = realloc (pwdbuffer, pwdlinelen);
+				if (n != NULL) {
+					pwdbuffer = n;
+					continue;
+				}
+			}
+		}
+
+		free (pwdbuffer);
 	        sprintf (error_string_response,
 	                "The '%s' user is not found in /etc/passwd, please read the documentation.",
 	                req_user);
@@ -169,7 +183,21 @@ static int gid_determine (const char *req_group)
 
 	grpbuffer = malloc (grplinelen);
 
-	if ((getgrnam_r (req_group, grpptr, grpbuffer, grplinelen, &temp_grp_pt)) != 0) {
+	while ((getgrnam_r (req_group, grpptr, grpbuffer, grplinelen, &temp_grp_pt)) != 0) {
+		if (errno == ERANGE) {
+			char *n;
+
+			grplinelen *= 2;
+			if (grplinelen <= 32678) {
+				n = realloc (grpbuffer, grplinelen);
+				if (n != NULL) {
+					grpbuffer = n;
+					continue;
+				}
+			}
+		}
+
+		free (grpbuffer);
 	        sprintf (error_string_response,
 	                "The '%s' group is not found in /etc/group, please read the documentation.",
 	                req_group);


### PR DESCRIPTION
These functions return ERANGE if the supplied buffer is too small to
fit a line.  Try doubling the buffer a few times until it works.
