### PR TITLE
Fix some typos in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -373,12 +373,12 @@ AC_ARG_WITH([initwrappersdir],
 	[ INITWRAPPERSDIR="$datarootdir/corosync" ])
 
 AC_ARG_WITH([logdir],
-	[  --logdir=DIR   : the base directory for corosync logging files. ],
+	[  --with-logdir=DIR       : the base directory for corosync logging files. ],
 	[ LOGDIR="$withval" ],
 	[ LOGDIR="$localstatedir/log/cluster" ])
 
 AC_ARG_WITH([logrotatedir],
-	[  --logrotatedir=DIR   : the base directory for logrorate.d files.  ],
+	[  --with-logrotatedir=DIR : the base directory for logrorate.d files.  ],
 	[ LOGROTATEDIR="$withval" ],
 	[ LOGROTATEDIR="$sysconfdir/logrotate.d" ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ if ! ${MAKE-make} --version /cannot/make/this >/dev/null 2>&1; then
 	AC_MSG_ERROR([you don't seem to have GNU make; it is required])
 fi
 
-sinclude(coroysync-default.m4)
+sinclude(corosync-default.m4)
 
 AC_PROG_CC
 AC_PROG_CXX


### PR DESCRIPTION
I don't know what `coroysync-default.m4` is supposed to be used for, but it very much seems like a typo.
The newly introduced logging-related `configure` option names certainly start with `--with-`, though.
Please consider pulling these in.