### PR TITLE
- add OpenSSL support for transport encryption;

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,6 @@ AC_TYPE_SSIZE_T
 AC_TYPE_SIGNAL
 
 # Checks for libraries.
-PKG_CHECK_MODULES([nss],[nss])
 PKG_CHECK_MODULES([LIBQB], [libqb])
 AC_CHECK_LIB([qb], [qb_log_thread_priority_set], \
 	     have_qb_log_thread_priority_set="yes", \
@@ -314,6 +313,11 @@ AC_ARG_ENABLE([dbus],
 	[  --enable-dbus                   : dbus events. ],,
 	[ enable_dbus="no" ])
 
+AC_ARG_ENABLE([openssl],
+	[  --enable-openssl                : enable OpenSSL. ],,
+	[ enable_openssl="no" ])
+AM_CONDITIONAL(BUILD_OPENSSL, test x$enable_openssl = xyes)
+
 AC_ARG_ENABLE([testagents],
 	[  --enable-testagents             : Install Test Agents. ],,
 	[ default="no" ])
@@ -410,6 +414,19 @@ if test "x${enable_dbus}" = xyes; then
 	AC_DEFINE_UNQUOTED([HAVE_DBUS], 1, [have dbus])
 	PACKAGE_FEATURES="$PACKAGE_FEATURES dbus"
 	WITH_LIST="$WITH_LIST --with dbus"
+fi
+
+if test "x${enable_openssl}" = xyes; then
+	PKG_CHECK_MODULES([OPENSSL],[openssl])
+	AC_DEFINE_UNQUOTED([HAVE_OPENSSL], 1, [have openssl])
+	PACKAGE_FEATURES="$PACKAGE_FEATURES openssl"
+	WITH_LIST="$WITH_LIST --with openssl"
+  AC_CHECK_LIB([ssl], [SSL_library_init], [],
+             [AC_MSG_FAILURE([can't find openssl ssl lib])])
+  AC_CHECK_LIB([crypto], [EVP_EncryptInit], [],
+             [AC_MSG_FAILURE([can't find openssl crypto lib])])
+else
+  PKG_CHECK_MODULES([nss],[nss])
 fi
 
 if test "x${enable_testagents}" = xyes; then

--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -15,6 +15,7 @@
 %bcond_with upstart
 %bcond_with xmlconf
 %bcond_with runautogen
+%bcond_with openssl
 
 %global gitver %{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}
 %global gittarver %{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}
@@ -39,7 +40,6 @@ Conflicts: openais <= 0.89, openais-devel <= 0.89
 
 BuildRequires: groff
 BuildRequires: libqb-devel
-BuildRequires: nss-devel
 %if %{with runautogen}
 BuildRequires: autoconf automake libtool
 %endif
@@ -63,6 +63,11 @@ Requires(postun): systemd
 %endif
 %if %{with xmlconf}
 Requires: libxslt
+%endif
+%if %{with openssl}
+Requires: ssl crypto
+%else
+Requires: nss-devel
 %endif
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
@@ -108,6 +113,9 @@ export rdmacm_LIBS=-lrdmacm \
 %endif
 %if %{with xmlconf}
 	--enable-xmlconf \
+%endif
+%if %{with openssl}
+	--enable-openssl \
 %endif
 	--with-initddir=%{_initrddir} \
 	--with-systemddir=%{_unitdir} \

--- a/cts/agents/cpg_test_agent.c
+++ b/cts/agents/cpg_test_agent.c
@@ -31,6 +31,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#include <config.h>
+
 #include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
@@ -56,6 +59,7 @@
 #include <corosync/cfg.h>
 #include "common_test_agent.h"
 
+#ifndef HAVE_OPENSSL
 #include <nss.h>
 #include <pk11pub.h>
 
@@ -801,4 +805,13 @@ main(int argc, char *argv[])
 
 	return test_agent_run ("cpg_test_agent", 9034, do_command, my_pre_exit);
 }
+#else
+int
+main(int argc, char *argv[])
+{
+  return (0);
+}
+#endif
+
+
 

--- a/exec/totemudp.c
+++ b/exec/totemudp.c
@@ -71,10 +71,16 @@
 #include "util.h"
 #include "totemcrypto.h"
 
-#include <nss.h>
-#include <pk11pub.h>
-#include <pkcs11.h>
-#include <prerror.h>
+#ifdef HAVE_OPENSSL
+  #include <openssl/conf.h>
+  #include <openssl/evp.h>
+  #include <openssl/err.h>
+#else
+  #include <nss.h>
+  #include <pk11pub.h>
+  #include <pkcs11.h>
+  #include <prerror.h>
+#endif
 
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0

--- a/exec/totemudpu.c
+++ b/exec/totemudpu.c
@@ -71,10 +71,16 @@
 #include "util.h"
 #include "totemcrypto.h"
 
-#include <nss.h>
-#include <pk11pub.h>
-#include <pkcs11.h>
-#include <prerror.h>
+#ifdef HAVE_OPENSSL
+  #include <openssl/conf.h>
+  #include <openssl/evp.h>
+  #include <openssl/err.h>
+#else
+  #include <nss.h>
+  #include <pk11pub.h>
+  #include <pkcs11.h>
+  #include <prerror.h>
+#endif
 
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0

--- a/test/cpgverify.c
+++ b/test/cpgverify.c
@@ -46,6 +46,7 @@
 #include <corosync/corotypes.h>
 #include <corosync/cpg.h>
 
+#ifndef HAVE_OPENSSL
 #include <nss.h>
 #include <pk11pub.h>
 
@@ -189,3 +190,11 @@ try_again_one:
 
 	return (0);
 }
+#else
+int main (int argc, char *argv[])
+{
+  // TODO Implement OpenSSL testing
+	return (0);
+}
+#endif
+


### PR DESCRIPTION
It adds configuration option (--enable-openssl) to
enable OpenSSL library usage instead of NSS one.
OpenSSL support is provided mostly for FIPS compliance.

It was tested with following options:
1.
crypto_hash: sha256
crypto_cipher: aes128
2.
crypto_hash: none
crypto_cipher: none

Test code is not provided
