### PR TITLE
fix shared memory leak

### DIFF
--- a/exec/main.c
+++ b/exec/main.c
@@ -1351,6 +1351,10 @@ int main (int argc, char **argv, char **envp)
 	qb_loop_signal_add(corosync_poll_handle, QB_LOOP_HIGH,
 		SIGINT, NULL, sig_exit_handler, NULL);
 	qb_loop_signal_add(corosync_poll_handle, QB_LOOP_HIGH,
+		SIGSEGV, NULL, sigsegv_handler, NULL);
+	qb_loop_signal_add(corosync_poll_handle, QB_LOOP_HIGH,
+		SIGABRT, NULL, sigabrt_handler, NULL);
+	qb_loop_signal_add(corosync_poll_handle, QB_LOOP_HIGH,
 		SIGQUIT, NULL, sig_exit_handler, NULL);
 	qb_loop_signal_add(corosync_poll_handle, QB_LOOP_HIGH,
 		SIGTERM, NULL, sig_exit_handler, NULL);


### PR DESCRIPTION
Hi corosync master,
Recently, i find two problems of corosync:
1. shared memory leak:
if we run 'corosync -v' or 'corosync --help' or 'corosync -invalidparameters', after corosync exits, it will leave one qb-corosync-xxx-blackbox files under '/dev/shm', which will introduce memory leak.
2. corosync doesn't execute signal handlers when it receives SIGSEGV or SIGABRT signal.

Please help to check below patch for these two problems. thanks a lot.
