### PR TITLE
Fix setting of watchdog timer

### DIFF
--- a/exec/wd.c
+++ b/exec/wd.c
@@ -669,7 +669,7 @@ static void wd_top_level_key_changed(
 
 	ENTER();
 
-	if (icmap_get_uint32("resources.watchdog_timeout", &tmp_value_32) != CS_OK) {
+	if (icmap_get_uint32("resources.watchdog_timeout", &tmp_value_32) == CS_OK) {
 		if (tmp_value_32 >= 2 && tmp_value_32 <= 120) {
 			watchdog_timeout_apply (tmp_value_32);
 		}

--- a/exec/wd.c
+++ b/exec/wd.c
@@ -585,7 +585,11 @@ static void wd_scan_resources (void)
 static void watchdog_timeout_apply (uint32_t new)
 {
 	struct watchdog_info ident;
-	uint32_t original_timeout = watchdog_timeout;
+	uint32_t original_timeout = 0;
+
+	if (dog > 0) {
+		ioctl(dog, WDIOC_GETTIMEOUT, &original_timeout);
+	}
 
 	if (new == original_timeout) {
 		return;
@@ -716,9 +720,6 @@ static char *wd_exec_init_fn (struct corosync_api_v1 *corosync_api)
 	setup_watchdog();
 
 	wd_scan_resources();
-
-	api->timer_add_duration(tickle_timeout*MILLI_2_NANO_SECONDS, NULL,
-				wd_tickle_fn, &wd_timer);
 
 	return NULL;
 }


### PR DESCRIPTION
This request has two commits.
1. https://github.com/inouekazu/corosync/commit/ad9190891373d5aeecfd42e9cea58e6d224737a4
   Since resources.watchdog_timeout of cmap is not used as watchdog timeout, fixed it.
2. https://github.com/inouekazu/corosync/commit/a765ca65b51da94da1e5c0d7909338895725c3be
   Since the watchdog **default** timeout (6sec) is not set ([ioctl(dog, WDIOC_SETTIMEOUT, &watchdog_timeout);](https://github.com/corosync/corosync/blob/177ef0e5240b4060ff5b14eab6f2eefee3aa777d/exec/wd.c#L601) is not called..), fixed it.
