### PR TITLE
Fix return codes to be LSB compliant

### DIFF
--- a/init/corosync.in
+++ b/init/corosync.in
@@ -41,6 +41,7 @@ status()
 	pid=$(pidof $1 2>/dev/null)
 	res=$?
 	if [ $res -ne 0 ]; then
+		res=3
 		echo "$1 is stopped"
 	else
 		echo "$1 (pid $pid) is running..."
@@ -118,16 +119,21 @@ start()
 		if ! wait_for_ipc; then
 			failure
 			rtrn=1
+		else
+			rtrn=0
+			touch $LOCK_FILE
+			success
 		fi
-		touch $LOCK_FILE
-		success
 	fi
 	echo
 }
 
 stop()
 {
-	! status $prog > /dev/null 2>&1 && return
+	if ! status $prog > /dev/null 2>&1; then
+		rtrn=0
+		return
+	fi
 
 	echo -n "Signaling $desc ($prog) to terminate: "
 	kill -TERM $(pidof $prog) > /dev/null 2>&1
@@ -141,6 +147,7 @@ stop()
 	done
 
 	rm -f $LOCK_FILE
+	rtrn=0
 	success
 	echo
 }


### PR DESCRIPTION
`systemctl start corosync` always fail, however `/usr/share/corosync/corosync start` works properly.
systemd expects it returns 0 but `/usr/share/corosync/corosync start` returns 1.

To work properly with systemd, fix return codes.
- `status` returns 3 when Corosync is already stopped.
- `stop` returns 0 when Corosync is already stopped.

Tested following on systemd214 on Arch Linux, corosync is configured with `./configure --enable-systemd`.

```
~]# /usr/share/corosync/corosync status
corosync is stopped

~]# /usr/share/corosync/corosync status; echo $?
corosync is stopped
3

~]# /usr/share/corosync/corosync start; echo $?
Starting Corosync Cluster Engine (corosync): [  OK  ]
0

~]# /usr/share/corosync/corosync status; echo $?
corosync (pid 29953) is running...
0

~]# /usr/share/corosync/corosync stop; echo $?
Signaling Corosync Cluster Engine (corosync) to terminate: [  OK  ]
Waiting for corosync services to unload:.[  OK  ]
0

~]# /usr/share/corosync/corosync stop; echo $?
0
```
