### PR TITLE
logsys: fix TOTEM logging when corosync built out of tree

### DIFF
--- a/exec/main.c
+++ b/exec/main.c
@@ -939,7 +939,7 @@ _logsys_log_printf(int level, int subsys,
 	va_list ap;
 
 	va_start(ap, format);
-	qb_log_from_external_source_va(function_name, file_name,
+	qb_log_from_external_source_va(function_name, basename(file_name),
 				    format, level, file_line,
 				    subsys, ap);
 	va_end(ap);


### PR DESCRIPTION
If corosync is built out-of-tree (passing --srcdir to configure) then
TOTEM logging doesn't print anything.

This is caused by the source filenames (from __FILE__ at compilation
time) having the configured path in them - in this example
../corosync/exec/totemudp.c etc. The list of totem source filenames
passed to libqb logging facility only has the basenames so the filenames
never match up as libqb does an exact string match.

I looked into fixing this in libqb but it causes a regression. We can't
simply basename() __FILE__ at the point of calling log_printf as it's i
common also to use __FILE__ to generate the logging source, and
using basename() on both removes the distinction between similarly named
files from different directories which could be a requirement.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>