### PR TITLE
Systemd notification feature and dependency fixup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -483,6 +483,8 @@ if test "x${enable_augeas}" = xyes; then
 	PACKAGE_FEATURES="$PACKAGE_FEATURES augeas"
 fi
 if test "x${enable_systemd}" = xyes; then
+	PKG_CHECK_MODULES([libsystemd], [libsystemd])
+	AC_DEFINE([HAVE_LIBSYSTEMD], [1], [have systemd interface library])
 	PACKAGE_FEATURES="$PACKAGE_FEATURES systemd"
 	WITH_LIST="$WITH_LIST --with systemd"
 fi

--- a/exec/Makefile.am
+++ b/exec/Makefile.am
@@ -71,10 +71,10 @@ endif
 
 corosync_CPPFLAGS	= -DLOGCONFIG_USE_ICMAP=1
 
-corosync_CFLAGS         = $(statgrab_CFLAGS)
+corosync_CFLAGS         = $(statgrab_CFLAGS) $(libsystemd_CFLAGS)
 
 corosync_LDADD		= libtotem_pg.la ../common_lib/libcorosync_common.la \
-			  $(LIBQB_LIBS) $(statgrab_LIBS)
+			  $(LIBQB_LIBS) $(statgrab_LIBS) $(libsystemd_LIBS)
 
 corosync_DEPENDENCIES	= libtotem_pg.la ../common_lib/libcorosync_common.la
 

--- a/exec/main.c
+++ b/exec/main.c
@@ -96,6 +96,10 @@
 #include <semaphore.h>
 #include <string.h>
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #include <qb/qbdefs.h>
 #include <qb/qblog.h>
 #include <qb/qbloop.h>
@@ -312,6 +316,10 @@ static void corosync_sync_completed (void)
 	 * Inform totem to start using new message queue again
 	 */
 	totempg_trans_ack();
+
+#ifdef HAVE_LIBSYSTEMD
+	sd_notify (0, "READY=1");
+#endif
 }
 
 static int corosync_sync_callbacks_retrieve (

--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Corosync Dbus and snmp notifier
-Wants=corosync.service
+Requires=corosync.service
 After=corosync.service
 
 [Service]
@@ -8,7 +8,6 @@ EnvironmentFile=-@SYSCONFDIR@/sysconfig/corosync-notifyd
 EnvironmentFile=-@SYSCONFDIR@/default/corosync-notifyd
 ExecStart=@SBINDIR@/corosync-notifyd -f $OPTIONS
 Type=simple
-Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -7,7 +7,7 @@ After=corosync.service
 EnvironmentFile=-@SYSCONFDIR@/sysconfig/corosync-notifyd
 EnvironmentFile=-@SYSCONFDIR@/default/corosync-notifyd
 ExecStart=@SBINDIR@/corosync-notifyd -f $OPTIONS
-Type=simple
+Type=notify
 
 [Install]
 WantedBy=multi-user.target

--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -4,7 +4,8 @@ Wants=corosync.service
 After=corosync.service
 
 [Service]
-EnvironmentFile=@SYSCONFDIR@/sysconfig/corosync-notifyd
+EnvironmentFile=-@SYSCONFDIR@/sysconfig/corosync-notifyd
+EnvironmentFile=-@SYSCONFDIR@/default/corosync-notifyd
 ExecStart=@SBINDIR@/corosync-notifyd -f $OPTIONS
 Type=simple
 Restart=on-failure

--- a/init/corosync.service.in
+++ b/init/corosync.service.in
@@ -5,9 +5,10 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=@INITWRAPPERSDIR@/corosync start
-ExecStop=@INITWRAPPERSDIR@/corosync stop
-Type=forking
+EnvironmentFile=-@SYSCONFDIR@/sysconfig/corosync
+EnvironmentFile=-@SYSCONFDIR@/default/corosync
+ExecStart=@SBINDIR@/corosync -f $OPTIONS
+Type=notify
 
 # The following config is for corosync with enabled watchdog service.
 #

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -67,8 +67,9 @@ corosync_quorumtool_LDADD = $(LIBQB_LIBS) \
 			    $(top_builddir)/lib/libquorum.la \
 			    $(top_builddir)/lib/libvotequorum.la
 
-corosync_notifyd_CFLAGS   = $(DBUS_CFLAGS)
+corosync_notifyd_CFLAGS   = $(DBUS_CFLAGS) $(libsystemd_CFLAGS)
 corosync_notifyd_LDADD    = $(LIBQB_LIBS) $(DBUS_LIBS) $(SNMP_LIBS) \
+			    $(libsystemd_LIBS) \
 			    $(top_builddir)/lib/libcmap.la \
 			    $(top_builddir)/lib/libcfg.la \
 			    $(top_builddir)/lib/libquorum.la

--- a/tools/corosync-notifyd.c
+++ b/tools/corosync-notifyd.c
@@ -62,6 +62,10 @@
 #include <corosync/quorum.h>
 #include <corosync/cmap.h>
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 /*
  * generic declarations
  */
@@ -1205,6 +1209,10 @@ main(int argc, char *argv[])
 			   NULL,
 			   sig_exit_handler,
 			   NULL);
+
+#ifdef HAVE_LIBSYSTEMD
+	sd_notify (0, "READY=1");
+#endif
 
 	qb_loop_run(main_loop);
 


### PR DESCRIPTION
Hi, these patches improve systemd integration on several points:
- besides `sysconfig`, also read configuration from `default` directories as used by Debian and its derivatives;
- startup notifications let systemd better schedule dependent service startups, thus there's no need to retry connections to corosync from corosync-notifyd, dlm-controld, clvmd or pacemaker;
- `Require` dependency of corosync-notifyd on corosync makes systemd stop and start the former if corosync is temporarily stopped (like for an upgrade).

Please consider incorporating them. I think they also make packagers' life easier and lead to simpler systemd unit files in general (no need to fork or manage pidfiles). I'm not sure what the "init wrappers" were used for, I did not get rid of them, in case they are still needed for some other purpose. I only tested this under Debian jessie, but this stuff should be distro-independent (at least we should make it so).
