### PR TITLE
Fix detection of warning flags for clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -235,10 +235,19 @@ LIB_MSG_RESULT(m4_shift(m4_shift($@)))dnl
 # Helpers
 # ===============================================
 
+## check if the compiler supports -Werror -Wunknown-warning-option
+AC_MSG_CHECKING([whether $CC supports -Wunknown-warning-option -Werror])
+BACKUP="$CPPFLAGS"
+CPPFLAGS="$CPPFLAGS -Werror -Wunknown-warning-option"
+AC_PREPROC_IFELSE([AC_LANG_PROGRAM([])],
+		  [unknown_warnings_as_errors='-Wunknown-warning-option -Werror'; AC_MSG_RESULT([yes])],
+		  [unknown_warnings_as_errors=''; AC_MSG_RESULT([no])])
+CPPFLAGS="$BACKUP"
+
 ## helper for CC stuff
 cc_supports_flag() {
 	BACKUP="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $@ -Werror"
+	CPPFLAGS="$CPPFLAGS $@ $unknown_warnings_as_errors"
 	AC_MSG_CHECKING([whether $CC supports "$@"])
 	AC_PREPROC_IFELSE([AC_LANG_PROGRAM([])],
 			  [RC=0; AC_MSG_RESULT([yes])],

--- a/configure.ac
+++ b/configure.ac
@@ -238,7 +238,7 @@ LIB_MSG_RESULT(m4_shift(m4_shift($@)))dnl
 ## helper for CC stuff
 cc_supports_flag() {
 	BACKUP="$CPPFLAGS"
-	CPPFLAGS="$CPPFLAGS $@"
+	CPPFLAGS="$CPPFLAGS $@ -Werror"
 	AC_MSG_CHECKING([whether $CC supports "$@"])
 	AC_PREPROC_IFELSE([AC_LANG_PROGRAM([])],
 			  [RC=0; AC_MSG_RESULT([yes])],


### PR DESCRIPTION
Using ./configure CC=clang, the following flags are detected
as supported:

checking whether clang supports "-Wgnu89-inline"... yes
checking whether clang supports "-Wno-strict-aliasing"... yes

Which results in a lot of warnings during make:

warning: unknown warning option '-Wunsigned-char' [-Wunknown-warning-option]
warning: unknown warning option '-Wgnu89-inline' [-Wunknown-warning-option]

Clang doesn't support these flags, but the compile check returns a
warning, not an error:

configure:16649: checking whether clang supports "-Wunsigned-char"
configure:16662: clang -E  -Wunsigned-char conftest.c
warning: unknown warning option '-Wunsigned-char' [-Wunknown-warning-option]
1 warning generated.
configure:16662: $? = 0
configure:16663: result: yes