### PR TITLE
Manual fixes

### DIFF
--- a/man/cpg_zcb_alloc.3.in
+++ b/man/cpg_zcb_alloc.3.in
@@ -34,6 +34,7 @@
 .TH CPG_ZCB_ALLOC 2009-04-15 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 cpg_zcb_alloc \- Allocates a zero copy buffer
+.SH SYNOPSIS
 .B #include <corosync/cpg.h>
 .sp
 .BI "int cpg_zcb_alloc(cpg_handle_t " handle ", size_t " size ", void **" buffer ");

--- a/man/cpg_zcb_free.3.in
+++ b/man/cpg_zcb_free.3.in
@@ -34,6 +34,7 @@
 .TH CPG_ZCB_FREE 2009-04-15 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 cpg_zcb_free \- Frees a zero copy buffer
+.SH SYNOPSIS
 .B #include <corosync/cpg.h>
 .sp
 .BI "int cpg_zcb_fre(cpg_handle_t " handle ", void *" buffer ");

--- a/man/index.html
+++ b/man/index.html
@@ -138,6 +138,30 @@
       Description of the cpg_iteration_finalize interface.
       <br>
 
+      <a href="cpg_context_get.3.html">cpg_context_get(3)</a>:
+      Gets the context variable for a CPG instance.
+      <br>
+
+      <a href="cpg_context_set.3.html">cpg_context_set(3)</a>:
+      Sets the context variable for a CPG instance.
+      <br>
+
+      <a href="cpg_model_initialize.3.html">cpg_model_initialize(3)</a>:
+      Create a new connection to the CPG service
+      <br>
+
+      <a href="cpg_zcb_alloc.3.html">cpg_zcb_alloc(3)</a>:
+      Allocates a zero copy buffer.
+      <br>
+
+      <a href="cpg_zcb_free.3.html">cpg_zcb_free(3)</a>:
+      Frees a zero copy buffer.
+      <br>
+
+      <a href="cpg_zcb_mcast_joined.3.html">cpg_zcb_mcast_joined(3)</a>:
+      Multicasts a zero copy buffer to all groups joined to a handle.
+      <br>
+
       <h3>SAM service</h3>
 
       <a href="sam_overview.8.html">sam_overview(8)</a>:
@@ -282,6 +306,26 @@
 
       <a href="votequorum_setvotes.3.html">votequorum_setvotes(3)</a>:
       Description of the votequorum interface.
+      <br>
+
+      <a href="votequorum_qdevice_master_wins.3.html">votequorum_qdevice_master_wins(3)</a>:
+      Sets or clears quorum device master_wins flag.
+      <br>
+
+      <a href="votequorum_qdevice_poll.3.html">votequorum_qdevice_poll(3)</a>:
+      Tells votequorum the result of the quorum device poll.
+      <br>
+
+      <a href="votequorum_qdevice_register.3.html">votequorum_qdevice_register(3)</a>:
+      Registers a new quorum device.
+      <br>
+
+      <a href="votequorum_qdevice_unregister.3.html">votequorum_qdevice_unregister(3)</a>:
+      Unregisters a new quorum device.
+      <br>
+
+      <a href="votequorum_qdevice_update.3.html">votequorum_qdevice_update(3)</a>:
+      Updates quorum device name.
       <br>
 
       <h3>CMAP service</h3>

--- a/man/index.html
+++ b/man/index.html
@@ -67,6 +67,10 @@
       Description of corosync-cmapctl tool.
       <br>
 
+      <a href="cmap_keys.8.html">cmap_keys(8)</a>:
+      Overview of keys stored in the Configuration Map.
+      <br>
+
       <a href="corosync-quorumtool.8.html">corosync-quorumtool(8)</a>:
       Description of corosync-quorumtool tool.
       <br>

--- a/man/index.html
+++ b/man/index.html
@@ -126,10 +126,6 @@
       Description of the cpg_local_get interface.
       <br>
 
-      <a href="cpg_groups_get.3.html">cpg_local_get(3)</a>:
-      Description of the cpg_groups_get interface.
-      <br>
-
       <a href="cpg_iteration_initialize.3.html">cpg_iteration_initialize(3)</a>:
       Description of the cpg_iteration_initialize interface.
       <br>

--- a/man/index.html
+++ b/man/index.html
@@ -51,10 +51,6 @@
       Description of corosync-cpgtool tool.
       <br>
 
-      <a href="corosync-fplay.8.html">corosync-fplay(8)</a>:
-      Description of corosync-fplay tool.
-      <br>
-
       <a href="corosync-keygen.8.html">corosync-keygen(8)</a>:
       Description of corosync-keygen tool.
       <br>


### PR DESCRIPTION
Mainly bringing man/index.html into sync with the directory contents. Based on the output of

    $ comm -3 <(ls | sed s/\.in$// | sort) <(sed -n 's/.*href="//;T;s/\.html.*//;p' index.html | sort)

To avoid useless repetition, I decided to put the short descriptions into the HTML. As the manual pages are already listed in `man/Makefile.am`, the index could be generated automatically, but I did not go into that.

On the road I also noticed two simple formatting errors (missing section macros), also fixing those.