### PR TITLE
systemd: Set the Restart=on-failure to unit file of corosync-notifyd

### DIFF
--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -7,6 +7,7 @@ After=corosync.service
 EnvironmentFile=@SYSCONFDIR@/sysconfig/corosync-notifyd
 ExecStart=@SBINDIR@/corosync-notifyd -f $OPTIONS
 Type=simple
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I think that it's good to restart when corosync-notifyd was killed, or when it crashed.
