### PR TITLE
systemd unit: Add config example to exert watchdog

### DIFF
--- a/init/corosync.service.in
+++ b/init/corosync.service.in
@@ -9,12 +9,16 @@ ExecStart=@INITWRAPPERSDIR@/corosync start
 ExecStop=@INITWRAPPERSDIR@/corosync stop
 Type=forking
 
-# If you are using with pacemaker and want to exert watchdog,
-# uncomment the line of the following Restart= and RestartSec=.
+# The following config is for corosync with enabled watchdog service.
+#
+#  When corosync watchdog service is being enabled and using with
+#  pacemaker.service, and if you want to exert the watchdog when a
+#  corosync process is terminated abnormally,
+#  uncomment the line of the following Restart= and RestartSec=.
 #Restart=on-failure
-# Specify a period longer than soft_margin as RestartSec.
+#  Specify a period longer than soft_margin as RestartSec.
 #RestartSec=70
-# rewrite according to environment.
+#  rewrite according to environment.
 #ExecStartPre=/sbin/modprobe softdog soft_margin=60
 
 [Install]


### PR DESCRIPTION
This request adds the config example that a watchdog works.

Since "[Requires=corosync.service](https://github.com/ClusterLabs/pacemaker/blob/d924912/mcp/pacemaker.service.in#L10)" is set to pacemaker.service, watchdog of corosync does not work if corosync and pacemaker are started using pacemaker.service.

```
$ systemctl start pacemaker
$ ps -ef|egrep "coros|pacem"
root      1644     1  5 17:28 ?        00:00:00 corosync
root      1650     1  0 17:28 ?        00:00:00 /usr/sbin/pacemakerd -f
haclust+  1651  1650  1 17:28 ?        00:00:00 /usr/libexec/pacemaker/cib
root      1652  1650  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/stonithd
root      1653  1650  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/lrmd
haclust+  1654  1650  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/attrd
haclust+  1655  1650  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/pengine
haclust+  1656  1650  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/crmd
$ pkill -9 corosync
$ ps -ef|egrep "coros|pacem"
root      1653     1  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/lrmd
haclust+  1655     1  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/pengine
root      1679     1  7 17:28 ?        00:00:00 corosync
root      1685     1  0 17:28 ?        00:00:00 /usr/sbin/pacemakerd -f
haclust+  1686  1685  1 17:28 ?        00:00:00 /usr/libexec/pacemaker/cib
root      1687  1685  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/stonithd
haclust+  1688  1685  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/attrd
haclust+  1689  1685  0 17:28 ?        00:00:00 /usr/libexec/pacemaker/crmd
```

It's because pacemakerd is also terminated when corosync has terminated, so restart of pacemakerd and (Requires=)**corosync**.service is performed by Systemd.
