### PR TITLE
Substitute LOGDIR into the example configs

### DIFF
--- a/conf/corosync.conf.example.in
+++ b/conf/corosync.conf.example.in
@@ -59,7 +59,7 @@ logging {
 	# Log to a log file. When set to "no", the "logfile" option
 	# must not be set.
 	to_logfile: yes
-	logfile: /var/log/cluster/corosync.log
+	logfile: @LOGDIR@/corosync.log
 	# Log to the system log daemon. When in doubt, set to yes.
 	to_syslog: yes
 	# Log debug messages (very verbose). When in doubt, leave off.

--- a/conf/corosync.conf.example.udpu.in
+++ b/conf/corosync.conf.example.udpu.in
@@ -18,7 +18,7 @@ logging {
 	fileline: off
 	to_logfile: yes
 	to_syslog: yes
-	logfile: /var/log/cluster/corosync.log
+	logfile: @LOGDIR@/corosync.log
 	debug: off
 	timestamp: on
 	logger_subsys {

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,8 @@ AC_CONFIG_FILES([Makefile
 		 conf/Makefile
 		 qdevices/Makefile
 		 Doxyfile
+		 conf/corosync.conf.example
+		 conf/corosync.conf.example.udpu
 		 conf/logrotate/Makefile])
 
 ### Local business


### PR DESCRIPTION
Since aabbace the log directory can be set with a configure option.
Let's use its value in the example configs as well by renaming the
files and making configure do the substitution.  This makes the
examples more straightforward to use in general.

(Not theoretic, there is an open [Debian bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=739730) for this. Even though we don't plan to use file logging by default, it would be nice to fix. BTW, cat I get `corosync` reopen its log files? That would be necessary for reliable log rotation.)