### PR TITLE
votequorum: votequorum.h uses types defined in corotypes.h

### DIFF
--- a/include/corosync/votequorum.h
+++ b/include/corosync/votequorum.h
@@ -36,6 +36,8 @@
 #ifndef COROSYNC_VOTEQUORUM_H_DEFINED
 #define COROSYNC_VOTEQUORUM_H_DEFINED
 
+#include <corosync/corotypes.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This fixes #82.