### PR TITLE
Allow corotypes.h to be included from C++ code.

### DIFF
--- a/include/corosync/corotypes.h
+++ b/include/corosync/corotypes.h
@@ -41,6 +41,10 @@
 #include <time.h>
 #include <sys/time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef int64_t cs_time_t;
 
 #define CS_FALSE 0
@@ -135,6 +139,10 @@ static inline uint64_t cs_timestamp_get(void)
 cs_error_t qb_to_cs_error (int result);
 const char * cs_strerror(cs_error_t err);
 cs_error_t hdb_error_to_cs (int res);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* COROTYPES_H_DEFINED */
 


### PR DESCRIPTION
The title pretty much says it all.  corotypes.h does not include conditional extern "C" blocks, so, for example, using cs_strerror from C++ code causes link errors.
