### PR TITLE
Adds doxygen documentation stubs

### DIFF
--- a/common_lib/error_conversion.c
+++ b/common_lib/error_conversion.c
@@ -36,6 +36,11 @@
 #include <config.h>
 #include <corosync/corotypes.h>
 
+/**
+ * @brief qb_to_cs_error
+ * @param result
+ * @return
+ */
 cs_error_t qb_to_cs_error (int result)
 {
 	int32_t res;
@@ -117,6 +122,11 @@ cs_error_t qb_to_cs_error (int result)
 	return err;
 }
 
+/**
+ * @brief hdb_error_to_cs
+ * @param res
+ * @return
+ */
 cs_error_t hdb_error_to_cs (int res)
 {
 	if (res == 0) {
@@ -135,6 +145,11 @@ cs_error_t hdb_error_to_cs (int res)
 	}
 }
 
+/**
+ * @brief cs_strerror
+ * @param err
+ * @return
+ */
 const char * cs_strerror(cs_error_t err)
 {
 	switch (err) {

--- a/exec/apidef.c
+++ b/exec/apidef.c
@@ -59,15 +59,24 @@ LOGSYS_DECLARE_SUBSYS ("APIDEF");
 /*
  * Remove compile warnings about type name changes in corosync_tpg_group
  */
+/**
+ * @brief typedef_tpg_join callback function
+ */
 typedef int (*typedef_tpg_join) (
 	void *,
 	const struct corosync_tpg_group *,
 	size_t);
 
+/**
+ * @brief typedef_tpg_leave callback function
+ */
 typedef int (*typedef_tpg_leave) (void *,
 	const struct corosync_tpg_group *,
 	size_t);
 
+/**
+ * @brief typedef_tpg_groups_mcast_groups callback function
+ */
 typedef int (*typedef_tpg_groups_mcast_groups) (
 	void *, int,
 	const struct corosync_tpg_group *,
@@ -75,6 +84,9 @@ typedef int (*typedef_tpg_groups_mcast_groups) (
 	const struct iovec *,
 	unsigned int);
 
+/**
+ * @brief typedef_tpg_groups_send_ok callback function
+ */
 typedef int (*typedef_tpg_groups_send_ok) (
 	void *,
 	const struct corosync_tpg_group *,
@@ -82,16 +94,32 @@ typedef int (*typedef_tpg_groups_send_ok) (
 	struct iovec *,
 	int);
 
+/**
+ * @brief _corosync_public_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 static inline void _corosync_public_exit_error (cs_fatal_error_t err,
 						const char *file,
 						unsigned int line)
   __attribute__((noreturn));
+
+/**
+ * @brief _corosync_public_exit_error
+ * @param err The error that occured
+ * @param file The source file in which the error occured
+ * @param line The line number associated with the error
+ */
 static inline void _corosync_public_exit_error (
 	cs_fatal_error_t err, const char *file, unsigned int line)
 {
 	_corosync_exit_error (err, file, line);
 }
 
+/**
+ * @brief apidef_corosync_api_v1
+ */
 static struct corosync_api_v1 apidef_corosync_api_v1 = {
 	.timer_add_duration = corosync_timer_add_duration,
 	.timer_add_absolute = corosync_timer_add_absolute,
@@ -144,6 +172,10 @@ static struct corosync_api_v1 apidef_corosync_api_v1 = {
 	.poll_dispatch_delete = cs_poll_dispatch_delete
 };
 
+/**
+ * @brief apidef_get
+ * @return
+ */
 struct corosync_api_v1 *apidef_get (void)
 {
 	return (&apidef_corosync_api_v1);

--- a/exec/apidef.h
+++ b/exec/apidef.h
@@ -37,6 +37,10 @@
 
 #include <corosync/coroapi.h>
 
+/**
+ * @brief apidef_get
+ * @return
+ */
 extern struct corosync_api_v1 *apidef_get (void);
 
 #endif /* APIDEF_H_DEFINED*/

--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -68,6 +68,9 @@
 
 LOGSYS_DECLARE_SUBSYS ("CFG");
 
+/**
+ * @brief The cfg_message_req_types enum
+ */
 enum cfg_message_req_types {
         MESSAGE_REQ_EXEC_CFG_RINGREENABLE = 0,
 	MESSAGE_REQ_EXEC_CFG_KILLNODE = 1,
@@ -77,6 +80,9 @@ enum cfg_message_req_types {
 
 #define DEFAULT_SHUTDOWN_TIMEOUT 5
 
+/**
+ * @brief trackers_list
+ */
 static struct list_head trackers_list;
 
 /*
@@ -89,6 +95,9 @@ static int shutdown_yes;
 static int shutdown_no;
 static int shutdown_expected;
 
+/**
+ * @brief The cfg_info struct
+ */
 struct cfg_info
 {
 	struct list_head list;
@@ -238,33 +247,54 @@ struct corosync_service_engine cfg_service_engine = {
 	.confchg_fn				= cfg_confchg_fn
 };
 
+/**
+ * @brief cfg_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *cfg_get_service_engine_ver0 (void)
 {
 	return (&cfg_service_engine);
 }
 
+/**
+ * @brief The req_exec_cfg_ringreenable struct
+ */
 struct req_exec_cfg_ringreenable {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
         mar_message_source_t source __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cfg_reload_config struct
+ */
 struct req_exec_cfg_reload_config {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_message_source_t source __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cfg_killnode struct
+ */
 struct req_exec_cfg_killnode {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
         mar_uint32_t nodeid __attribute__((aligned(8)));
 	mar_name_t reason __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cfg_shutdown struct
+ */
 struct req_exec_cfg_shutdown {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
 /* IMPL */
 
+/**
+ * @brief cfg_exec_init_fn Initializes the CFG
+ * @param corosync_api_v1
+ * @return
+ */
 static char *cfg_exec_init_fn (
 	struct corosync_api_v1 *corosync_api_v1)
 {
@@ -274,6 +304,17 @@ static char *cfg_exec_init_fn (
 	return (NULL);
 }
 
+/**
+ * @brief cfg_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void cfg_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -283,8 +324,9 @@ static void cfg_confchg_fn (
 {
 }
 
-/*
- * Tell other nodes we are shutting down
+/**
+ * @brief send_shutdown Tell other nodes we are shutting down
+ * @return
  */
 static int send_shutdown(void)
 {
@@ -306,6 +348,12 @@ static int send_shutdown(void)
 	return 0;
 }
 
+/**
+ * @brief send_test_shutdown
+ * @param only_conn
+ * @param exclude_conn
+ * @param status
+ */
 static void send_test_shutdown(void *only_conn, void *exclude_conn, int status)
 {
 	struct res_lib_cfg_testshutdown res_lib_cfg_testshutdown;
@@ -335,6 +383,9 @@ static void send_test_shutdown(void *only_conn, void *exclude_conn, int status)
 	LEAVE();
 }
 
+/**
+ * @brief check_shutdown_status
+ */
 static void check_shutdown_status(void)
 {
 	ENTER();
@@ -397,9 +448,12 @@ static void check_shutdown_status(void)
 	LEAVE();
 }
 
-
-/*
- * Not all nodes responded to the shutdown (in time)
+/**
+ * @brief shutdown_timer_fn
+ *
+ * Note: Not all nodes responded to the shutdown (in time)
+ *
+ * @param arg -- Unused
  */
 static void shutdown_timer_fn(void *arg)
 {
@@ -415,6 +469,10 @@ static void shutdown_timer_fn(void *arg)
 	LEAVE();
 }
 
+/**
+ * @brief remove_ci_from_shutdown
+ * @param ci
+ */
 static void remove_ci_from_shutdown(struct cfg_info *ci)
 {
 	ENTER();
@@ -453,7 +511,11 @@ static void remove_ci_from_shutdown(struct cfg_info *ci)
 	LEAVE();
 }
 
-
+/**
+ * @brief cfg_lib_exit_fn
+ * @param conn
+ * @return
+ */
 int cfg_lib_exit_fn (void *conn)
 {
 	struct cfg_info *ci = (struct cfg_info *)api->ipc_private_data_get (conn);
@@ -464,6 +526,11 @@ int cfg_lib_exit_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief cfg_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int cfg_lib_init_fn (void *conn)
 {
 	struct cfg_info *ci = (struct cfg_info *)api->ipc_private_data_get (conn);
@@ -477,6 +544,11 @@ static int cfg_lib_init_fn (void *conn)
 
 /*
  * Executive message handlers
+ */
+/**
+ * @brief message_handler_req_exec_cfg_ringreenable
+ * @param message
+ * @param nodeid
  */
 static void message_handler_req_exec_cfg_ringreenable (
         const void *message,
@@ -502,6 +574,10 @@ static void message_handler_req_exec_cfg_ringreenable (
 	LEAVE();
 }
 
+/**
+ * @brief exec_cfg_killnode_endian_convert
+ * @param msg
+ */
 static void exec_cfg_killnode_endian_convert (void *msg)
 {
 	struct req_exec_cfg_killnode *req_exec_cfg_killnode =
@@ -512,7 +588,11 @@ static void exec_cfg_killnode_endian_convert (void *msg)
 	LEAVE();
 }
 
-
+/**
+ * @brief message_handler_req_exec_cfg_killnode
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cfg_killnode (
         const void *message,
         unsigned int nodeid)
@@ -535,6 +615,11 @@ static void message_handler_req_exec_cfg_killnode (
 /*
  * Self shutdown
  */
+/**
+ * @brief message_handler_req_exec_cfg_shutdown
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cfg_shutdown (
         const void *message,
         unsigned int nodeid)
@@ -549,6 +634,12 @@ static void message_handler_req_exec_cfg_shutdown (
 }
 
 /* strcmp replacement that can handle NULLs */
+/**
+ * @brief nullcheck_strcmp
+ * @param left
+ * @param right
+ * @return
+ */
 static int nullcheck_strcmp(const char* left, const char *right)
 {
 	if (!left && right)
@@ -565,6 +656,11 @@ static int nullcheck_strcmp(const char* left, const char *right)
 /*
  * If a key has changed value in the new file, then warn the user and remove it from the temp_map
  */
+/**
+ * @brief delete_and_notify_if_changed
+ * @param temp_map
+ * @param key_name
+ */
 static void delete_and_notify_if_changed(icmap_map_t temp_map, const char *key_name)
 {
 	if (!(icmap_key_value_eq(temp_map, key_name, icmap_get_global_map(), key_name))) {
@@ -573,12 +669,17 @@ static void delete_and_notify_if_changed(icmap_map_t temp_map, const char *key_n
 		}
 	}
 }
+
 /*
  * Remove any keys from the new config file that in the new corosync.conf but that
  * cannot be changed at run time. A log message will be issued for each
  * entry that the user wants to change but they cannot.
  *
  * Add more here as needed.
+ */
+/**
+ * @brief remove_ro_entries
+ * @param temp_map
  */
 static void remove_ro_entries(icmap_map_t temp_map)
 {
@@ -609,6 +710,11 @@ static void remove_ro_entries(icmap_map_t temp_map)
  *
  * NOTE: This routine depends entirely on the keys returned by the iterators
  * being in alpha-sorted order.
+ */
+/**
+ * @brief remove_deleted_entries
+ * @param temp_map
+ * @param prefix
  */
 static void remove_deleted_entries(icmap_map_t temp_map, const char *prefix)
 {
@@ -662,6 +768,11 @@ static void remove_deleted_entries(icmap_map_t temp_map, const char *prefix)
 
 /*
  * Reload configuration file
+ */
+/**
+ * @brief message_handler_req_exec_cfg_reload_config
+ * @param message
+ * @param nodeid
  */
 static void message_handler_req_exec_cfg_reload_config (
         const void *message,
@@ -741,6 +852,11 @@ reload_return:
 /*
  * Library Interface Implementation
  */
+/**
+ * @brief message_handler_req_lib_cfg_ringstatusget
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_ringstatusget (
 	void *conn,
 	const void *msg)
@@ -801,6 +917,11 @@ send_response:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_ringreenable
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_ringreenable (
 	void *conn,
 	const void *msg)
@@ -824,6 +945,11 @@ static void message_handler_req_lib_cfg_ringreenable (
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_killnode
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_killnode (
 	void *conn,
 	const void *msg)
@@ -856,7 +982,11 @@ static void message_handler_req_lib_cfg_killnode (
 	LEAVE();
 }
 
-
+/**
+ * @brief message_handler_req_lib_cfg_tryshutdown
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_tryshutdown (
 	void *conn,
 	const void *msg)
@@ -975,6 +1105,11 @@ static void message_handler_req_lib_cfg_tryshutdown (
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_replytoshutdown
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_replytoshutdown (
 	void *conn,
 	const void *msg)
@@ -1011,6 +1146,11 @@ exit_fn:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_get_node_addrs
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_get_node_addrs (void *conn,
 							const void *msg)
 {
@@ -1046,6 +1186,11 @@ static void message_handler_req_lib_cfg_get_node_addrs (void *conn,
 	api->ipc_response_send(conn, res_lib_cfg_get_node_addrs, res_lib_cfg_get_node_addrs->header.size);
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_local_get
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_local_get (void *conn, const void *msg)
 {
 	struct res_lib_cfg_local_get res_lib_cfg_local_get;
@@ -1059,6 +1204,11 @@ static void message_handler_req_lib_cfg_local_get (void *conn, const void *msg)
 		sizeof(res_lib_cfg_local_get));
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_reload_config
+ * @param conn The connection on which to send?
+ * @param msg The message to send?
+ */
 static void message_handler_req_lib_cfg_reload_config (void *conn, const void *msg)
 {
 	struct req_exec_cfg_reload_config req_exec_cfg_reload_config;

--- a/exec/cmap.c
+++ b/exec/cmap.c
@@ -62,6 +62,9 @@ LOGSYS_DECLARE_SUBSYS ("CMAP");
 #define MAX_REQ_EXEC_CMAP_MCAST_ITEMS		32
 #define ICMAP_VALUETYPE_NOT_EXIST		0
 
+/**
+ * @brief The cmap_conn_info struct
+ */
 struct cmap_conn_info {
 	struct hdb_handle_database iter_db;
 	struct hdb_handle_database track_db;
@@ -70,16 +73,25 @@ struct cmap_conn_info {
 typedef uint64_t cmap_iter_handle_t;
 typedef uint64_t cmap_track_handle_t;
 
+/**
+ * @brief The cmap_track_user_data struct
+ */
 struct cmap_track_user_data {
 	void *conn;
 	cmap_track_handle_t track_handle;
 	uint64_t track_inst_handle;
 };
 
+/**
+ * @brief The cmap_message_req_types enum
+ */
 enum cmap_message_req_types {
 	MESSAGE_REQ_EXEC_CMAP_MCAST = 0,
 };
 
+/**
+ * @brief The cmap_mcast_reason enum
+ */
 enum cmap_mcast_reason {
 	CMAP_MCAST_REASON_SYNC = 0,
 	CMAP_MCAST_REASON_NEW_CONFIG_VERSION = 1,
@@ -145,6 +157,10 @@ static void cmap_config_version_track_cb(
 /*
  * Library Handler Definition
  */
+
+/**
+ *
+ */
 static struct corosync_lib_handler cmap_lib_engine[] =
 {
 	{ /* 0 */
@@ -185,6 +201,9 @@ static struct corosync_lib_handler cmap_lib_engine[] =
 	},
 };
 
+/**
+ *
+ */
 static struct corosync_exec_handler cmap_exec_engine[] =
 {
     { /* 0 - MESSAGE_REQ_EXEC_CMAP_MCAST */
@@ -193,6 +212,9 @@ static struct corosync_exec_handler cmap_exec_engine[] =
     },
 };
 
+/**
+ *
+ */
 struct corosync_service_engine cmap_service_engine = {
 	.name				        = "corosync configuration map access",
 	.id					= CMAP_SERVICE,
@@ -214,11 +236,18 @@ struct corosync_service_engine cmap_service_engine = {
 	.sync_abort				= cmap_sync_abort
 };
 
+/**
+ * @brief cmap_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *cmap_get_service_engine_ver0 (void)
 {
 	return (&cmap_service_engine);
 }
 
+/**
+ * @brief The req_exec_cmap_mcast_item struct
+ */
 struct req_exec_cmap_mcast_item {
 	mar_name_t key_name __attribute__((aligned(8)));
 	mar_uint8_t value_type __attribute__((aligned(8)));
@@ -226,6 +255,9 @@ struct req_exec_cmap_mcast_item {
 	uint8_t value[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cmap_mcast struct
+ */
 struct req_exec_cmap_mcast {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
         mar_uint8_t reason __attribute__((aligned(8)));
@@ -244,6 +276,14 @@ static uint64_t cmap_my_config_version = 0;
 static int cmap_first_sync = 1;
 static icmap_track_t cmap_config_version_track;
 
+/**
+ * @brief cmap_config_version_track_cb
+ * @param event
+ * @param key_name
+ * @param new_value
+ * @param old_value
+ * @param user_data
+ */
 static void cmap_config_version_track_cb(
 	int32_t event,
 	const char *key_name,
@@ -269,6 +309,10 @@ static void cmap_config_version_track_cb(
 	LEAVE();
 }
 
+/**
+ * @brief cmap_exec_exit_fn
+ * @return
+ */
 static int cmap_exec_exit_fn(void)
 {
 
@@ -279,6 +323,11 @@ static int cmap_exec_exit_fn(void)
 	return 0;
 }
 
+/**
+ * @brief cmap_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *cmap_exec_init_fn (
 	struct corosync_api_v1 *corosync_api)
 {
@@ -299,6 +348,11 @@ static char *cmap_exec_init_fn (
 	return (NULL);
 }
 
+/**
+ * @brief cmap_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int cmap_lib_init_fn (void *conn)
 {
 	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
@@ -314,6 +368,11 @@ static int cmap_lib_init_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief cmap_lib_exit_fn
+ * @param conn
+ * @return
+ */
 static int cmap_lib_exit_fn (void *conn)
 {
 	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
@@ -352,6 +411,14 @@ static int cmap_lib_exit_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief cmap_sync_init
+ * @param trans_list
+ * @param trans_list_entries
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void cmap_sync_init (
 	const unsigned int *trans_list,
 	size_t trans_list_entries,
@@ -369,6 +436,10 @@ static void cmap_sync_init (
 	}
 }
 
+/**
+ * @brief cmap_sync_process
+ * @return
+ */
 static int cmap_sync_process (void)
 {
 	const char *key = "totem.config_version";
@@ -379,6 +450,9 @@ static int cmap_sync_process (void)
 	return (ret == CS_OK ? 0 : -1);
 }
 
+/**
+ * @brief cmap_sync_activate
+ */
 static void cmap_sync_activate (void)
 {
 
@@ -418,12 +492,20 @@ static void cmap_sync_activate (void)
 	}
 }
 
+/**
+ * @brief cmap_sync_abort
+ */
 static void cmap_sync_abort (void)
 {
 
 
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_set
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_set(void *conn, const void *message)
 {
 	const struct req_lib_cmap_set *req_lib_cmap_set = message;
@@ -445,6 +527,11 @@ static void message_handler_req_lib_cmap_set(void *conn, const void *message)
 	api->ipc_response_send(conn, &res_lib_cmap_set, sizeof(res_lib_cmap_set));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_delete
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_delete(void *conn, const void *message)
 {
 	const struct req_lib_cmap_set *req_lib_cmap_set = message;
@@ -465,6 +552,11 @@ static void message_handler_req_lib_cmap_delete(void *conn, const void *message)
 	api->ipc_response_send(conn, &res_lib_cmap_delete, sizeof(res_lib_cmap_delete));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_get
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_get(void *conn, const void *message)
 {
 	const struct req_lib_cmap_get *req_lib_cmap_get = message;
@@ -523,6 +615,11 @@ error_exit:
 	api->ipc_response_send(conn, &error_res_lib_cmap_get, sizeof(error_res_lib_cmap_get));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_adjust_int
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_adjust_int(void *conn, const void *message)
 {
 	const struct req_lib_cmap_adjust_int *req_lib_cmap_adjust_int = message;
@@ -544,6 +641,11 @@ static void message_handler_req_lib_cmap_adjust_int(void *conn, const void *mess
 	api->ipc_response_send(conn, &res_lib_cmap_adjust_int, sizeof(res_lib_cmap_adjust_int));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_iter_init
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_iter_init(void *conn, const void *message)
 {
 	const struct req_lib_cmap_iter_init *req_lib_cmap_iter_init = message;
@@ -591,6 +693,11 @@ reply_send:
 	api->ipc_response_send(conn, &res_lib_cmap_iter_init, sizeof(res_lib_cmap_iter_init));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_iter_next
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_iter_next(void *conn, const void *message)
 {
 	const struct req_lib_cmap_iter_next *req_lib_cmap_iter_next = message;
@@ -632,6 +739,11 @@ reply_send:
 	api->ipc_response_send(conn, &res_lib_cmap_iter_next, sizeof(res_lib_cmap_iter_next));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_iter_finalize
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_iter_finalize(void *conn, const void *message)
 {
 	const struct req_lib_cmap_iter_finalize *req_lib_cmap_iter_finalize = message;
@@ -661,6 +773,14 @@ reply_send:
 	api->ipc_response_send(conn, &res_lib_cmap_iter_finalize, sizeof(res_lib_cmap_iter_finalize));
 }
 
+/**
+ * @brief cmap_notify_fn
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void cmap_notify_fn(int32_t event,
 		const char *key_name,
 		struct icmap_notify_value new_val,
@@ -697,6 +817,11 @@ static void cmap_notify_fn(int32_t event,
 	api->ipc_dispatch_iov_send(cmap_track_user_data->conn, iov, 3);
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_track_add
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_track_add(void *conn, const void *message)
 {
 	const struct req_lib_cmap_track_add *req_lib_cmap_track_add = message;
@@ -800,6 +925,13 @@ reply_send:
 	api->ipc_response_send(conn, &res_lib_cmap_track_delete, sizeof(res_lib_cmap_track_delete));
 }
 
+/**
+ * @brief cmap_mcast_send
+ * @param reason
+ * @param argc
+ * @param argv
+ * @return
+ */
 static cs_error_t cmap_mcast_send(enum cmap_mcast_reason reason, int argc, char *argv[])
 {
 	int i;
@@ -880,6 +1012,12 @@ free_mem:
 	return (err);
 }
 
+/**
+ * @brief cmap_mcast_item_find
+ * @param message
+ * @param key
+ * @return
+ */
 static struct req_exec_cmap_mcast_item *cmap_mcast_item_find(
 		const void *message,
 		char *key)
@@ -906,6 +1044,12 @@ static struct req_exec_cmap_mcast_item *cmap_mcast_item_find(
 	return (NULL);
 }
 
+/**
+ * @brief message_handler_req_exec_cmap_mcast_reason_sync_nv
+ * @param reason
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cmap_mcast_reason_sync_nv(
 		enum cmap_mcast_reason reason,
 		const void *message,
@@ -945,6 +1089,11 @@ static void message_handler_req_exec_cmap_mcast_reason_sync_nv(
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_cmap_mcast
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cmap_mcast(
 		const void *message,
 		unsigned int nodeid)
@@ -971,6 +1120,10 @@ static void message_handler_req_exec_cmap_mcast(
 	LEAVE();
 }
 
+/**
+ * @brief exec_cmap_mcast_endian_convert
+ * @param message
+ */
 static void exec_cmap_mcast_endian_convert(void *message)
 {
 	struct req_exec_cmap_mcast *req_exec_cmap_mcast = message;

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -63,6 +63,9 @@
 #include "main.h"
 #include "util.h"
 
+/**
+ * @brief The parser_cb_type enum
+ */
 enum parser_cb_type {
 	PARSER_CB_START,
 	PARSER_CB_END,
@@ -71,6 +74,9 @@ enum parser_cb_type {
 	PARSER_CB_ITEM,
 };
 
+/**
+ * @brief The main_cp_cb_data_state enum
+ */
 enum main_cp_cb_data_state {
 	MAIN_CP_CB_DATA_STATE_NORMAL,
 	MAIN_CP_CB_DATA_STATE_TOTEM,
@@ -87,6 +93,9 @@ enum main_cp_cb_data_state {
 	MAIN_CP_CB_DATA_STATE_QB
 };
 
+/**
+ * @brief parser_cb_f callback
+ */
 typedef int (*parser_cb_f)(const char *path,
 			char *key,
 			char *value,
@@ -96,12 +105,18 @@ typedef int (*parser_cb_f)(const char *path,
 			icmap_map_t config_map,
 			void *user_data);
 
+/**
+ * @brief The key_value_list_item struct
+ */
 struct key_value_list_item {
 	char *key;
 	char *value;
 	struct list_head list;
 };
 
+/**
+ * @brief The main_cp_cb_data struct
+ */
 struct main_cp_cb_data {
 	int ringnumber;
 	char *bindnetaddr;
@@ -123,6 +138,11 @@ static int read_config_file_into_icmap(
 	const char **error_string, icmap_map_t config_map);
 static char error_string_response[512];
 
+/**
+ * @brief uid_determine
+ * @param req_user
+ * @return
+ */
 static int uid_determine (const char *req_user)
 {
 	int pw_uid = 0;
@@ -177,6 +197,11 @@ static int uid_determine (const char *req_user)
 	return pw_uid;
 }
 
+/**
+ * @brief gid_determine
+ * @param req_group
+ * @return
+ */
 static int gid_determine (const char *req_group)
 {
 	int corosync_gid = 0;
@@ -230,6 +255,13 @@ static int gid_determine (const char *req_group)
 
 	return corosync_gid;
 }
+
+/**
+ * @brief strchr_rs
+ * @param haystack
+ * @param byte
+ * @return
+ */
 static char *strchr_rs (const char *haystack, int byte)
 {
 	const char *end_address = strchr (haystack, byte);
@@ -243,6 +275,12 @@ static char *strchr_rs (const char *haystack, int byte)
 	return ((char *) end_address);
 }
 
+/**
+ * @brief coroparse_configparse
+ * @param config_map
+ * @param error_string
+ * @return
+ */
 int coroparse_configparse (icmap_map_t config_map, const char **error_string)
 {
 	if (read_config_file_into_icmap(error_string, config_map)) {
@@ -252,6 +290,12 @@ int coroparse_configparse (icmap_map_t config_map, const char **error_string)
 	return 0;
 }
 
+/**
+ * @brief remove_whitespace
+ * @param string
+ * @param remove_colon_and_brace
+ * @return
+ */
 static char *remove_whitespace(char *string, int remove_colon_and_brace)
 {
 	char *start;
@@ -270,8 +314,18 @@ static char *remove_whitespace(char *string, int remove_colon_and_brace)
 	return start;
 }
 
-
-
+/**
+ * @brief parse_section
+ * @param fp
+ * @param path
+ * @param error_string
+ * @param depth
+ * @param state
+ * @param parser_cb
+ * @param config_map
+ * @param user_data
+ * @return
+ */
 static int parse_section(FILE *fp,
 			 char *path,
 			 const char **error_string,
@@ -408,6 +462,13 @@ static int parse_section(FILE *fp,
 	return 0;
 }
 
+/**
+ * @brief safe_atoq_range
+ * @param value_type
+ * @param min_val
+ * @param max_val
+ * @return
+ */
 static int safe_atoq_range(icmap_value_types_t value_type, long long int *min_val, long long int *max_val)
 {
 	switch (value_type) {
@@ -424,10 +485,14 @@ static int safe_atoq_range(icmap_value_types_t value_type, long long int *min_va
 	return (0);
 }
 
-/*
- * Convert string str to long long int res. Type of result is target_type and currently only
+/**
+ * @brief safe_atoq Convert string str to long long int res. Type of result is target_type and currently only
  * ICMAP_VALUETYPE_[U]INT[8|16|32] is supported.
  * Return 0 on success, -1 on failure.
+ * @param str
+ * @param res
+ * @param target_type
+ * @return
  */
 static int safe_atoq(const char *str, long long int *res, icmap_value_types_t target_type)
 {
@@ -462,6 +527,12 @@ static int safe_atoq(const char *str, long long int *res, icmap_value_types_t ta
 	return (0);
 }
 
+/**
+ * @brief str_to_ull
+ * @param str
+ * @param res
+ * @return
+ */
 static int str_to_ull(const char *str, unsigned long long int *res)
 {
 	unsigned long long int val;
@@ -486,6 +557,18 @@ static int str_to_ull(const char *str, unsigned long long int *res)
 	return (0);
 }
 
+/**
+ * @brief main_config_parser_cb
+ * @param path
+ * @param key
+ * @param value
+ * @param state
+ * @param type
+ * @param error_string
+ * @param config_map
+ * @param user_data
+ * @return
+ */
 static int main_config_parser_cb(const char *path,
 			char *key,
 			char *value,
@@ -1112,6 +1195,18 @@ atoi_error:
 	return (0);
 }
 
+/**
+ * @brief uidgid_config_parser_cb
+ * @param path
+ * @param key
+ * @param value
+ * @param state
+ * @param type
+ * @param error_string
+ * @param config_map
+ * @param user_data
+ * @return
+ */
 static int uidgid_config_parser_cb(const char *path,
 			char *key,
 			char *value,
@@ -1166,6 +1261,12 @@ static int uidgid_config_parser_cb(const char *path,
 	return (1);
 }
 
+/**
+ * @brief read_uidgid_files_into_icmap
+ * @param error_string
+ * @param config_map
+ * @return
+ */
 static int read_uidgid_files_into_icmap(
 	const char **error_string,
 	icmap_map_t config_map)
@@ -1227,7 +1328,12 @@ error_exit:
 	return res;
 }
 
-/* Read config file and load into icmap */
+/**
+ * @brief read_config_file_into_icmap Read config file and load into icmap
+ * @param error_string
+ * @param config_map
+ * @return
+ */
 static int read_config_file_into_icmap(
 	const char **error_string,
 	icmap_map_t config_map)

--- a/exec/cpg.c
+++ b/exec/cpg.c
@@ -77,6 +77,9 @@ LOGSYS_DECLARE_SUBSYS ("CPG");
 
 #define GROUP_HASH_SIZE 32
 
+/**
+ * @brief The cpg_message_req_types enum
+ */
 enum cpg_message_req_types {
 	MESSAGE_REQ_EXEC_CPG_PROCJOIN = 0,
 	MESSAGE_REQ_EXEC_CPG_PROCLEAVE = 1,
@@ -87,11 +90,15 @@ enum cpg_message_req_types {
 	MESSAGE_REQ_EXEC_CPG_PARTIAL_MCAST = 6,
 };
 
+/**
+ * @brief The zcb_mapped struct
+ */
 struct zcb_mapped {
 	struct list_head list;
 	void *addr;
 	size_t size;
 };
+
 /*
  * state`		exec deliver
  * match group name, pid -> if matched deliver for YES:
@@ -129,6 +136,9 @@ struct zcb_mapped {
  * JOIN_STARTED		YES(CS_OK)
  * JOIN_COMPLETED	YES(CS_OK)
  */
+/**
+ * @brief The cpd_state enum
+ */
 enum cpd_state {
 	CPD_STATE_UNJOINED,
 	CPD_STATE_LEAVE_STARTED,
@@ -136,11 +146,17 @@ enum cpd_state {
 	CPD_STATE_JOIN_COMPLETED
 };
 
+/**
+ * @brief The cpg_sync_state enum
+ */
 enum cpg_sync_state {
 	CPGSYNC_DOWNLIST,
 	CPGSYNC_JOINLIST
 };
 
+/**
+ * @brief The cpg_downlist_state_e enum
+ */
 enum cpg_downlist_state_e {
        CPG_DOWNLIST_NONE,
        CPG_DOWNLIST_WAITING_FOR_MESSAGES,
@@ -150,6 +166,9 @@ static enum cpg_downlist_state_e downlist_state;
 static struct list_head downlist_messages_head;
 static struct list_head joinlist_messages_head;
 
+/**
+ * @brief The cpg_pd struct
+ */
 struct cpg_pd {
 	void *conn;
  	mar_cpg_name_t group_name;
@@ -164,6 +183,9 @@ struct cpg_pd {
 	struct list_head zcb_mapped_list_head;
 };
 
+/**
+ * @brief The cpg_iteration_instance struct
+ */
 struct cpg_iteration_instance {
 	hdb_handle_t handle;
 	struct list_head list;
@@ -189,6 +211,9 @@ static enum cpg_sync_state my_sync_state = CPGSYNC_DOWNLIST;
 
 static mar_cpg_ring_id_t last_sync_ring_id;
 
+/**
+ * @brief The process_info struct
+ */
 struct process_info {
 	unsigned int nodeid;
 	uint32_t pid;
@@ -197,6 +222,9 @@ struct process_info {
 };
 DECLARE_LIST_INIT(process_info_list_head);
 
+/**
+ * @brief The join_list_entry struct
+ */
 struct join_list_entry {
 	uint32_t pid;
 	mar_cpg_name_t group_name;
@@ -341,7 +369,7 @@ static inline int zcb_all_free (
 static char *cpg_print_group_name (
 	const mar_cpg_name_t *group);
 
-/*
+/**
  * Library Handler Definition
  */
 static struct corosync_lib_handler cpg_lib_engine[] =
@@ -401,6 +429,9 @@ static struct corosync_lib_handler cpg_lib_engine[] =
 
 };
 
+/**
+ *
+ */
 static struct corosync_exec_handler cpg_exec_engine[] =
 {
 	{ /* 0 - MESSAGE_REQ_EXEC_CPG_PROCJOIN */
@@ -454,11 +485,18 @@ struct corosync_service_engine cpg_service_engine = {
 	.sync_abort                             = cpg_sync_abort
 };
 
+/**
+ * @brief cpg_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *cpg_get_service_engine_ver0 (void)
 {
 	return (&cpg_service_engine);
 }
 
+/**
+ * @brief The req_exec_cpg_procjoin struct
+ */
 struct req_exec_cpg_procjoin {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -466,6 +504,9 @@ struct req_exec_cpg_procjoin {
 	mar_uint32_t reason __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cpg_mcast struct
+ */
 struct req_exec_cpg_mcast {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -475,6 +516,9 @@ struct req_exec_cpg_mcast {
 	mar_uint8_t message[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cpg_partial_mcast struct
+ */
 struct req_exec_cpg_partial_mcast {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -486,12 +530,18 @@ struct req_exec_cpg_partial_mcast {
 	mar_uint8_t message[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cpg_downlist_old struct
+ */
 struct req_exec_cpg_downlist_old {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_uint32_t left_nodes __attribute__((aligned(8)));
 	mar_uint32_t nodeids[PROCESSOR_COUNT_MAX]  __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cpg_downlist struct
+ */
 struct req_exec_cpg_downlist {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	/* merge decisions */
@@ -501,6 +551,9 @@ struct req_exec_cpg_downlist {
 	mar_uint32_t nodeids[PROCESSOR_COUNT_MAX]  __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The downlist_msg struct
+ */
 struct downlist_msg {
 	mar_uint32_t sender_nodeid;
 	mar_uint32_t old_members __attribute__((aligned(8)));
@@ -509,6 +562,9 @@ struct downlist_msg {
 	struct list_head list;
 };
 
+/**
+ * @brief The joinlist_msg struct
+ */
 struct joinlist_msg {
 	mar_uint32_t sender_nodeid;
 	uint32_t pid;
@@ -516,10 +572,18 @@ struct joinlist_msg {
 	struct list_head list;
 };
 
+/**
+ * @brief g_req_exec_cpg_downlist
+ */
 static struct req_exec_cpg_downlist g_req_exec_cpg_downlist;
 
 /*
  * Function print group name. It's not reentrant
+ */
+/**
+ * @brief cpg_print_group_name
+ * @param group
+ * @return
  */
 static char *cpg_print_group_name(const mar_cpg_name_t *group)
 {
@@ -548,6 +612,14 @@ static char *cpg_print_group_name(const mar_cpg_name_t *group)
 	return (res);
 }
 
+/**
+ * @brief cpg_sync_init
+ * @param trans_list
+ * @param trans_list_entries
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void cpg_sync_init (
 	const unsigned int *trans_list,
 	size_t trans_list_entries,
@@ -590,6 +662,10 @@ static void cpg_sync_init (
 	g_req_exec_cpg_downlist.left_nodes = entries;
 }
 
+/**
+ * @brief cpg_sync_process
+ * @return
+ */
 static int cpg_sync_process (void)
 {
 	int res = -1;
@@ -607,6 +683,9 @@ static int cpg_sync_process (void)
 	return (res);
 }
 
+/**
+ * @brief cpg_sync_activate
+ */
 static void cpg_sync_activate (void)
 {
 	memcpy (my_old_member_list, my_member_list,
@@ -626,6 +705,9 @@ static void cpg_sync_activate (void)
 	notify_lib_totem_membership (NULL, my_member_list_entries, my_member_list);
 }
 
+/**
+ * @brief cpg_sync_abort
+ */
 static void cpg_sync_abort (void)
 {
 	downlist_state = CPG_DOWNLIST_NONE;
@@ -633,6 +715,13 @@ static void cpg_sync_abort (void)
 	joinlist_messages_delete ();
 }
 
+/**
+ * @brief notify_lib_totem_membership
+ * @param conn
+ * @param member_list_entries
+ * @param member_list
+ * @return
+ */
 static int notify_lib_totem_membership (
 	void *conn,
 	int member_list_entries,
@@ -670,6 +759,17 @@ static int notify_lib_totem_membership (
 	return CS_OK;
 }
 
+/**
+ * @brief notify_lib_joinlist
+ * @param group_name
+ * @param conn
+ * @param joined_list_entries
+ * @param joined_list
+ * @param left_list_entries
+ * @param left_list
+ * @param id
+ * @return
+ */
 static int notify_lib_joinlist(
 	const mar_cpg_name_t *group_name,
 	void *conn,
@@ -802,6 +902,11 @@ static int notify_lib_joinlist(
 	return CS_OK;
 }
 
+/**
+ * @brief downlist_log
+ * @param msg
+ * @param dl
+ */
 static void downlist_log(const char *msg, struct downlist_msg* dl)
 {
 	log_printf (LOG_DEBUG,
@@ -812,6 +917,10 @@ static void downlist_log(const char *msg, struct downlist_msg* dl)
 		    dl->left_nodes);
 }
 
+/**
+ * @brief downlist_master_choose
+ * @return
+ */
 static struct downlist_msg* downlist_master_choose (void)
 {
 	struct downlist_msg *cmp;
@@ -869,6 +978,9 @@ static struct downlist_msg* downlist_master_choose (void)
 	return best;
 }
 
+/**
+ * @brief downlist_master_choose_and_send
+ */
 static void downlist_master_choose_and_send (void)
 {
 	struct downlist_msg *stored_msg;
@@ -964,6 +1076,10 @@ static void downlist_master_choose_and_send (void)
 /*
  * Remove processes that might have left the group while we were suspended.
  */
+
+/**
+ * @brief joinlist_remove_zombie_pi_entries
+ */
 static void joinlist_remove_zombie_pi_entries (void)
 {
 	struct list_head *pi_iter;
@@ -1011,6 +1127,9 @@ static void joinlist_remove_zombie_pi_entries (void)
 	}
 }
 
+/**
+ * @brief joinlist_inform_clients
+ */
 static void joinlist_inform_clients (void)
 {
 	struct joinlist_msg *stored_msg;
@@ -1041,6 +1160,9 @@ static void joinlist_inform_clients (void)
 	joinlist_remove_zombie_pi_entries ();
 }
 
+/**
+ * @brief downlist_messages_delete
+ */
 static void downlist_messages_delete (void)
 {
 	struct downlist_msg *stored_msg;
@@ -1058,6 +1180,9 @@ static void downlist_messages_delete (void)
 	}
 }
 
+/**
+ * @brief joinlist_messages_delete
+ */
 static void joinlist_messages_delete (void)
 {
 	struct joinlist_msg *stored_msg;
@@ -1076,6 +1201,11 @@ static void joinlist_messages_delete (void)
 	list_init (&joinlist_messages_head);
 }
 
+/**
+ * @brief cpg_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *cpg_exec_init_fn (struct corosync_api_v1 *corosync_api)
 {
 	list_init (&downlist_messages_head);
@@ -1084,6 +1214,10 @@ static char *cpg_exec_init_fn (struct corosync_api_v1 *corosync_api)
 	return (NULL);
 }
 
+/**
+ * @brief cpg_iteration_instance_finalize
+ * @param cpg_iteration_instance
+ */
 static void cpg_iteration_instance_finalize (struct cpg_iteration_instance *cpg_iteration_instance)
 {
 	struct list_head *iter, *iter_next;
@@ -1104,6 +1238,10 @@ static void cpg_iteration_instance_finalize (struct cpg_iteration_instance *cpg_
 	hdb_handle_destroy (&cpg_iteration_handle_t_db, cpg_iteration_instance->handle);
 }
 
+/**
+ * @brief cpg_pd_finalize
+ * @param cpd
+ */
 static void cpg_pd_finalize (struct cpg_pd *cpd)
 {
 	struct list_head *iter, *iter_next;
@@ -1124,6 +1262,11 @@ static void cpg_pd_finalize (struct cpg_pd *cpd)
 	list_del (&cpd->list);
 }
 
+/**
+ * @brief cpg_lib_exit_fn
+ * @param conn
+ * @return
+ */
 static int cpg_lib_exit_fn (void *conn)
 {
 	struct cpg_pd *cpd = (struct cpg_pd *)api->ipc_private_data_get (conn);
@@ -1141,6 +1284,14 @@ static int cpg_lib_exit_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief cpg_node_joinleave_send
+ * @param pid
+ * @param group_name
+ * @param fn
+ * @param reason
+ * @return
+ */
 static int cpg_node_joinleave_send (unsigned int pid, const mar_cpg_name_t *group_name, int fn, int reason)
 {
 	struct req_exec_cpg_procjoin req_exec_cpg_procjoin;
@@ -1163,6 +1314,10 @@ static int cpg_node_joinleave_send (unsigned int pid, const mar_cpg_name_t *grou
 }
 
 /* Can byteswap join & leave messages */
+/**
+ * @brief exec_cpg_procjoin_endian_convert
+ * @param msg
+ */
 static void exec_cpg_procjoin_endian_convert (void *msg)
 {
 	struct req_exec_cpg_procjoin *req_exec_cpg_procjoin = msg;
@@ -1172,6 +1327,10 @@ static void exec_cpg_procjoin_endian_convert (void *msg)
 	req_exec_cpg_procjoin->reason = swab32(req_exec_cpg_procjoin->reason);
 }
 
+/**
+ * @brief exec_cpg_joinlist_endian_convert
+ * @param msg_v
+ */
 static void exec_cpg_joinlist_endian_convert (void *msg_v)
 {
 	char *msg = msg_v;
@@ -1187,10 +1346,18 @@ static void exec_cpg_joinlist_endian_convert (void *msg_v)
 	}
 }
 
+/**
+ * @brief exec_cpg_downlist_endian_convert_old
+ * @param msg
+ */
 static void exec_cpg_downlist_endian_convert_old (void *msg)
 {
 }
 
+/**
+ * @brief exec_cpg_downlist_endian_convert
+ * @param msg
+ */
 static void exec_cpg_downlist_endian_convert (void *msg)
 {
 	struct req_exec_cpg_downlist *req_exec_cpg_downlist = msg;
@@ -1204,7 +1371,10 @@ static void exec_cpg_downlist_endian_convert (void *msg)
 	}
 }
 
-
+/**
+ * @brief exec_cpg_mcast_endian_convert
+ * @param msg
+ */
 static void exec_cpg_mcast_endian_convert (void *msg)
 {
 	struct req_exec_cpg_mcast *req_exec_cpg_mcast = msg;
@@ -1216,6 +1386,10 @@ static void exec_cpg_mcast_endian_convert (void *msg)
 	swab_mar_message_source_t (&req_exec_cpg_mcast->source);
 }
 
+/**
+ * @brief exec_cpg_partial_mcast_endian_convert
+ * @param msg
+ */
 static void exec_cpg_partial_mcast_endian_convert (void *msg)
 {
 	struct req_exec_cpg_partial_mcast *req_exec_cpg_mcast = msg;
@@ -1229,6 +1403,13 @@ static void exec_cpg_partial_mcast_endian_convert (void *msg)
 	swab_mar_message_source_t (&req_exec_cpg_mcast->source);
 }
 
+/**
+ * @brief process_info_find
+ * @param group_name
+ * @param pid
+ * @param nodeid
+ * @return
+ */
 static struct process_info *process_info_find(const mar_cpg_name_t *group_name, uint32_t pid, unsigned int nodeid) {
 	struct list_head *iter;
 
@@ -1245,6 +1426,13 @@ static struct process_info *process_info_find(const mar_cpg_name_t *group_name, 
 	return NULL;
 }
 
+/**
+ * @brief do_proc_join
+ * @param name
+ * @param pid
+ * @param nodeid
+ * @param reason
+ */
 static void do_proc_join(
 	const mar_cpg_name_t *name,
 	uint32_t pid,
@@ -1296,6 +1484,13 @@ static void do_proc_join(
 			    MESSAGE_RES_CPG_CONFCHG_CALLBACK);
 }
 
+/**
+ * @brief do_proc_leave
+ * @param name
+ * @param pid
+ * @param nodeid
+ * @param reason
+ */
 static void do_proc_leave(
 	const mar_cpg_name_t *name,
 	uint32_t pid,
@@ -1327,6 +1522,11 @@ static void do_proc_leave(
 	}
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_downlist_old
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_downlist_old (
 	const void *message,
 	unsigned int nodeid)
@@ -1335,6 +1535,11 @@ static void message_handler_req_exec_cpg_downlist_old (
 		nodeid);
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_downlist
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_downlist(
 	const void *message,
 	unsigned int nodeid)
@@ -1380,6 +1585,11 @@ static void message_handler_req_exec_cpg_downlist(
 }
 
 
+/**
+ * @brief message_handler_req_exec_cpg_procjoin
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_procjoin (
 	const void *message,
 	unsigned int nodeid)
@@ -1396,6 +1606,11 @@ static void message_handler_req_exec_cpg_procjoin (
 		CONFCHG_CPG_REASON_JOIN);
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_procleave
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_procleave (
 	const void *message,
 	unsigned int nodeid)
@@ -1414,6 +1629,11 @@ static void message_handler_req_exec_cpg_procleave (
 
 
 /* Got a proclist from another node */
+/**
+ * @brief message_handler_req_exec_cpg_joinlist
+ * @param message_v
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_joinlist (
 	const void *message_v,
 	unsigned int nodeid)
@@ -1438,6 +1658,11 @@ static void message_handler_req_exec_cpg_joinlist (
 	}
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_mcast
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_mcast (
 	const void *message,
 	unsigned int nodeid)
@@ -1496,6 +1721,11 @@ static void message_handler_req_exec_cpg_mcast (
 	}
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_partial_mcast
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_partial_mcast (
 	const void *message,
 	unsigned int nodeid)
@@ -1559,6 +1789,10 @@ static void message_handler_req_exec_cpg_partial_mcast (
 }
 
 
+/**
+ * @brief cpg_exec_send_downlist
+ * @return
+ */
 static int cpg_exec_send_downlist(void)
 {
 	struct iovec iov;
@@ -1574,6 +1808,10 @@ static int cpg_exec_send_downlist(void)
 	return (api->totem_mcast (&iov, 1, TOTEM_AGREED));
 }
 
+/**
+ * @brief cpg_exec_send_joinlist
+ * @return
+ */
 static int cpg_exec_send_joinlist(void)
 {
 	int count = 0;
@@ -1623,6 +1861,11 @@ static int cpg_exec_send_joinlist(void)
 	return (api->totem_mcast (&req_exec_cpg_iovec, 1, TOTEM_AGREED));
 }
 
+/**
+ * @brief cpg_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int cpg_lib_init_fn (void *conn)
 {
 	struct cpg_pd *cpd = (struct cpg_pd *)api->ipc_private_data_get (conn);
@@ -1639,6 +1882,11 @@ static int cpg_lib_init_fn (void *conn)
 }
 
 /* Join message from the library */
+/**
+ * @brief message_handler_req_lib_cpg_join
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_join (void *conn, const void *message)
 {
 	const struct req_lib_cpg_join *req_lib_cpg_join = message;
@@ -1712,6 +1960,11 @@ response_send:
 }
 
 /* Leave message from the library */
+/**
+ * @brief message_handler_req_lib_cpg_leave
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_leave (void *conn, const void *message)
 {
 	struct res_lib_cpg_leave res_lib_cpg_leave;
@@ -1749,6 +2002,12 @@ static void message_handler_req_lib_cpg_leave (void *conn, const void *message)
 }
 
 /* Finalize message from library */
+
+/**
+ * @brief message_handler_req_lib_cpg_finalize
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_finalize (
 	void *conn,
 	const void *message)
@@ -1820,6 +2079,14 @@ error_close_unlink:
 	return -1;
 }
 
+/**
+ * @brief zcb_alloc
+ * @param cpd
+ * @param path_to_file
+ * @param size
+ * @param addr
+ * @return
+ */
 static inline int zcb_alloc (
 	struct cpg_pd *cpd,
 	const char *path_to_file,
@@ -1851,6 +2118,11 @@ static inline int zcb_alloc (
 }
 
 
+/**
+ * @brief zcb_free
+ * @param zcb_mapped
+ * @return
+ */
 static inline int zcb_free (struct zcb_mapped *zcb_mapped)
 {
 	unsigned int res;
@@ -1861,6 +2133,12 @@ static inline int zcb_free (struct zcb_mapped *zcb_mapped)
 	return (res);
 }
 
+/**
+ * @brief zcb_by_addr_free
+ * @param cpd
+ * @param addr
+ * @return
+ */
 static inline int zcb_by_addr_free (struct cpg_pd *cpd, void *addr)
 {
 	struct list_head *list;
@@ -1881,6 +2159,11 @@ static inline int zcb_by_addr_free (struct cpg_pd *cpd, void *addr)
 	return (res);
 }
 
+/**
+ * @brief zcb_all_free
+ * @param cpd
+ * @return
+ */
 static inline int zcb_all_free (
 	struct cpg_pd *cpd)
 {
@@ -1899,11 +2182,19 @@ static inline int zcb_all_free (
 	return (0);
 }
 
+/**
+ * @brief The u union
+ */
 union u {
 	uint64_t server_addr;
 	void *server_ptr;
 };
 
+/**
+ * @brief void2serveraddr
+ * @param server_ptr
+ * @return
+ */
 static uint64_t void2serveraddr (void *server_ptr)
 {
 	union u u;
@@ -1912,6 +2203,11 @@ static uint64_t void2serveraddr (void *server_ptr)
 	return (u.server_addr);
 }
 
+/**
+ * @brief serveraddr2void
+ * @param server_addr
+ * @return
+ */
 static void *serveraddr2void (uint64_t server_addr)
 {
 	union u u;
@@ -1920,6 +2216,11 @@ static void *serveraddr2void (uint64_t server_addr)
 	return (u.server_ptr);
 };
 
+/**
+ * @brief message_handler_req_lib_cpg_zc_alloc
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_zc_alloc (
 	void *conn,
 	const void *message)
@@ -1947,6 +2248,11 @@ static void message_handler_req_lib_cpg_zc_alloc (
 		res_header.size);
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_zc_free
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_zc_free (
 	void *conn,
 	const void *message)
@@ -1970,6 +2276,11 @@ static void message_handler_req_lib_cpg_zc_free (
 }
 
 /* Fragmented mcast message from the library */
+/**
+ * @brief message_handler_req_lib_cpg_partial_mcast
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_partial_mcast (void *conn, const void *message)
 {
 	const struct req_lib_cpg_partial_mcast *req_lib_cpg_mcast = message;
@@ -2041,6 +2352,12 @@ static void message_handler_req_lib_cpg_partial_mcast (void *conn, const void *m
 }
 
 /* Mcast message from the library */
+
+/**
+ * @brief message_handler_req_lib_cpg_mcast
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_mcast (void *conn, const void *message)
 {
 	const struct req_lib_cpg_mcast *req_lib_cpg_mcast = message;
@@ -2093,6 +2410,11 @@ static void message_handler_req_lib_cpg_mcast (void *conn, const void *message)
 	}
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_zc_execute
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_zc_execute (
 	void *conn,
 	const void *message)
@@ -2159,6 +2481,11 @@ static void message_handler_req_lib_cpg_zc_execute (
 
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_membership
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_membership (void *conn,
 						    const void *message)
 {
@@ -2189,6 +2516,11 @@ static void message_handler_req_lib_cpg_membership (void *conn,
 		sizeof (res_lib_cpg_membership_get));
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_local_get
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_local_get (void *conn,
 						   const void *message)
 {
@@ -2203,6 +2535,11 @@ static void message_handler_req_lib_cpg_local_get (void *conn,
 		sizeof (res_lib_cpg_local_get));
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_iteration_initialize
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_iteration_initialize (
 	void *conn,
 	const void *message)
@@ -2348,6 +2685,11 @@ response_send:
 		sizeof (res_lib_cpg_iterationinitialize));
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_iteration_next
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_iteration_next (
 	void *conn,
 	const void *message)
@@ -2401,6 +2743,11 @@ error_exit:
 		sizeof (res_lib_cpg_iterationnext));
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_iteration_finalize
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_iteration_finalize (
 	void *conn,
 	const void *message)

--- a/exec/cs_queue.h
+++ b/exec/cs_queue.h
@@ -41,6 +41,9 @@
 #include <errno.h>
 #include "assert.h"
 
+/**
+ * @brief The cs_queue struct
+ */
 struct cs_queue {
 	int head;
 	int tail;
@@ -54,6 +57,14 @@ struct cs_queue {
 	int threaded_mode_enabled;
 };
 
+/**
+ * @brief cs_queue_init
+ * @param cs_queue
+ * @param cs_queue_items
+ * @param size_per_item
+ * @param threaded_mode_enabled
+ * @return
+ */
 static inline int cs_queue_init (struct cs_queue *cs_queue, int cs_queue_items, int size_per_item, int threaded_mode_enabled) {
 	cs_queue->head = 0;
 	cs_queue->tail = cs_queue_items - 1;
@@ -74,6 +85,11 @@ static inline int cs_queue_init (struct cs_queue *cs_queue, int cs_queue_items, 
 	return (0);
 }
 
+/**
+ * @brief cs_queue_reinit
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_reinit (struct cs_queue *cs_queue)
 {
 	if (cs_queue->threaded_mode_enabled) {
@@ -91,6 +107,10 @@ static inline int cs_queue_reinit (struct cs_queue *cs_queue)
 	return (0);
 }
 
+/**
+ * @brief cs_queue_free
+ * @param cs_queue
+ */
 static inline void cs_queue_free (struct cs_queue *cs_queue) {
 	if (cs_queue->threaded_mode_enabled) {
 		pthread_mutex_destroy (&cs_queue->mutex);
@@ -98,6 +118,11 @@ static inline void cs_queue_free (struct cs_queue *cs_queue) {
 	free (cs_queue->items);
 }
 
+/**
+ * @brief cs_queue_is_full
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_is_full (struct cs_queue *cs_queue) {
 	int full;
 
@@ -111,6 +136,11 @@ static inline int cs_queue_is_full (struct cs_queue *cs_queue) {
 	return (full);
 }
 
+/**
+ * @brief cs_queue_is_empty
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_is_empty (struct cs_queue *cs_queue) {
 	int empty;
 
@@ -124,6 +154,11 @@ static inline int cs_queue_is_empty (struct cs_queue *cs_queue) {
 	return (empty);
 }
 
+/**
+ * @brief cs_queue_item_add
+ * @param cs_queue
+ * @param item
+ */
 static inline void cs_queue_item_add (struct cs_queue *cs_queue, void *item)
 {
 	char *cs_queue_item;
@@ -149,6 +184,11 @@ static inline void cs_queue_item_add (struct cs_queue *cs_queue, void *item)
 	}
 }
 
+/**
+ * @brief cs_queue_item_get
+ * @param cs_queue
+ * @return
+ */
 static inline void *cs_queue_item_get (struct cs_queue *cs_queue)
 {
 	char *cs_queue_item;
@@ -166,6 +206,10 @@ static inline void *cs_queue_item_get (struct cs_queue *cs_queue)
 	return ((void *)cs_queue_item);
 }
 
+/**
+ * @brief cs_queue_item_remove
+ * @param cs_queue
+ */
 static inline void cs_queue_item_remove (struct cs_queue *cs_queue) {
 	if (cs_queue->threaded_mode_enabled) {
 		pthread_mutex_lock (&cs_queue->mutex);
@@ -181,6 +225,11 @@ static inline void cs_queue_item_remove (struct cs_queue *cs_queue) {
 	}
 }
 
+/**
+ * @brief cs_queue_items_remove
+ * @param cs_queue
+ * @param rel_count
+ */
 static inline void cs_queue_items_remove (struct cs_queue *cs_queue, int rel_count)
 {
 	if (cs_queue->threaded_mode_enabled) {
@@ -196,7 +245,10 @@ static inline void cs_queue_items_remove (struct cs_queue *cs_queue, int rel_cou
 	}
 }
 
-
+/**
+ * @brief cs_queue_item_iterator_init
+ * @param cs_queue
+ */
 static inline void cs_queue_item_iterator_init (struct cs_queue *cs_queue)
 {
 	if (cs_queue->threaded_mode_enabled) {
@@ -208,6 +260,11 @@ static inline void cs_queue_item_iterator_init (struct cs_queue *cs_queue)
 	}
 }
 
+/**
+ * @brief cs_queue_item_iterator_get
+ * @param cs_queue
+ * @return
+ */
 static inline void *cs_queue_item_iterator_get (struct cs_queue *cs_queue)
 {
 	char *cs_queue_item;
@@ -231,6 +288,11 @@ static inline void *cs_queue_item_iterator_get (struct cs_queue *cs_queue)
 	return ((void *)cs_queue_item);
 }
 
+/**
+ * @brief cs_queue_item_iterator_next
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_item_iterator_next (struct cs_queue *cs_queue)
 {
 	int next_res;
@@ -247,6 +309,11 @@ static inline int cs_queue_item_iterator_next (struct cs_queue *cs_queue)
 	return (next_res);
 }
 
+/**
+ * @brief cs_queue_avail
+ * @param cs_queue
+ * @param avail
+ */
 static inline void cs_queue_avail (struct cs_queue *cs_queue, int *avail)
 {
 	if (cs_queue->threaded_mode_enabled) {
@@ -259,6 +326,11 @@ static inline void cs_queue_avail (struct cs_queue *cs_queue, int *avail)
 	}
 }
 
+/**
+ * @brief cs_queue_used
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_used (struct cs_queue *cs_queue) {
 	int used;
 
@@ -273,6 +345,11 @@ static inline int cs_queue_used (struct cs_queue *cs_queue) {
 	return (used);
 }
 
+/**
+ * @brief cs_queue_usedhw
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_usedhw (struct cs_queue *cs_queue) {
 	int usedhw;
 

--- a/exec/fsm.h
+++ b/exec/fsm.h
@@ -77,6 +77,13 @@ struct cs_fsm {
  * so cs_fsm_process() sets the entry and cs_fsm_state_set()
  * sets the new state.
  */
+/**
+ * @brief cs_fsm_process
+ * @param fsm
+ * @param new_event
+ * @param data
+ * @param cb
+ */
 static inline void cs_fsm_process (struct cs_fsm *fsm, int32_t new_event, void * data, cs_fsm_cb cb)
 {
 	int32_t i;
@@ -98,6 +105,13 @@ static inline void cs_fsm_process (struct cs_fsm *fsm, int32_t new_event, void *
 	}
 }
 
+/**
+ * @brief cs_fsm_state_set
+ * @param fsm
+ * @param next_state
+ * @param data
+ * @param cb
+ */
 static inline void cs_fsm_state_set (struct cs_fsm* fsm, int32_t next_state, void* data, cs_fsm_cb cb)
 {
 	int i;

--- a/exec/icmap.c
+++ b/exec/icmap.c
@@ -129,6 +129,15 @@ static cs_error_t icmap_get_int_r(
  * of arguments validity checks but doesn't copy data (it returns raw item data
  * pointer). It's not very safe tho it's static.
  */
+/**
+ * @brief icmap_get_ref_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 static cs_error_t icmap_get_ref_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -138,6 +147,11 @@ static cs_error_t icmap_get_ref_r(
 
 /*
  * Function implementation
+ */
+/**
+ * @brief icmap_tt_to_qbtt
+ * @param track_type
+ * @return
  */
 static int32_t icmap_tt_to_qbtt(int32_t track_type)
 {
@@ -162,6 +176,11 @@ static int32_t icmap_tt_to_qbtt(int32_t track_type)
 	return (res);
 }
 
+/**
+ * @brief icmap_qbtt_to_tt
+ * @param track_type
+ * @return
+ */
 static int32_t icmap_qbtt_to_tt(int32_t track_type)
 {
 	int32_t res = 0;
@@ -185,6 +204,14 @@ static int32_t icmap_qbtt_to_tt(int32_t track_type)
 	return (res);
 }
 
+/**
+ * @brief icmap_map_free_cb
+ * @param event
+ * @param key
+ * @param old_value
+ * @param value
+ * @param user_data
+ */
 static void icmap_map_free_cb(uint32_t event,
 		char* key, void* old_value,
 		void* value, void* user_data)
@@ -200,6 +227,11 @@ static void icmap_map_free_cb(uint32_t event,
 	}
 }
 
+/**
+ * @brief icmap_init_r
+ * @param result
+ * @return
+ */
 cs_error_t icmap_init_r(icmap_map_t *result)
 {
 	int32_t err;
@@ -218,11 +250,18 @@ cs_error_t icmap_init_r(icmap_map_t *result)
 	return (qb_to_cs_error(err));
 }
 
+/**
+ * @brief icmap_init
+ * @return
+ */
 cs_error_t icmap_init(void)
 {
 	return (icmap_init_r(&icmap_global_map));
 }
 
+/**
+ * @brief icmap_set_ro_access_free
+ */
 static void icmap_set_ro_access_free(void)
 {
 	struct list_head *iter = icmap_ro_access_item_list_head.next;
@@ -237,6 +276,9 @@ static void icmap_set_ro_access_free(void)
 	}
 }
 
+/**
+ * @brief icmap_del_all_track
+ */
 static void icmap_del_all_track(void)
 {
 	struct list_head *iter = icmap_track_list_head.next;
@@ -249,6 +291,10 @@ static void icmap_del_all_track(void)
 	}
 }
 
+/**
+ * @brief icmap_fini_r
+ * @param map
+ */
 void icmap_fini_r(const icmap_map_t map)
 {
 
@@ -258,6 +304,9 @@ void icmap_fini_r(const icmap_map_t map)
 	return;
 }
 
+/**
+ * @brief icmap_fini
+ */
 void icmap_fini(void)
 {
 
@@ -275,12 +324,21 @@ void icmap_fini(void)
 	return ;
 }
 
+/**
+ * @brief icmap_get_global_map
+ * @return
+ */
 icmap_map_t icmap_get_global_map(void)
 {
 
 	return (icmap_global_map);
 }
 
+/**
+ * @brief icmap_is_valid_name_char
+ * @param c
+ * @return
+ */
 static int icmap_is_valid_name_char(char c)
 {
 	return ((c >= 'a' && c <= 'z') ||
@@ -289,6 +347,10 @@ static int icmap_is_valid_name_char(char c)
 		c == '.' || c == '_' || c == '-' || c == '/' || c == ':');
 }
 
+/**
+ * @brief icmap_convert_name_to_valid_name
+ * @param key_name
+ */
 void icmap_convert_name_to_valid_name(char *key_name)
 {
 	int i;
@@ -300,6 +362,11 @@ void icmap_convert_name_to_valid_name(char *key_name)
 	}
 }
 
+/**
+ * @brief icmap_check_key_name
+ * @param key_name
+ * @return
+ */
 static int icmap_check_key_name(const char *key_name)
 {
 	int i;
@@ -317,6 +384,11 @@ static int icmap_check_key_name(const char *key_name)
 	return (0);
 }
 
+/**
+ * @brief icmap_get_valuetype_len
+ * @param type
+ * @return
+ */
 static size_t icmap_get_valuetype_len(icmap_value_types_t type)
 {
 	size_t res = 0;
@@ -341,6 +413,13 @@ static size_t icmap_get_valuetype_len(icmap_value_types_t type)
 	return (res);
 }
 
+/**
+ * @brief icmap_check_value_len
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 static int icmap_check_value_len(const void *value, size_t value_len, icmap_value_types_t type)
 {
 
@@ -371,6 +450,14 @@ static int icmap_check_value_len(const void *value, size_t value_len, icmap_valu
 	return (0);
 }
 
+/**
+ * @brief icmap_item_eq
+ * @param item
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 static int icmap_item_eq(const struct icmap_item *item, const void *value, size_t value_len, icmap_value_types_t type)
 {
 	size_t ptr_len;
@@ -396,6 +483,14 @@ static int icmap_item_eq(const struct icmap_item *item, const void *value, size_
 	return (0);
 }
 
+/**
+ * @brief icmap_key_value_eq
+ * @param map1
+ * @param key_name1
+ * @param map2
+ * @param key_name2
+ * @return
+ */
 int icmap_key_value_eq(
 	const icmap_map_t map1,
 	const char *key_name1,
@@ -418,6 +513,15 @@ int icmap_key_value_eq(
 	return (icmap_item_eq(item1, item2->value, item2->value_len, item2->type));
 }
 
+/**
+ * @brief icmap_set_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t icmap_set_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -498,6 +602,14 @@ cs_error_t icmap_set_r(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_set
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t icmap_set(
 	const char *key_name,
 	const void *value,
@@ -508,66 +620,143 @@ cs_error_t icmap_set(
 	return (icmap_set_r(icmap_global_map, key_name, value, value_len, type));
 }
 
+/**
+ * @brief icmap_set_int8_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int8_r(const icmap_map_t map, const char *key_name, int8_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_INT8));
 }
 
+/**
+ * @brief icmap_set_uint8_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint8_r(const icmap_map_t map, const char *key_name, uint8_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_UINT8));
 }
 
+/**
+ * @brief icmap_set_int16_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int16_r(const icmap_map_t map, const char *key_name, int16_t value)
 {
 
 	return (icmap_set_r(map,key_name, &value, sizeof(value), ICMAP_VALUETYPE_INT16));
 }
 
+/**
+ * @brief icmap_set_uint16_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint16_r(const icmap_map_t map, const char *key_name, uint16_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_UINT16));
 }
 
+/**
+ * @brief icmap_set_int32_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int32_r(const icmap_map_t map, const char *key_name, int32_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_INT32));
 }
 
+/**
+ * @brief icmap_set_uint32_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint32_r(const icmap_map_t map, const char *key_name, uint32_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_UINT32));
 }
 
+/**
+ * @brief icmap_set_int64_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int64_r(const icmap_map_t map, const char *key_name, int64_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_INT64));
 }
 
+/**
+ * @brief icmap_set_uint64_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint64_r(const icmap_map_t map, const char *key_name, uint64_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_UINT64));
 }
 
+/**
+ * @brief icmap_set_float_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_float_r(const icmap_map_t map, const char *key_name, float value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_FLOAT));
 }
 
+/**
+ * @brief icmap_set_double_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_double_r(const icmap_map_t map, const char *key_name, double value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_DOUBLE));
 }
 
+/**
+ * @brief icmap_set_string_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_string_r(const icmap_map_t map, const char *key_name, const char *value)
 {
 
@@ -578,72 +767,144 @@ cs_error_t icmap_set_string_r(const icmap_map_t map, const char *key_name, const
 	return (icmap_set_r(map, key_name, value, strlen(value), ICMAP_VALUETYPE_STRING));
 }
 
+/**
+ * @brief icmap_set_int8
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int8(const char *key_name, int8_t value)
 {
 
 	return (icmap_set_int8_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_uint8
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint8(const char *key_name, uint8_t value)
 {
 
 	return (icmap_set_uint8_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_int16
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int16(const char *key_name, int16_t value)
 {
 
 	return (icmap_set_int16_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_uint16
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint16(const char *key_name, uint16_t value)
 {
 
 	return (icmap_set_uint16_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_int32
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int32(const char *key_name, int32_t value)
 {
 
 	return (icmap_set_int32_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_uint32
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint32(const char *key_name, uint32_t value)
 {
 
 	return (icmap_set_uint32_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_int64
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int64(const char *key_name, int64_t value)
 {
 
 	return (icmap_set_int64_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_uint64
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint64(const char *key_name, uint64_t value)
 {
 
 	return (icmap_set_uint64_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_float
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_float(const char *key_name, float value)
 {
 
 	return (icmap_set_float_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_double
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_double(const char *key_name, double value)
 {
 
 	return (icmap_set_double_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_string
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_string(const char *key_name, const char *value)
 {
 
 	return (icmap_set_string_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_delete_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_delete_r(const icmap_map_t map, const char *key_name)
 {
 	struct icmap_item *item;
@@ -664,12 +925,26 @@ cs_error_t icmap_delete_r(const icmap_map_t map, const char *key_name)
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_delete
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_delete(const char *key_name)
 {
 
 	return (icmap_delete_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_get_ref_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 static cs_error_t icmap_get_ref_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -703,6 +978,15 @@ static cs_error_t icmap_get_ref_r(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_get_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t icmap_get_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -736,6 +1020,14 @@ cs_error_t icmap_get_r(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_get
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t icmap_get(
 	const char *key_name,
 	void *value,
@@ -746,6 +1038,14 @@ cs_error_t icmap_get(
 	return (icmap_get_r(icmap_global_map, key_name, value, value_len, type));
 }
 
+/**
+ * @brief icmap_get_int_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param type
+ * @return
+ */
 static cs_error_t icmap_get_int_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -773,126 +1073,262 @@ static cs_error_t icmap_get_int_r(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_get_int8_r
+ * @param map
+ * @param key_name
+ * @param i8
+ * @return
+ */
 cs_error_t icmap_get_int8_r(const icmap_map_t map, const char *key_name, int8_t *i8)
 {
 
 	return (icmap_get_int_r(map, key_name, i8, ICMAP_VALUETYPE_INT8));
 }
 
+/**
+ * @brief icmap_get_uint8_r
+ * @param map
+ * @param key_name
+ * @param u8
+ * @return
+ */
 cs_error_t icmap_get_uint8_r(const icmap_map_t map, const char *key_name, uint8_t *u8)
 {
 
 	return (icmap_get_int_r(map, key_name, u8, ICMAP_VALUETYPE_UINT8));
 }
 
+/**
+ * @brief icmap_get_int16_r
+ * @param map
+ * @param key_name
+ * @param i16
+ * @return
+ */
 cs_error_t icmap_get_int16_r(const icmap_map_t map, const char *key_name, int16_t *i16)
 {
 
 	return (icmap_get_int_r(map, key_name, i16, ICMAP_VALUETYPE_INT16));
 }
 
+/**
+ * @brief icmap_get_uint16_r
+ * @param map
+ * @param key_name
+ * @param u16
+ * @return
+ */
 cs_error_t icmap_get_uint16_r(const icmap_map_t map, const char *key_name, uint16_t *u16)
 {
 
 	return (icmap_get_int_r(map, key_name, u16, ICMAP_VALUETYPE_UINT16));
 }
 
+/**
+ * @brief icmap_get_int32_r
+ * @param map
+ * @param key_name
+ * @param i32
+ * @return
+ */
 cs_error_t icmap_get_int32_r(const icmap_map_t map, const char *key_name, int32_t *i32)
 {
 
 	return (icmap_get_int_r(map, key_name, i32, ICMAP_VALUETYPE_INT32));
 }
 
+/**
+ * @brief icmap_get_uint32_r
+ * @param map
+ * @param key_name
+ * @param u32
+ * @return
+ */
 cs_error_t icmap_get_uint32_r(const icmap_map_t map, const char *key_name, uint32_t *u32)
 {
 
 	return (icmap_get_int_r(map, key_name, u32, ICMAP_VALUETYPE_UINT32));
 }
 
+/**
+ * @brief icmap_get_int64_r
+ * @param map
+ * @param key_name
+ * @param i64
+ * @return
+ */
 cs_error_t icmap_get_int64_r(const icmap_map_t map, const char *key_name, int64_t *i64)
 {
 
 	return(icmap_get_int_r(map, key_name, i64, ICMAP_VALUETYPE_INT64));
 }
 
+/**
+ * @brief icmap_get_uint64_r
+ * @param map
+ * @param key_name
+ * @param u64
+ * @return
+ */
 cs_error_t icmap_get_uint64_r(const icmap_map_t map, const char *key_name, uint64_t *u64)
 {
 
 	return (icmap_get_int_r(map, key_name, u64, ICMAP_VALUETYPE_UINT64));
 }
 
+/**
+ * @brief icmap_get_float_r
+ * @param map
+ * @param key_name
+ * @param flt
+ * @return
+ */
 cs_error_t icmap_get_float_r(const icmap_map_t map, const char *key_name, float *flt)
 {
 
 	return (icmap_get_int_r(map, key_name, flt, ICMAP_VALUETYPE_FLOAT));
 }
 
+/**
+ * @brief icmap_get_double_r
+ * @param map
+ * @param key_name
+ * @param dbl
+ * @return
+ */
 cs_error_t icmap_get_double_r(const icmap_map_t map, const char *key_name, double *dbl)
 {
 
 	return (icmap_get_int_r(map, key_name, dbl, ICMAP_VALUETYPE_DOUBLE));
 }
 
+/**
+ * @brief icmap_get_int8
+ * @param key_name
+ * @param i8
+ * @return
+ */
 cs_error_t icmap_get_int8(const char *key_name, int8_t *i8)
 {
 
 	return (icmap_get_int8_r(icmap_global_map, key_name, i8));
 }
 
+/**
+ * @brief icmap_get_uint8
+ * @param key_name
+ * @param u8
+ * @return
+ */
 cs_error_t icmap_get_uint8(const char *key_name, uint8_t *u8)
 {
 
 	return (icmap_get_uint8_r(icmap_global_map, key_name, u8));
 }
 
+/**
+ * @brief icmap_get_int16
+ * @param key_name
+ * @param i16
+ * @return
+ */
 cs_error_t icmap_get_int16(const char *key_name, int16_t *i16)
 {
 
 	return (icmap_get_int16_r(icmap_global_map, key_name, i16));
 }
 
+/**
+ * @brief icmap_get_uint16
+ * @param key_name
+ * @param u16
+ * @return
+ */
 cs_error_t icmap_get_uint16(const char *key_name, uint16_t *u16)
 {
 
 	return (icmap_get_uint16_r(icmap_global_map, key_name, u16));
 }
 
+/**
+ * @brief icmap_get_int32
+ * @param key_name
+ * @param i32
+ * @return
+ */
 cs_error_t icmap_get_int32(const char *key_name, int32_t *i32)
 {
 
 	return (icmap_get_int32_r(icmap_global_map, key_name, i32));
 }
 
+/**
+ * @brief icmap_get_uint32
+ * @param key_name
+ * @param u32
+ * @return
+ */
 cs_error_t icmap_get_uint32(const char *key_name, uint32_t *u32)
 {
 
 	return (icmap_get_uint32_r(icmap_global_map, key_name, u32));
 }
 
+/**
+ * @brief icmap_get_int64
+ * @param key_name
+ * @param i64
+ * @return
+ */
 cs_error_t icmap_get_int64(const char *key_name, int64_t *i64)
 {
 
 	return(icmap_get_int64_r(icmap_global_map, key_name, i64));
 }
 
+/**
+ * @brief icmap_get_uint64
+ * @param key_name
+ * @param u64
+ * @return
+ */
 cs_error_t icmap_get_uint64(const char *key_name, uint64_t *u64)
 {
 
 	return (icmap_get_uint64_r(icmap_global_map, key_name, u64));
 }
 
+/**
+ * @brief icmap_get_float
+ * @param key_name
+ * @param flt
+ * @return
+ */
 cs_error_t icmap_get_float(const char *key_name, float *flt)
 {
 
 	return (icmap_get_float_r(icmap_global_map, key_name, flt));
 }
 
+/**
+ * @brief icmap_get_double
+ * @param key_name
+ * @param dbl
+ * @return
+ */
 cs_error_t icmap_get_double(const char *key_name, double *dbl)
 {
 
 	return (icmap_get_double_r(icmap_global_map, key_name, dbl));
 }
 
+/**
+ * @brief icmap_get_string
+ * @param key_name
+ * @param str
+ * @return
+ */
 cs_error_t icmap_get_string(const char *key_name, char **str)
 {
 	cs_error_t res;
@@ -927,6 +1363,13 @@ return_error:
 	return (res);
 }
 
+/**
+ * @brief icmap_adjust_int_r
+ * @param map
+ * @param key_name
+ * @param step
+ * @return
+ */
 cs_error_t icmap_adjust_int_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -984,6 +1427,12 @@ cs_error_t icmap_adjust_int_r(
 	return (err);
 }
 
+/**
+ * @brief icmap_adjust_int
+ * @param key_name
+ * @param step
+ * @return
+ */
 cs_error_t icmap_adjust_int(
 	const char *key_name,
 	int32_t step)
@@ -992,6 +1441,13 @@ cs_error_t icmap_adjust_int(
 	return (icmap_adjust_int_r(icmap_global_map, key_name, step));
 }
 
+/**
+ * @brief icmap_fast_adjust_int_r
+ * @param map
+ * @param key_name
+ * @param step
+ * @return
+ */
 cs_error_t icmap_fast_adjust_int_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -1041,6 +1497,12 @@ cs_error_t icmap_fast_adjust_int_r(
 	return (err);
 }
 
+/**
+ * @brief icmap_fast_adjust_int
+ * @param key_name
+ * @param step
+ * @return
+ */
 cs_error_t icmap_fast_adjust_int(
 	const char *key_name,
 	int32_t step)
@@ -1049,57 +1511,119 @@ cs_error_t icmap_fast_adjust_int(
 	return (icmap_fast_adjust_int_r(icmap_global_map, key_name, step));
 }
 
+/**
+ * @brief icmap_inc_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_inc_r(const icmap_map_t map, const char *key_name)
 {
 	return (icmap_adjust_int_r(map, key_name, 1));
 }
 
+/**
+ * @brief icmap_inc
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_inc(const char *key_name)
 {
 	return (icmap_inc_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_dec_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_dec_r(const icmap_map_t map, const char *key_name)
 {
 	return (icmap_adjust_int_r(map, key_name, -1));
 }
 
+/**
+ * @brief icmap_dec
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_dec(const char *key_name)
 {
 	return (icmap_dec_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_fast_inc_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_fast_inc_r(const icmap_map_t map, const char *key_name)
 {
 	return (icmap_fast_adjust_int_r(map, key_name, 1));
 }
 
+/**
+ * @brief icmap_fast_inc
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_fast_inc(const char *key_name)
 {
 	return (icmap_fast_inc_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_fast_dec_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_fast_dec_r(const icmap_map_t map, const char *key_name)
 {
 	return (icmap_fast_adjust_int_r(map, key_name, -1));
 }
 
+/**
+ * @brief icmap_fast_dec
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_fast_dec(const char *key_name)
 {
 	return (icmap_fast_dec_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_iter_init_r
+ * @param map
+ * @param prefix
+ * @return
+ */
 icmap_iter_t icmap_iter_init_r(const icmap_map_t map, const char *prefix)
 {
 	return (qb_map_pref_iter_create(map->qb_map, prefix));
 }
 
+/**
+ * @brief icmap_iter_init
+ * @param prefix
+ * @return
+ */
 icmap_iter_t icmap_iter_init(const char *prefix)
 {
 	return (icmap_iter_init_r(icmap_global_map, prefix));
 }
 
 
+/**
+ * @brief icmap_iter_next
+ * @param iter
+ * @param value_len
+ * @param type
+ * @return
+ */
 const char *icmap_iter_next(icmap_iter_t iter, size_t *value_len, icmap_value_types_t *type)
 {
 	struct icmap_item *item;
@@ -1121,11 +1645,23 @@ const char *icmap_iter_next(icmap_iter_t iter, size_t *value_len, icmap_value_ty
 	return (res);
 }
 
+/**
+ * @brief icmap_iter_finalize
+ * @param iter
+ */
 void icmap_iter_finalize(icmap_iter_t iter)
 {
 	qb_map_iter_free(iter);
 }
 
+/**
+ * @brief icmap_notify_fn
+ * @param event
+ * @param key
+ * @param old_value
+ * @param value
+ * @param user_data
+ */
 static void icmap_notify_fn(uint32_t event, char *key, void *old_value, void *value, void *user_data)
 {
 	icmap_track_t icmap_track = (icmap_track_t)user_data;
@@ -1164,6 +1700,15 @@ static void icmap_notify_fn(uint32_t event, char *key, void *old_value, void *va
 			icmap_track->user_data);
 }
 
+/**
+ * @brief icmap_track_add
+ * @param key_name
+ * @param track_type
+ * @param notify_fn
+ * @param user_data
+ * @param icmap_track
+ * @return
+ */
 cs_error_t icmap_track_add(
 	const char *key_name,
 	int32_t track_type,
@@ -1209,6 +1754,11 @@ cs_error_t icmap_track_add(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_track_delete
+ * @param icmap_track
+ * @return
+ */
 cs_error_t icmap_track_delete(icmap_track_t icmap_track)
 {
 	int32_t err;
@@ -1225,11 +1775,23 @@ cs_error_t icmap_track_delete(icmap_track_t icmap_track)
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_track_get_user_data
+ * @param icmap_track
+ * @return
+ */
 void *icmap_track_get_user_data(icmap_track_t icmap_track)
 {
 	return (icmap_track->user_data);
 }
 
+/**
+ * @brief icmap_set_ro_access
+ * @param key_name
+ * @param prefix
+ * @param ro_access
+ * @return
+ */
 cs_error_t icmap_set_ro_access(const char *key_name, int prefix, int ro_access)
 {
 	struct list_head *iter;
@@ -1277,6 +1839,11 @@ cs_error_t icmap_set_ro_access(const char *key_name, int prefix, int ro_access)
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_is_key_ro
+ * @param key_name
+ * @return
+ */
 int icmap_is_key_ro(const char *key_name)
 {
 	struct list_head *iter;
@@ -1303,6 +1870,12 @@ int icmap_is_key_ro(const char *key_name)
 
 }
 
+/**
+ * @brief icmap_copy_map
+ * @param dst_map
+ * @param src_map
+ * @return
+ */
 cs_error_t icmap_copy_map(icmap_map_t dst_map, const icmap_map_t src_map)
 {
 	icmap_iter_t iter;

--- a/exec/ipc_glue.c
+++ b/exec/ipc_glue.c
@@ -117,6 +117,11 @@ static struct qb_ipcs_service_handlers corosync_service_funcs = {
 	.connection_destroyed	= cs_ipcs_connection_destroyed,
 };
 
+/**
+ * @brief cs_ipcs_serv_short_name
+ * @param service_id
+ * @return
+ */
 static const char* cs_ipcs_serv_short_name(int32_t service_id)
 {
 	const char *name;
@@ -152,11 +157,20 @@ static const char* cs_ipcs_serv_short_name(int32_t service_id)
 	return name;
 }
 
+/**
+ * @brief cs_ipc_allow_connections
+ * @param allow
+ */
 void cs_ipc_allow_connections(int32_t allow)
 {
 	ipc_allow_connections = allow;
 }
 
+/**
+ * @brief cs_ipcs_service_destroy
+ * @param service_id
+ * @return
+ */
 int32_t cs_ipcs_service_destroy(int32_t service_id)
 {
 	if (ipcs_mapper[service_id].inst) {
@@ -166,6 +180,13 @@ int32_t cs_ipcs_service_destroy(int32_t service_id)
 	return 0;
 }
 
+/**
+ * @brief cs_ipcs_connection_accept
+ * @param c
+ * @param euid
+ * @param egid
+ * @return
+ */
 static int32_t cs_ipcs_connection_accept (qb_ipcs_connection_t *c, uid_t euid, gid_t egid)
 {
 	int32_t service = qb_ipcs_service_id_get(c);
@@ -203,6 +224,13 @@ static int32_t cs_ipcs_connection_accept (qb_ipcs_connection_t *c, uid_t euid, g
 	return -EACCES;
 }
 
+/**
+ * @brief pid_to_name
+ * @param pid
+ * @param out_name
+ * @param name_len
+ * @return
+ */
 static char * pid_to_name (pid_t pid, char *out_name, size_t name_len)
 {
 	char *name;
@@ -247,6 +275,9 @@ static char * pid_to_name (pid_t pid, char *out_name, size_t name_len)
 	return out_name;
 }
 
+/**
+ * @brief The cs_ipcs_conn_context struct
+ */
 struct cs_ipcs_conn_context {
 	char *icmap_path;
 	struct list_head outq_head;
@@ -258,6 +289,10 @@ struct cs_ipcs_conn_context {
 	char data[1];
 };
 
+/**
+ * @brief cs_ipcs_connection_created
+ * @param c
+ */
 static void cs_ipcs_connection_created(qb_ipcs_connection_t *c)
 {
 	int32_t service = 0;
@@ -364,16 +399,29 @@ static void cs_ipcs_connection_created(qb_ipcs_connection_t *c)
 	icmap_set_uint64(key_name, 0);
 }
 
+/**
+ * @brief cs_ipc_refcnt_inc
+ * @param conn
+ */
 void cs_ipc_refcnt_inc(void *conn)
 {
 	qb_ipcs_connection_ref(conn);
 }
 
+/**
+ * @brief cs_ipc_refcnt_dec
+ * @param conn
+ */
 void cs_ipc_refcnt_dec(void *conn)
 {
 	qb_ipcs_connection_unref(conn);
 }
 
+/**
+ * @brief cs_ipcs_private_data_get
+ * @param conn
+ * @return
+ */
 void *cs_ipcs_private_data_get(void *conn)
 {
 	struct cs_ipcs_conn_context *cnx;
@@ -381,6 +429,10 @@ void *cs_ipcs_private_data_get(void *conn)
 	return &cnx->data[0];
 }
 
+/**
+ * @brief cs_ipcs_connection_destroyed
+ * @param c
+ */
 static void cs_ipcs_connection_destroyed (qb_ipcs_connection_t *c)
 {
 	struct cs_ipcs_conn_context *context;
@@ -405,6 +457,11 @@ static void cs_ipcs_connection_destroyed (qb_ipcs_connection_t *c)
 	}
 }
 
+/**
+ * @brief cs_ipcs_connection_closed
+ * @param c
+ * @return
+ */
 static int32_t cs_ipcs_connection_closed (qb_ipcs_connection_t *c)
 {
 	int32_t res = 0;
@@ -438,6 +495,13 @@ static int32_t cs_ipcs_connection_closed (qb_ipcs_connection_t *c)
 	return 0;
 }
 
+/**
+ * @brief cs_ipcs_response_iov_send
+ * @param conn
+ * @param iov
+ * @param iov_len
+ * @return
+ */
 int cs_ipcs_response_iov_send (void *conn,
 	const struct iovec *iov,
 	unsigned int iov_len)
@@ -449,6 +513,13 @@ int cs_ipcs_response_iov_send (void *conn,
 	return rc;
 }
 
+/**
+ * @brief cs_ipcs_response_send
+ * @param conn
+ * @param msg
+ * @param mlen
+ * @return
+ */
 int cs_ipcs_response_send(void *conn, const void *msg, size_t mlen)
 {
 	int32_t rc = qb_ipcs_response_send(conn, msg, mlen);
@@ -458,6 +529,10 @@ int cs_ipcs_response_send(void *conn, const void *msg, size_t mlen)
 	return rc;
 }
 
+/**
+ * @brief outq_flush
+ * @param data
+ */
 static void outq_flush (void *data)
 {
 	qb_ipcs_connection_t *conn = data;
@@ -499,6 +574,12 @@ static void outq_flush (void *data)
 	}
 }
 
+/**
+ * @brief msg_send_or_queue
+ * @param conn
+ * @param iov
+ * @param iov_len
+ */
 static void msg_send_or_queue(qb_ipcs_connection_t *conn, const struct iovec *iov, uint32_t iov_len)
 {
 	int32_t rc = 0;
@@ -552,6 +633,13 @@ static void msg_send_or_queue(qb_ipcs_connection_t *conn, const struct iovec *io
 	context->queued++;
 }
 
+/**
+ * @brief cs_ipcs_dispatch_send
+ * @param conn
+ * @param msg
+ * @param mlen
+ * @return
+ */
 int cs_ipcs_dispatch_send(void *conn, const void *msg, size_t mlen)
 {
 	struct iovec iov;
@@ -561,6 +649,13 @@ int cs_ipcs_dispatch_send(void *conn, const void *msg, size_t mlen)
 	return 0;
 }
 
+/**
+ * @brief cs_ipcs_dispatch_iov_send
+ * @param conn
+ * @param iov
+ * @param iov_len
+ * @return
+ */
 int cs_ipcs_dispatch_iov_send (void *conn,
 	const struct iovec *iov,
 	unsigned int iov_len)
@@ -569,6 +664,13 @@ int cs_ipcs_dispatch_iov_send (void *conn,
 	return 0;
 }
 
+/**
+ * @brief cs_ipcs_msg_process
+ * @param c
+ * @param data
+ * @param size
+ * @return
+ */
 static int32_t cs_ipcs_msg_process(qb_ipcs_connection_t *c,
 		void *data, size_t size)
 {
@@ -643,29 +745,63 @@ static int32_t cs_ipcs_msg_process(qb_ipcs_connection_t *c,
 	return res;
 }
 
-
+/**
+ * @brief cs_ipcs_job_add
+ * @param p
+ * @param data
+ * @param fn
+ * @return
+ */
 static int32_t cs_ipcs_job_add(enum qb_loop_priority p,	void *data, qb_loop_job_dispatch_fn fn)
 {
 	return qb_loop_job_add(cs_poll_handle_get(), p, data, fn);
 }
 
+/**
+ * @brief cs_ipcs_dispatch_add
+ * @param p
+ * @param fd
+ * @param events
+ * @param data
+ * @param fn
+ * @return
+ */
 static int32_t cs_ipcs_dispatch_add(enum qb_loop_priority p, int32_t fd, int32_t events,
 	void *data, qb_ipcs_dispatch_fn_t fn)
 {
 	return qb_loop_poll_add(cs_poll_handle_get(), p, fd, events, data, fn);
 }
 
+/**
+ * @brief cs_ipcs_dispatch_mod
+ * @param p
+ * @param fd
+ * @param events
+ * @param data
+ * @param fn
+ * @return
+ */
 static int32_t cs_ipcs_dispatch_mod(enum qb_loop_priority p, int32_t fd, int32_t events,
 	void *data, qb_ipcs_dispatch_fn_t fn)
 {
 	return qb_loop_poll_mod(cs_poll_handle_get(), p, fd, events, data, fn);
 }
 
+/**
+ * @brief cs_ipcs_dispatch_del
+ * @param fd
+ * @return
+ */
 static int32_t cs_ipcs_dispatch_del(int32_t fd)
 {
 	return qb_loop_poll_del(cs_poll_handle_get(), fd);
 }
 
+/**
+ * @brief cs_ipcs_low_fds_event
+ * @param not_enough
+ * @param fds_available
+ */
 static void cs_ipcs_low_fds_event(int32_t not_enough, int32_t fds_available)
 {
 	ipc_not_enough_fds_left = not_enough;
@@ -679,12 +815,23 @@ static void cs_ipcs_low_fds_event(int32_t not_enough, int32_t fds_available)
 	}
 }
 
+/**
+ * @brief cs_ipcs_q_level_get
+ * @return
+ */
 int32_t cs_ipcs_q_level_get(void)
 {
 	return ipc_fc_totem_queue_level;
 }
 
+/**
+ * @brief ipcs_check_for_flow_control_timer
+ */
 static qb_loop_timer_handle ipcs_check_for_flow_control_timer;
+
+/**
+ * @brief cs_ipcs_check_for_flow_control
+ */
 static void cs_ipcs_check_for_flow_control(void)
 {
 	int32_t i;
@@ -730,24 +877,40 @@ static void cs_ipcs_check_for_flow_control(void)
 	}
 }
 
+/**
+ * @brief cs_ipcs_fc_quorum_changed
+ * @param quorate
+ * @param context
+ */
 static void cs_ipcs_fc_quorum_changed(int quorate, void *context)
 {
 	ipc_fc_is_quorate = quorate;
 	cs_ipcs_check_for_flow_control();
 }
 
+/**
+ * @brief cs_ipcs_totem_queue_level_changed
+ * @param level
+ */
 static void cs_ipcs_totem_queue_level_changed(enum totem_q_level level)
 {
 	ipc_fc_totem_queue_level = level;
 	cs_ipcs_check_for_flow_control();
 }
 
+/**
+ * @brief cs_ipcs_sync_state_changed
+ * @param sync_in_process
+ */
 void cs_ipcs_sync_state_changed(int32_t sync_in_process)
 {
 	ipc_fc_sync_in_process = sync_in_process;
 	cs_ipcs_check_for_flow_control();
 }
 
+/**
+ * @brief cs_ipcs_stats_update
+ */
 void cs_ipcs_stats_update(void)
 {
 	int32_t i;
@@ -808,6 +971,10 @@ void cs_ipcs_stats_update(void)
 	}
 }
 
+/**
+ * @brief cs_get_ipc_type
+ * @return
+ */
 static enum qb_ipc_type cs_get_ipc_type (void)
 {
 	char *str;
@@ -845,6 +1012,11 @@ static enum qb_ipc_type cs_get_ipc_type (void)
 	return ret;
 }
 
+/**
+ * @brief cs_ipcs_service_init
+ * @param service
+ * @return
+ */
 const char *cs_ipcs_service_init(struct corosync_service_engine *service)
 {
 	const char *serv_short_name;
@@ -885,6 +1057,9 @@ const char *cs_ipcs_service_init(struct corosync_service_engine *service)
 	return NULL;
 }
 
+/**
+ * @brief cs_ipcs_init
+ */
 void cs_ipcs_init(void)
 {
 	api = apidef_get ();

--- a/exec/logconfig.c
+++ b/exec/logconfig.c
@@ -76,6 +76,14 @@ static char error_string_response[512];
  *
  * Returns: 0 on success, -1 on failure
  **/
+/**
+ * @brief insert_into_buffer
+ * @param target_buffer
+ * @param bufferlen
+ * @param entry
+ * @param after
+ * @return
+ */
 static int insert_into_buffer(
 	char *target_buffer,
 	size_t bufferlen,
@@ -129,6 +137,11 @@ static int insert_into_buffer(
 /*
  * format set is the only global specific option that
  * doesn't apply at system/subsystem level.
+ */
+/**
+ * @brief corosync_main_config_format_set
+ * @param error_string
+ * @return
  */
 static int corosync_main_config_format_set (
 	const char **error_string)
@@ -228,6 +241,17 @@ parse_error:
 	return (-1);
 }
 
+/**
+ * @brief corosync_main_config_log_destination_set
+ * @param path
+ * @param key
+ * @param subsys
+ * @param error_string
+ * @param mode_mask
+ * @param deprecated
+ * @param replacement
+ * @return
+ */
 static int corosync_main_config_log_destination_set (
 	const char *path,
 	const char *key,
@@ -281,6 +305,13 @@ parse_error:
 	return (-1);
 }
 
+/**
+ * @brief corosync_main_config_set
+ * @param path
+ * @param subsys
+ * @param error_string
+ * @return
+ */
 static int corosync_main_config_set (
 	const char *path,
 	const char *subsys,
@@ -457,6 +488,11 @@ parse_error:
 	return (-1);
 }
 
+/**
+ * @brief corosync_main_config_read_logging
+ * @param error_string
+ * @return
+ */
 static int corosync_main_config_read_logging (
 	const char **error_string)
 {
@@ -524,6 +560,14 @@ parse_error:
 }
 
 #ifdef LOGCONFIG_USE_ICMAP 
+/**
+ * @brief main_logging_notify
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void main_logging_notify(
 		int32_t event,
 		const char *key_name,
@@ -531,6 +575,16 @@ static void main_logging_notify(
 		struct icmap_notify_value old_val,
 		void *user_data)
 #else
+/**
+ * @brief main_logging_notify
+ * @param cmap_handle_unused
+ * @param cmap_track_handle_unused
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void main_logging_notify(
 		cmap_handle_t cmap_handle_unused,
 		cmap_handle_t cmap_track_handle_unused,
@@ -569,6 +623,10 @@ static void main_logging_notify(
 }
 
 #ifdef LOGCONFIG_USE_ICMAP
+
+/**
+ * @brief add_logsys_config_notification
+ */
 static void add_logsys_config_notification(void)
 {
 	icmap_track_t icmap_track = NULL;
@@ -586,6 +644,10 @@ static void add_logsys_config_notification(void)
 			&icmap_track);
 }
 #else
+
+/**
+ * @brief add_logsys_config_notification
+ */
 static void add_logsys_config_notification(void)
 {
 	cmap_track_handle_t cmap_track;

--- a/exec/logsys.c
+++ b/exec/logsys.c
@@ -84,6 +84,10 @@ static struct syslog_names prioritynames[] =
 /*
  * need unlogical order to preserve 64bit alignment
  */
+
+/**
+ * @brief The logsys_logger struct
+ */
 struct logsys_logger {
 	char subsys[LOGSYS_MAX_SUBSYS_NAMELEN];	/* subsystem name */
 	char *logfile;				/* log to file */
@@ -119,6 +123,11 @@ static char *format_buffer=NULL;
 
 static int logsys_thread_started = 0;
 
+/**
+ * @brief _logsys_config_subsys_get_unlocked
+ * @param subsys
+ * @return
+ */
 static int _logsys_config_subsys_get_unlocked (const char *subsys)
 {
 	unsigned int i;
@@ -140,6 +149,13 @@ static int _logsys_config_subsys_get_unlocked (const char *subsys)
 /*
  * we need a version that can work when somebody else is already
  * holding a config mutex lock or we will never get out of here
+ */
+/**
+ * @brief logsys_config_file_set_unlocked
+ * @param subsysid
+ * @param error_string
+ * @param file
+ * @return
  */
 static int logsys_config_file_set_unlocked (
 		int subsysid,
@@ -252,6 +268,11 @@ static int logsys_config_file_set_unlocked (
 	return (0);
 }
 
+/**
+ * @brief logsys_subsys_init
+ * @param subsys
+ * @param subsysid
+ */
 static void logsys_subsys_init (
 		const char *subsys,
 		int subsysid)
@@ -273,6 +294,11 @@ static void logsys_subsys_init (
 	logsys_loggers[subsysid].file_idx = 0;
 }
 
+/**
+ * @brief _logsys_tags_stringify
+ * @param tags
+ * @return
+ */
 static const char *_logsys_tags_stringify(uint32_t tags)
 {
 	if (tags == QB_LOG_TAG_LIBQB_MSG) {
@@ -282,6 +308,9 @@ static const char *_logsys_tags_stringify(uint32_t tags)
 	}
 }
 
+/**
+ * @brief logsys_system_fini
+ */
 void logsys_system_fini (void)
 {
 	int i;
@@ -300,6 +329,14 @@ void logsys_system_fini (void)
  * Internal API - exported
  */
 
+/**
+ * @brief _logsys_system_setup
+ * @param mainsystem
+ * @param mode
+ * @param syslog_facility
+ * @param syslog_priority
+ * @return
+ */
 int _logsys_system_setup(
 	const char *mainsystem,
 	unsigned int mode,
@@ -411,6 +448,11 @@ int _logsys_system_setup(
 }
 
 
+/**
+ * @brief _logsys_subsys_filename_add
+ * @param s
+ * @param filename
+ */
 static void _logsys_subsys_filename_add (int32_t s, const char *filename)
 {
 	int i;
@@ -433,6 +475,12 @@ static void _logsys_subsys_filename_add (int32_t s, const char *filename)
 	}
 }
 
+/**
+ * @brief _logsys_subsys_create
+ * @param subsys
+ * @param filename
+ * @return
+ */
 int _logsys_subsys_create (const char *subsys, const char *filename)
 {
 	int i;
@@ -467,6 +515,11 @@ int _logsys_subsys_create (const char *subsys, const char *filename)
 	return i;
 }
 
+/**
+ * @brief _logsys_config_subsys_get
+ * @param subsys
+ * @return
+ */
 int _logsys_config_subsys_get (const char *subsys)
 {
 	unsigned int i;
@@ -480,6 +533,12 @@ int _logsys_config_subsys_get (const char *subsys)
 	return i;
 }
 
+/**
+ * @brief _logsys_config_mode_set_unlocked
+ * @param subsysid
+ * @param new_mode
+ * @return
+ */
 static int32_t _logsys_config_mode_set_unlocked(int32_t subsysid, uint32_t new_mode)
 {
 	if ( logsys_loggers[subsysid].mode == new_mode) {
@@ -503,6 +562,12 @@ static int32_t _logsys_config_mode_set_unlocked(int32_t subsysid, uint32_t new_m
 	return 0;
 }
 
+/**
+ * @brief logsys_config_mode_set
+ * @param subsys
+ * @param mode
+ * @return
+ */
 int logsys_config_mode_set (const char *subsys, unsigned int mode)
 {
 	int i;
@@ -525,6 +590,11 @@ int logsys_config_mode_set (const char *subsys, unsigned int mode)
 	return i;
 }
 
+/**
+ * @brief logsys_config_mode_get
+ * @param subsys
+ * @return
+ */
 unsigned int logsys_config_mode_get (const char *subsys)
 {
 	int i;
@@ -537,6 +607,13 @@ unsigned int logsys_config_mode_get (const char *subsys)
 	return logsys_loggers[i].mode;
 }
 
+/**
+ * @brief logsys_config_file_set
+ * @param subsys
+ * @param error_string
+ * @param file
+ * @return
+ */
 int logsys_config_file_set (
 		const char *subsys,
 		const char **error_string,
@@ -567,6 +644,11 @@ int logsys_config_file_set (
 	return res;
 }
 
+/**
+ * @brief logsys_file_format_get
+ * @param file_format
+ * @param buf_len
+ */
 static void
 logsys_file_format_get(char* file_format, int buf_len)
 {
@@ -583,6 +665,11 @@ logsys_file_format_get(char* file_format, int buf_len)
 	}
 }
 
+/**
+ * @brief logsys_format_set
+ * @param format
+ * @return
+ */
 int logsys_format_set (const char *format)
 {
 	int i;
@@ -641,11 +728,21 @@ int logsys_format_set (const char *format)
 	return 0;
 }
 
+/**
+ * @brief logsys_format_get
+ * @return
+ */
 char *logsys_format_get (void)
 {
 	return format_buffer;
 }
 
+/**
+ * @brief logsys_config_syslog_facility_set
+ * @param subsys
+ * @param facility
+ * @return
+ */
 int logsys_config_syslog_facility_set (
 	const char *subsys,
 	unsigned int facility)
@@ -653,6 +750,12 @@ int logsys_config_syslog_facility_set (
 	return qb_log_ctl(QB_LOG_SYSLOG, QB_LOG_CONF_FACILITY, facility);
 }
 
+/**
+ * @brief logsys_config_syslog_priority_set
+ * @param subsys
+ * @param priority
+ * @return
+ */
 int logsys_config_syslog_priority_set (
 	const char *subsys,
 	unsigned int priority)
@@ -680,6 +783,12 @@ int logsys_config_syslog_priority_set (
 	return i;
 }
 
+/**
+ * @brief logsys_config_logfile_priority_set
+ * @param subsys
+ * @param priority
+ * @return
+ */
 int logsys_config_logfile_priority_set (
 	const char *subsys,
 	unsigned int priority)
@@ -707,6 +816,11 @@ int logsys_config_logfile_priority_set (
 }
 
 
+/**
+ * @brief _logsys_config_apply_per_file
+ * @param s
+ * @param filename
+ */
 static void _logsys_config_apply_per_file(int32_t s, const char *filename)
 {
 	uint32_t syslog_priority = logsys_loggers[s].syslog_priority;
@@ -753,6 +867,10 @@ static void _logsys_config_apply_per_file(int32_t s, const char *filename)
 	}
 }
 
+/**
+ * @brief _logsys_config_apply_per_subsys
+ * @param s
+ */
 static void _logsys_config_apply_per_subsys(int32_t s)
 {
 	int32_t f;
@@ -767,6 +885,9 @@ static void _logsys_config_apply_per_subsys(int32_t s)
 	logsys_loggers[s].dirty = QB_FALSE;
 }
 
+/**
+ * @brief logsys_config_apply
+ */
 void logsys_config_apply(void)
 {
 	int32_t s;
@@ -779,6 +900,12 @@ void logsys_config_apply(void)
 	}
 }
 
+/**
+ * @brief logsys_config_debug_set
+ * @param subsys
+ * @param debug
+ * @return
+ */
 int logsys_config_debug_set (
 	const char *subsys,
 	unsigned int debug)
@@ -805,6 +932,11 @@ int logsys_config_debug_set (
 	return i;
 }
 
+/**
+ * @brief logsys_priority_id_get
+ * @param name
+ * @return
+ */
 int logsys_priority_id_get (const char *name)
 {
 	unsigned int i;
@@ -817,6 +949,10 @@ int logsys_priority_id_get (const char *name)
 	return (-1);
 }
 
+/**
+ * @brief logsys_thread_start
+ * @return
+ */
 int logsys_thread_start (void)
 {
 	int i;

--- a/exec/main.c
+++ b/exec/main.c
@@ -156,11 +156,23 @@ static const char *corosync_lock_file = LOCALSTATEDIR"/run/corosync.pid";
 
 static int ip_version = AF_INET;
 
+/**
+ * @brief cs_poll_handle_get
+ * @return
+ */
 qb_loop_t *cs_poll_handle_get (void)
 {
 	return (corosync_poll_handle);
 }
 
+/**
+ * @brief cs_poll_dispatch_add
+ * @param handle
+ * @param fd
+ * @param events
+ * @param data
+ * @return
+ */
 int cs_poll_dispatch_add (qb_loop_t * handle,
 		int fd,
 		int events,
@@ -174,11 +186,20 @@ int cs_poll_dispatch_add (qb_loop_t * handle,
 				dispatch_fn);
 }
 
+/**
+ * @brief cs_poll_dispatch_delete
+ * @param handle
+ * @param fd
+ * @return
+ */
 int cs_poll_dispatch_delete(qb_loop_t * handle, int fd)
 {
 	return qb_loop_poll_del(handle, fd);
 }
 
+/**
+ * @brief corosync_state_dump
+ */
 void corosync_state_dump (void)
 {
 	int i;
@@ -190,6 +211,9 @@ void corosync_state_dump (void)
 	}
 }
 
+/**
+ * @brief corosync_blackbox_write_to_file
+ */
 static void corosync_blackbox_write_to_file (void)
 {
 	char fname[PATH_MAX];
@@ -219,6 +243,9 @@ static void corosync_blackbox_write_to_file (void)
 	}
 }
 
+/**
+ * @brief unlink_all_completed
+ */
 static void unlink_all_completed (void)
 {
 	api->timer_delete (corosync_stats_timer_handle);
@@ -226,17 +253,32 @@ static void unlink_all_completed (void)
 	icmap_fini();
 }
 
+/**
+ * @brief corosync_shutdown_request
+ */
 void corosync_shutdown_request (void)
 {
 	corosync_service_unlink_all (api, unlink_all_completed);
 }
 
+/**
+ * @brief sig_diag_handler
+ * @param num
+ * @param data
+ * @return
+ */
 static int32_t sig_diag_handler (int num, void *data)
 {
 	corosync_state_dump ();
 	return 0;
 }
 
+/**
+ * @brief sig_exit_handler
+ * @param num
+ * @param data
+ * @return
+ */
 static int32_t sig_exit_handler (int num, void *data)
 {
 	log_printf(LOGSYS_LEVEL_NOTICE, "Node was shut down by a signal");
@@ -244,6 +286,10 @@ static int32_t sig_exit_handler (int num, void *data)
 	return 0;
 }
 
+/**
+ * @brief sigsegv_handler
+ * @param num
+ */
 static void sigsegv_handler (int num)
 {
 	(void)signal (SIGSEGV, SIG_DFL);
@@ -255,6 +301,12 @@ static void sigsegv_handler (int num)
 /*
  * QB wrapper for real signal handler
  */
+/**
+ * @brief sig_segv_handler
+ * @param num
+ * @param data
+ * @return
+ */
 static int32_t sig_segv_handler (int num, void *data)
 {
 
@@ -263,6 +315,10 @@ static int32_t sig_segv_handler (int num, void *data)
 	return 0;
 }
 
+/**
+ * @brief sigabrt_handler
+ * @param num
+ */
 static void sigabrt_handler (int num)
 {
 	(void)signal (SIGABRT, SIG_DFL);
@@ -273,6 +329,12 @@ static void sigabrt_handler (int num)
 
 /*
  * QB wrapper for real signal handler
+ */
+/**
+ * @brief sig_abrt_handler
+ * @param num
+ * @param data
+ * @return
  */
 static int32_t sig_abrt_handler (int num, void *data)
 {
@@ -291,14 +353,23 @@ static struct totempg_group corosync_group = {
 	.group_len	= 1
 };
 
+/**
+ * @brief serialize_lock
+ */
 static void serialize_lock (void)
 {
 }
 
+/**
+ * @brief serialize_unlock
+ */
 static void serialize_unlock (void)
 {
 }
 
+/**
+ * @brief corosync_sync_completed
+ */
 static void corosync_sync_completed (void)
 {
 	log_printf (LOGSYS_LEVEL_NOTICE,
@@ -313,6 +384,12 @@ static void corosync_sync_completed (void)
 	totempg_trans_ack();
 }
 
+/**
+ * @brief corosync_sync_callbacks_retrieve
+ * @param service_id
+ * @param callbacks
+ * @return
+ */
 static int corosync_sync_callbacks_retrieve (
 	int service_id,
 	struct sync_callbacks *callbacks)
@@ -336,6 +413,10 @@ static int corosync_sync_callbacks_retrieve (
 
 static struct memb_ring_id corosync_ring_id;
 
+/**
+ * @brief member_object_joined
+ * @param nodeid
+ */
 static void member_object_joined (unsigned int nodeid)
 {
 	char member_ip[ICMAP_KEYNAME_MAXLEN];
@@ -362,6 +443,10 @@ static void member_object_joined (unsigned int nodeid)
 		"Member joined: %s", api->totem_ifaces_print (nodeid));
 }
 
+/**
+ * @brief member_object_left
+ * @param nodeid
+ */
 static void member_object_left (unsigned int nodeid)
 {
 	char member_status[ICMAP_KEYNAME_MAXLEN];
@@ -374,6 +459,17 @@ static void member_object_left (unsigned int nodeid)
 		"Member left: %s", api->totem_ifaces_print (nodeid));
 }
 
+/**
+ * @brief confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -420,11 +516,17 @@ static void confchg_fn (
 	}
 }
 
+/**
+ * @brief priv_drop
+ */
 static void priv_drop (void)
 {
 	return; /* TODO: we are still not dropping privs */
 }
 
+/**
+ * @brief corosync_tty_detach
+ */
 static void corosync_tty_detach (void)
 {
 	int devnull;
@@ -466,6 +568,9 @@ static void corosync_tty_detach (void)
 	close(devnull);
 }
 
+/**
+ * @brief corosync_mlockall
+ */
 static void corosync_mlockall (void)
 {
 	int res;
@@ -488,6 +593,10 @@ static void corosync_mlockall (void)
 }
 
 
+/**
+ * @brief corosync_totem_stats_updater
+ * @param data
+ */
 static void corosync_totem_stats_updater (void *data)
 {
 	totempg_stats_t * stats;
@@ -583,6 +692,9 @@ static void corosync_totem_stats_updater (void *data)
 		&corosync_stats_timer_handle);
 }
 
+/**
+ * @brief corosync_totem_stats_init
+ */
 static void corosync_totem_stats_init (void)
 {
 	icmap_set_uint32("runtime.totem.pg.mrp.srp.mtt_rx_token", 0);
@@ -595,6 +707,13 @@ static void corosync_totem_stats_init (void)
 		&corosync_stats_timer_handle);
 }
 
+/**
+ * @brief deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static void deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
@@ -640,6 +759,13 @@ static void deliver_fn (
 		(msg, nodeid);
 }
 
+/**
+ * @brief main_mcast
+ * @param iovec
+ * @param iov_len
+ * @param guarantee
+ * @return
+ */
 int main_mcast (
         const struct iovec *iovec,
         unsigned int iov_len,
@@ -659,6 +785,11 @@ int main_mcast (
 	return (totempg_groups_mcast_joined (corosync_group_handle, iovec, iov_len, guarantee));
 }
 
+/**
+ * @brief corosync_ring_id_create_or_load
+ * @param memb_ring_id
+ * @param addr
+ */
 static void corosync_ring_id_create_or_load (
 	struct memb_ring_id *memb_ring_id,
 	const struct totem_ip_address *addr)
@@ -705,6 +836,11 @@ static void corosync_ring_id_create_or_load (
 	assert (!totemip_zero_check(&memb_ring_id->rep));
 }
 
+/**
+ * @brief corosync_ring_id_store
+ * @param memb_ring_id
+ * @param addr
+ */
 static void corosync_ring_id_store (
 	const struct memb_ring_id *memb_ring_id,
 	const struct totem_ip_address *addr)
@@ -740,6 +876,9 @@ static void corosync_ring_id_store (
 	}
 }
 
+/**
+ * @brief recheck_the_q_level_timer
+ */
 static qb_loop_timer_handle recheck_the_q_level_timer;
 void corosync_recheck_the_q_level(void *data)
 {
@@ -750,11 +889,22 @@ void corosync_recheck_the_q_level(void *data)
 	}
 }
 
+/**
+ * @brief The sending_allowed_private_data_struct struct
+ */
 struct sending_allowed_private_data_struct {
 	int reserved_msgs;
 };
 
 
+/**
+ * @brief corosync_sending_allowed
+ * @param service
+ * @param id
+ * @param msg
+ * @param sending_allowed_private_data
+ * @return
+ */
 int corosync_sending_allowed (
 	unsigned int service,
 	unsigned int id,
@@ -798,6 +948,10 @@ int corosync_sending_allowed (
 	return (sending_allowed);
 }
 
+/**
+ * @brief corosync_sending_allowed_release
+ * @param sending_allowed_private_data
+ */
 void corosync_sending_allowed_release (void *sending_allowed_private_data)
 {
 	struct sending_allowed_private_data_struct *pd =
@@ -809,6 +963,11 @@ void corosync_sending_allowed_release (void *sending_allowed_private_data)
 	totempg_groups_joined_release (pd->reserved_msgs);
 }
 
+/**
+ * @brief message_source_is_local
+ * @param source
+ * @return
+ */
 int message_source_is_local (const mar_message_source_t *source)
 {
 	int ret = 0;
@@ -820,6 +979,11 @@ int message_source_is_local (const mar_message_source_t *source)
 	return ret;
 }
 
+/**
+ * @brief message_source_set
+ * @param source
+ * @param conn
+ */
 void message_source_set (
 	mar_message_source_t *source,
 	void *conn)
@@ -830,6 +994,9 @@ void message_source_set (
 	source->conn = conn;
 }
 
+/**
+ * @brief The scheduler_pause_timeout_data struct
+ */
 struct scheduler_pause_timeout_data {
 	struct totem_config *totem_config;
 	qb_loop_timer_handle handle;
@@ -837,6 +1004,10 @@ struct scheduler_pause_timeout_data {
 	unsigned long long max_tv_diff;
 };
 
+/**
+ * @brief timer_function_scheduler_timeout
+ * @param data
+ */
 static void timer_function_scheduler_timeout (void *data)
 {
 	struct scheduler_pause_timeout_data *timeout_data = (struct scheduler_pause_timeout_data *)data;
@@ -875,6 +1046,9 @@ static void timer_function_scheduler_timeout (void *data)
 }
 
 
+/**
+ * @brief corosync_setscheduler
+ */
 static void corosync_setscheduler (void)
 {
 #if defined(HAVE_PTHREAD_SETSCHEDPARAM) && defined(HAVE_SCHED_GET_PRIORITY_MAX) && defined(HAVE_SCHED_SETSCHEDULER)
@@ -921,6 +1095,15 @@ static void corosync_setscheduler (void)
 #endif
 }
 
+/**
+ * @brief _logsys_log_printf
+ * @param level
+ * @param subsys
+ * @param function_name
+ * @param file_name
+ * @param file_line
+ * @param format
+ */
 static void
 _logsys_log_printf(int level, int subsys,
 		const char *function_name,
@@ -929,6 +1112,15 @@ _logsys_log_printf(int level, int subsys,
 		const char *format,
 		...) __attribute__((format(printf, 6, 7)));
 
+/**
+ * @brief _logsys_log_printf
+ * @param level
+ * @param subsys
+ * @param function_name
+ * @param file_name
+ * @param file_line
+ * @param format
+ */
 static void
 _logsys_log_printf(int level, int subsys,
 		const char *function_name,
@@ -945,6 +1137,14 @@ _logsys_log_printf(int level, int subsys,
 	va_end(ap);
 }
 
+/**
+ * @brief fplay_key_change_notify_fn
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void fplay_key_change_notify_fn (
 	int32_t event,
 	const char *key_name,
@@ -962,6 +1162,9 @@ static void fplay_key_change_notify_fn (
 	}
 }
 
+/**
+ * @brief corosync_fplay_control_init
+ */
 static void corosync_fplay_control_init (void)
 {
 	icmap_track_t track = NULL;
@@ -985,6 +1188,9 @@ static void corosync_fplay_control_init (void)
  *
  * Also some RO keys cannot be determined in this stage, so they are set later in
  * other functions (like nodelist.local_node_pos, ...)
+ */
+/**
+ * @brief set_icmap_ro_keys_flag
  */
 static void set_icmap_ro_keys_flag (void)
 {
@@ -1012,6 +1218,9 @@ static void set_icmap_ro_keys_flag (void)
 	icmap_set_ro_access("config.totemconfig_reload_in_progress", CS_FALSE, CS_TRUE);
 }
 
+/**
+ * @brief main_service_ready
+ */
 static void main_service_ready (void)
 {
 	int res;
@@ -1032,6 +1241,12 @@ static void main_service_ready (void)
 		corosync_sync_completed);
 }
 
+/**
+ * @brief corosync_flock
+ * @param lockfile
+ * @param pid
+ * @return
+ */
 static enum e_corosync_done corosync_flock (const char *lockfile, pid_t pid)
 {
 	struct flock lock;
@@ -1119,6 +1334,13 @@ error_close:
 	return (err);
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @param envp
+ * @return
+ */
 int main (int argc, char **argv, char **envp)
 {
 	const char *error_string;

--- a/exec/mon.c
+++ b/exec/mon.c
@@ -146,11 +146,21 @@ struct cs_fsm_entry mon_fsm_table[] = {
 	{ MON_S_FAILED,  MON_E_FAILURE,		NULL,			{-1} },
 };
 
+/**
+ * @brief mon_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *mon_get_service_engine_ver0 (void)
 {
 	return (&mon_service_engine);
 }
 
+/**
+ * @brief mon_res_state_to_str
+ * @param fsm
+ * @param state
+ * @return
+ */
 static const char * mon_res_state_to_str(struct cs_fsm* fsm,
 	int32_t state)
 {
@@ -168,6 +178,12 @@ static const char * mon_res_state_to_str(struct cs_fsm* fsm,
 	return NULL;
 }
 
+/**
+ * @brief mon_res_event_to_str
+ * @param fsm
+ * @param event
+ * @return
+ */
 static const char * mon_res_event_to_str(struct cs_fsm* fsm,
 	int32_t event)
 {
@@ -182,6 +198,15 @@ static const char * mon_res_event_to_str(struct cs_fsm* fsm,
 	return NULL;
 }
 
+/**
+ * @brief mon_fsm_cb
+ * @param fsm
+ * @param cb_event
+ * @param curr_state
+ * @param next_state
+ * @param fsm_event
+ * @param data
+ */
 static void mon_fsm_cb (struct cs_fsm *fsm, int cb_event, int32_t curr_state,
 	int32_t next_state, int32_t fsm_event, void *data)
 {
@@ -213,6 +238,12 @@ static void mon_fsm_cb (struct cs_fsm *fsm, int cb_event, int32_t curr_state,
 	}
 }
 
+/**
+ * @brief mon_fsm_state_set
+ * @param fsm
+ * @param next_state
+ * @param inst
+ */
 static void mon_fsm_state_set (struct cs_fsm* fsm,
 	enum mon_resource_state next_state, struct resource_instance* inst)
 {
@@ -234,6 +265,12 @@ static void mon_fsm_state_set (struct cs_fsm* fsm,
 }
 
 
+/**
+ * @brief mon_config_changed
+ * @param fsm
+ * @param event
+ * @param data
+ */
 static void mon_config_changed (struct cs_fsm* fsm, int32_t event, void * data)
 {
 	struct resource_instance * inst = (struct resource_instance *)data;
@@ -312,6 +349,12 @@ static void mon_config_changed (struct cs_fsm* fsm, int32_t event, void * data)
 	}
 }
 
+/**
+ * @brief mon_resource_failed
+ * @param fsm
+ * @param event
+ * @param data
+ */
 void mon_resource_failed (struct cs_fsm* fsm, int32_t event, void * data)
 {
 	struct resource_instance * inst = (struct resource_instance *)data;
@@ -319,6 +362,10 @@ void mon_resource_failed (struct cs_fsm* fsm, int32_t event, void * data)
 	mon_fsm_state_set (fsm, MON_S_FAILED, inst);
 }
 
+/**
+ * @brief percent_mem_used_get
+ * @return
+ */
 static int32_t percent_mem_used_get(void)
 {
 	sg_mem_stats *mem_stats;
@@ -343,6 +390,10 @@ static int32_t percent_mem_used_get(void)
 	return ((total - freemem) * 100) / total;
 }
 
+/**
+ * @brief mem_update_stats_fn
+ * @param data
+ */
 static void mem_update_stats_fn (void *data)
 {
 	struct resource_instance * inst = (struct resource_instance *)data;
@@ -368,6 +419,10 @@ static void mem_update_stats_fn (void *data)
 		inst, inst->update_stats_fn, &inst->timer_handle);
 }
 
+/**
+ * @brief min15_loadavg_get
+ * @return
+ */
 static double min15_loadavg_get(void)
 {
 	sg_load_stats *load_stats;
@@ -385,6 +440,10 @@ static double min15_loadavg_get(void)
 	return load_stats->min15;
 }
 
+/**
+ * @brief load_update_stats_fn
+ * @param data
+ */
 static void load_update_stats_fn (void *data)
 {
 	struct resource_instance * inst = (struct resource_instance *)data;
@@ -410,6 +469,14 @@ static void load_update_stats_fn (void *data)
 		inst, inst->update_stats_fn, &inst->timer_handle);
 }
 
+/**
+ * @brief mon_key_changed_cb
+ * @param event
+ * @param key_name
+ * @param new_value
+ * @param old_value
+ * @param user_data
+ */
 static void mon_key_changed_cb (
 	int32_t event,
 	const char *key_name,
@@ -442,6 +509,10 @@ static void mon_key_changed_cb (
 	}
 }
 
+/**
+ * @brief mon_instance_init
+ * @param inst
+ */
 static void mon_instance_init (struct resource_instance* inst)
 {
 	uint64_t tmp_value;
@@ -492,6 +563,11 @@ static void mon_instance_init (struct resource_instance* inst)
 			mon_key_changed_cb, inst, &icmap_track);
 }
 
+/**
+ * @brief mon_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *mon_exec_init_fn (struct corosync_api_v1 *corosync_api)
 {
 #ifdef HAVE_LIBSTATGRAB_GE_090

--- a/exec/pload.c
+++ b/exec/pload.c
@@ -172,6 +172,11 @@ do {								\
 /*
  * tell all cluster nodes to start mcasting
  */
+/**
+ * @brief pload_send_start
+ * @param count
+ * @param size
+ */
 static void pload_send_start (uint32_t count, uint32_t size)
 {
 	struct req_exec_pload_start req_exec_pload_start;
@@ -188,6 +193,11 @@ static void pload_send_start (uint32_t count, uint32_t size)
 
 /*
  * send N empty data messages of size X
+ */
+/**
+ * @brief pload_send_message
+ * @param arg
+ * @return
  */
 static int pload_send_message (const void *arg)
 {
@@ -226,6 +236,14 @@ static int pload_send_message (const void *arg)
 /*
  * hook into icmap to read config at runtime
  * we do NOT start by default, ever!
+ */
+/**
+ * @brief pload_read_config
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
  */
 static void pload_read_config(
 	int32_t event,
@@ -266,6 +284,11 @@ static void pload_read_config(
 /*
  * exec functions
  */
+/**
+ * @brief pload_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *pload_exec_init_fn (struct corosync_api_v1 *corosync_api)
 {
 	icmap_track_t pload_track = NULL;
@@ -290,6 +313,10 @@ static char *pload_exec_init_fn (struct corosync_api_v1 *corosync_api)
  * network messages/onwire handlers
  */
 
+/**
+ * @brief req_exec_pload_start_endian_convert
+ * @param msg
+ */
 static void req_exec_pload_start_endian_convert (void *msg)
 {
 	struct req_exec_pload_start *req_exec_pload_start = msg;
@@ -298,6 +325,11 @@ static void req_exec_pload_start_endian_convert (void *msg)
 	req_exec_pload_start->msg_size = swab32(req_exec_pload_start->msg_size);
 }
 
+/**
+ * @brief message_handler_req_exec_pload_start
+ * @param msg
+ * @param nodeid
+ */
 static void message_handler_req_exec_pload_start (
 	const void *msg,
 	unsigned int nodeid)
@@ -322,10 +354,19 @@ static void message_handler_req_exec_pload_start (
 		&start_mcasting_handle);
 }
 
+/**
+ * @brief req_exec_pload_mcast_endian_convert
+ * @param msg
+ */
 static void req_exec_pload_mcast_endian_convert (void *msg)
 {
 }
 
+/**
+ * @brief message_handler_req_exec_pload_mcast
+ * @param msg
+ * @param nodeid
+ */
 static void message_handler_req_exec_pload_mcast (
 	const void *msg,
 	unsigned int nodeid)

--- a/exec/quorum.c
+++ b/exec/quorum.c
@@ -64,6 +64,10 @@ LOGSYS_DECLARE_SUBSYS ("QUORUM");
 
 static struct quorum_callin_functions *corosync_quorum_fns = NULL;
 
+/**
+ * @brief corosync_quorum_is_quorate
+ * @return
+ */
 int corosync_quorum_is_quorate (void)
 {
 	if (corosync_quorum_fns) {
@@ -74,6 +78,12 @@ int corosync_quorum_is_quorate (void)
 	}
 }
 
+/**
+ * @brief corosync_quorum_register_callback
+ * @param fn
+ * @param context
+ * @return
+ */
 int corosync_quorum_register_callback (quorum_callback_fn_t fn, void *context)
 {
 	if (corosync_quorum_fns) {
@@ -84,6 +94,12 @@ int corosync_quorum_register_callback (quorum_callback_fn_t fn, void *context)
 	}
 }
 
+/**
+ * @brief corosync_quorum_unregister_callback
+ * @param fn
+ * @param context
+ * @return
+ */
 int corosync_quorum_unregister_callback (quorum_callback_fn_t fn, void *context)
 {
 	if (corosync_quorum_fns) {
@@ -94,6 +110,11 @@ int corosync_quorum_unregister_callback (quorum_callback_fn_t fn, void *context)
 	}
 }
 
+/**
+ * @brief corosync_quorum_initialize
+ * @param fns
+ * @return
+ */
 int corosync_quorum_initialize (struct quorum_callin_functions *fns)
 {
 	if (corosync_quorum_fns)
@@ -103,6 +124,10 @@ int corosync_quorum_initialize (struct quorum_callin_functions *fns)
 	return 0;
 }
 
+/**
+ * @brief quorum_none
+ * @return
+ */
 int quorum_none(void)
 {
 	if (corosync_quorum_fns)

--- a/exec/schedwrk.c
+++ b/exec/schedwrk.c
@@ -58,6 +58,12 @@ void2handle (const void *v) { union u u; u.v = v; return u.h; }
 static const void *
 handle2void (hdb_handle_t h) { union u u; u.h = h; return u.v; }
 
+/**
+ * @brief schedwrk_do
+ * @param type
+ * @param context
+ * @return
+ */
 static int schedwrk_do (enum totem_callback_token_type type, const void *context)
 {
 	hdb_handle_t handle = void2handle (context);
@@ -90,6 +96,9 @@ error_exit:
 	return (-1);
 }
 
+/**
+ * @brief schedwrk_init
+ */
 void schedwrk_init (
 	void (*serialize_lock_fn) (void),
 	void (*serialize_unlock_fn) (void))
@@ -98,6 +107,13 @@ void schedwrk_init (
 	serialize_unlock = serialize_unlock_fn;
 }
 
+/**
+ * @brief schedwrk_internal_create
+ * @param handle
+ * @param context
+ * @param lock
+ * @return
+ */
 static int schedwrk_internal_create (
 	hdb_handle_t *handle,
 	int (schedwrk_fn) (const void *),
@@ -140,6 +156,12 @@ error_exit:
 	return (-1);
 }
 
+/**
+ * @brief schedwrk_create
+ * @param handle
+ * @param context
+ * @return
+ */
 int schedwrk_create (
 	hdb_handle_t *handle,
 	int (schedwrk_fn) (const void *),
@@ -148,6 +170,12 @@ int schedwrk_create (
 	return schedwrk_internal_create (handle, schedwrk_fn, context, 1);
 }
 
+/**
+ * @brief schedwrk_create_nolock
+ * @param handle
+ * @param context
+ * @return
+ */
 int schedwrk_create_nolock (
 	hdb_handle_t *handle,
 	int (schedwrk_fn) (const void *),
@@ -156,6 +184,10 @@ int schedwrk_create_nolock (
 	return schedwrk_internal_create (handle, schedwrk_fn, context, 0);
 }
 
+/**
+ * @brief schedwrk_destroy
+ * @param handle
+ */
 void schedwrk_destroy (hdb_handle_t handle)
 {
 	hdb_handle_destroy (&schedwrk_instance_database, handle);

--- a/exec/service.c
+++ b/exec/service.c
@@ -114,6 +114,12 @@ const char *service_stats_tx[SERVICES_COUNT_MAX][SERVICE_HANDLER_MAXIMUM_COUNT];
 
 static void (*service_unlink_all_complete) (void) = NULL;
 
+/**
+ * @brief corosync_service_link_and_init
+ * @param corosync_api
+ * @param service
+ * @return
+ */
 char *corosync_service_link_and_init (
 	struct corosync_api_v1 *corosync_api,
 	struct default_service *service)
@@ -180,6 +186,10 @@ char *corosync_service_link_and_init (
 	return NULL;
 }
 
+/**
+ * @brief service_priority_max
+ * @return
+ */
 static int service_priority_max(void)
 {
 	int lpc = 0, max = 0;
@@ -193,6 +203,14 @@ static int service_priority_max(void)
 
 /*
  * use the force
+ */
+/**
+ * @brief corosync_service_unlink_and_exit_priority
+ * @param corosync_api
+ * @param lowest_priority
+ * @param current_priority
+ * @param current_service_engine
+ * @return
  */
 static unsigned int
 corosync_service_unlink_and_exit_priority (
@@ -253,6 +271,13 @@ corosync_service_unlink_and_exit_priority (
 	return (0);
 }
 
+/**
+ * @brief service_unlink_and_exit
+ * @param corosync_api
+ * @param service_name
+ * @param service_ver
+ * @return
+ */
 static unsigned int service_unlink_and_exit (
 	struct corosync_api_v1 *corosync_api,
 	const char *service_name,
@@ -336,6 +361,11 @@ static unsigned int service_unlink_and_exit (
 /*
  * Links default services into the executive
  */
+/**
+ * @brief corosync_service_defaults_link_and_init
+ * @param corosync_api
+ * @return
+ */
 unsigned int corosync_service_defaults_link_and_init (struct corosync_api_v1 *corosync_api)
 {
 	unsigned int i;
@@ -360,6 +390,10 @@ unsigned int corosync_service_defaults_link_and_init (struct corosync_api_v1 *co
 	return (0);
 }
 
+/**
+ * @brief service_exit_schedwrk_handler
+ * @param data
+ */
 static void service_exit_schedwrk_handler (void *data) {
 	int res;
 	static int current_priority = 0;
@@ -391,6 +425,10 @@ static void service_exit_schedwrk_handler (void *data) {
 		service_exit_schedwrk_handler);
 }
 
+/**
+ * @brief corosync_service_unlink_all
+ * @param api
+ */
 void corosync_service_unlink_all (
 	struct corosync_api_v1 *api,
 	void (*unlink_all_complete) (void))
@@ -417,6 +455,9 @@ void corosync_service_unlink_all (
 		service_exit_schedwrk_handler);
 }
 
+/**
+ * @brief The service_unlink_and_exit_data struct
+ */
 struct service_unlink_and_exit_data {
 	hdb_handle_t handle;
 	struct corosync_api_v1 *api;
@@ -424,6 +465,10 @@ struct service_unlink_and_exit_data {
 	unsigned int ver;
 };
 
+/**
+ * @brief service_unlink_and_exit_schedwrk_handler
+ * @param data
+ */
 static void service_unlink_and_exit_schedwrk_handler (void *data)
 {
 	struct service_unlink_and_exit_data *service_unlink_and_exit_data =
@@ -445,8 +490,18 @@ static void service_unlink_and_exit_schedwrk_handler (void *data)
 	}
 }
 
+/**
+ *
+ */
 typedef int (*schedwrk_cast) (const void *);
 
+/**
+ * @brief corosync_service_unlink_and_exit
+ * @param api
+ * @param service_name
+ * @param service_ver
+ * @return
+ */
 unsigned int corosync_service_unlink_and_exit (
         struct corosync_api_v1 *api,
         const char *service_name,

--- a/exec/sync.c
+++ b/exec/sync.c
@@ -170,6 +170,10 @@ int (*my_sync_callbacks_retrieve) (
 		int service_id,
                 struct sync_callbacks *callbacks);
 
+/**
+ * @brief sync_init
+ * @return
+ */
 int sync_init (
         int (*sync_callbacks_retrieve) (
                 int service_id,
@@ -203,6 +207,11 @@ int sync_init (
 	return (0);
 }
 
+/**
+ * @brief sync_barrier_handler
+ * @param nodeid
+ * @param msg
+ */
 static void sync_barrier_handler (unsigned int nodeid, const void *msg)
 {
 	const struct req_exec_barrier_message *req_exec_barrier_message = msg;
@@ -244,6 +253,14 @@ static void sync_barrier_handler (unsigned int nodeid, const void *msg)
 	}
 }
 
+/**
+ * @brief dummy_sync_init
+ * @param trans_list
+ * @param trans_list_entries
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void dummy_sync_init (
 	const unsigned int *trans_list,
 	size_t trans_list_entries,
@@ -253,19 +270,35 @@ static void dummy_sync_init (
 {
 }
 
+/**
+ * @brief dummy_sync_abort
+ */
 static void dummy_sync_abort (void)
 {
 }
 
+/**
+ * @brief dummy_sync_process
+ * @return
+ */
 static int dummy_sync_process (void)
 {
 	return (0);
 }
 
+/**
+ * @brief dummy_sync_activate
+ */
 static void dummy_sync_activate (void)
 {
 }
 
+/**
+ * @brief service_entry_compare
+ * @param a
+ * @param b
+ * @return
+ */
 static int service_entry_compare (const void *a, const void *b)
 {
 	const struct service_entry *service_entry_a = a;
@@ -274,6 +307,11 @@ static int service_entry_compare (const void *a, const void *b)
 	return (service_entry_a->service_id > service_entry_b->service_id);
 }
 
+/**
+ * @brief sync_memb_determine
+ * @param nodeid
+ * @param msg
+ */
 static void sync_memb_determine (unsigned int nodeid, const void *msg)
 {
 	const struct req_exec_memb_determine_message *req_exec_memb_determine_message = msg;
@@ -299,6 +337,11 @@ static void sync_memb_determine (unsigned int nodeid, const void *msg)
 	}
 }
 
+/**
+ * @brief sync_service_build_handler
+ * @param nodeid
+ * @param msg
+ */
 static void sync_service_build_handler (unsigned int nodeid, const void *msg)
 {
 	const struct req_exec_service_build_message *req_exec_service_build_message = msg;
@@ -362,6 +405,13 @@ static void sync_service_build_handler (unsigned int nodeid, const void *msg)
 	}
 }
 
+/**
+ * @brief sync_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static void sync_deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
@@ -383,6 +433,9 @@ static void sync_deliver_fn (
 	}
 }
 
+/**
+ * @brief memb_determine_message_transmit
+ */
 static void memb_determine_message_transmit (void)
 {
 	struct iovec iovec;
@@ -402,6 +455,9 @@ static void memb_determine_message_transmit (void)
 		&iovec, 1, TOTEMPG_AGREED);
 }
 
+/**
+ * @brief barrier_message_transmit
+ */
 static void barrier_message_transmit (void)
 {
 	struct iovec iovec;
@@ -420,6 +476,10 @@ static void barrier_message_transmit (void)
 		&iovec, 1, TOTEMPG_AGREED);
 }
 
+/**
+ * @brief service_build_message_transmit
+ * @param service_build_message
+ */
 static void service_build_message_transmit (struct req_exec_service_build_message *service_build_message)
 {
 	struct iovec iovec;
@@ -437,12 +497,18 @@ static void service_build_message_transmit (struct req_exec_service_build_messag
 		&iovec, 1, TOTEMPG_AGREED);
 }
 
+/**
+ * @brief sync_barrier_enter
+ */
 static void sync_barrier_enter (void)
 {
 	my_state = SYNC_BARRIER;
 	barrier_message_transmit ();
 }
 
+/**
+ * @brief sync_process_enter
+ */
 static void sync_process_enter (void)
 {
 	int i;
@@ -466,6 +532,12 @@ static void sync_process_enter (void)
 		NULL);
 }
 
+/**
+ * @brief sync_servicelist_build_enter
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void sync_servicelist_build_enter (
 	const unsigned int *member_list,
 	size_t member_list_entries,
@@ -520,6 +592,11 @@ static void sync_servicelist_build_enter (
 	service_build_message_transmit (&service_build);
 }
 
+/**
+ * @brief schedwrk_processor
+ * @param context
+ * @return
+ */
 static int schedwrk_processor (const void *context)
 {
 	int res = 0;
@@ -568,6 +645,12 @@ static int schedwrk_processor (const void *context)
 	return (0);
 }
 
+/**
+ * @brief sync_start
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 void sync_start (
         const unsigned int *member_list,
         size_t member_list_entries,
@@ -586,6 +669,12 @@ void sync_start (
 	}
 }
 
+/**
+ * @brief sync_save_transitional
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 void sync_save_transitional (
         const unsigned int *member_list,
         size_t member_list_entries,
@@ -597,6 +686,9 @@ void sync_save_transitional (
 	my_trans_list_entries = member_list_entries;
 }
 
+/**
+ * @brief sync_abort
+ */
 void sync_abort (void)
 {
 	ENTER();
@@ -613,6 +705,10 @@ void sync_abort (void)
 	memset (&my_ring_id, 0,	sizeof (struct memb_ring_id));
 }
 
+/**
+ * @brief sync_memb_list_determine
+ * @param ring_id
+ */
 void sync_memb_list_determine (const struct memb_ring_id *ring_id)
 {
 	ENTER();
@@ -622,6 +718,9 @@ void sync_memb_list_determine (const struct memb_ring_id *ring_id)
 	memb_determine_message_transmit ();
 }
 
+/**
+ * @brief sync_memb_list_abort
+ */
 void sync_memb_list_abort (void)
 {
 	ENTER();

--- a/exec/timer.c
+++ b/exec/timer.c
@@ -40,6 +40,13 @@
 #include <qb/qbdefs.h>
 #include <qb/qbutil.h>
 
+/**
+ * @brief corosync_timer_add_absolute
+ * @param nanosec_from_epoch
+ * @param data
+ * @param handle
+ * @return
+ */
 int corosync_timer_add_absolute (
 		unsigned long long nanosec_from_epoch,
 		void *data,
@@ -55,6 +62,13 @@ int corosync_timer_add_absolute (
 				 handle);
 }
 
+/**
+ * @brief corosync_timer_add_duration
+ * @param nanosec_duration
+ * @param data
+ * @param handle
+ * @return
+ */
 int corosync_timer_add_duration (
 	unsigned long long nanosec_duration,
 	void *data,
@@ -69,12 +83,21 @@ int corosync_timer_add_duration (
 				 handle);
 }
 
+/**
+ * @brief corosync_timer_delete
+ * @param th
+ */
 void corosync_timer_delete (
 	corosync_timer_handle_t th)
 {
 	qb_loop_timer_del(cs_poll_handle_get(), th);
 }
 
+/**
+ * @brief corosync_timer_expire_time_get
+ * @param th
+ * @return
+ */
 unsigned long long corosync_timer_expire_time_get (
 	corosync_timer_handle_t th)
 {
@@ -89,6 +112,10 @@ unsigned long long corosync_timer_expire_time_get (
 	return (expire);
 }
 
+/**
+ * @brief cs_timer_time_get
+ * @return
+ */
 unsigned long long cs_timer_time_get (void)
 {
 	return qb_util_nano_from_epoch_get();

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -86,6 +86,12 @@ static void add_totem_config_notification(struct totem_config *totem_config);
 
 
 /* All the volatile parameters are uint32s, luckily */
+/**
+ * @brief totem_get_param_by_name
+ * @param totem_config
+ * @param param_name
+ * @return
+ */
 static uint32_t *totem_get_param_by_name(struct totem_config *totem_config, const char *param_name)
 {
 	if (strcmp(param_name, "totem.token") == 0)
@@ -138,6 +144,14 @@ static uint32_t *totem_get_param_by_name(struct totem_config *totem_config, cons
  * Read key_name from icmap. If key is not found or key_name == delete_key or if allow_zero is false
  * and readed value is zero, default value is used and stored into totem_config.
  */
+/**
+ * @brief totem_volatile_config_set_value
+ * @param totem_config
+ * @param key_name
+ * @param deleted_key
+ * @param default_value
+ * @param allow_zero_value
+ */
 static void totem_volatile_config_set_value (struct totem_config *totem_config,
 	const char *key_name, const char *deleted_key, unsigned int default_value,
 	int allow_zero_value)
@@ -164,6 +178,11 @@ static void totem_volatile_config_set_value (struct totem_config *totem_config,
  * Read and validate config values from cmap and store them into totem_config. If key doesn't exists,
  * default value is stored. deleted_key is name of key beeing processed by delete operation
  * from cmap. It is considered as non existing even if it can be read. Can be NULL.
+ */
+/**
+ * @brief totem_volatile_config_read
+ * @param totem_config
+ * @param deleted_key
  */
 static void totem_volatile_config_read (struct totem_config *totem_config, const char *deleted_key)
 {
@@ -233,6 +252,12 @@ static void totem_volatile_config_read (struct totem_config *totem_config, const
 	totem_volatile_config_set_value(totem_config, "totem.heartbeat_failures_allowed", deleted_key, 0, 1);
 }
 
+/**
+ * @brief totem_volatile_config_validate
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 static int totem_volatile_config_validate (
 	struct totem_config *totem_config,
 	const char **error_string)
@@ -340,6 +365,11 @@ parse_error:
 
 }
 
+/**
+ * @brief totem_get_crypto
+ * @param totem_config
+ * @return
+ */
 static int totem_get_crypto(struct totem_config *totem_config)
 {
 	char *str;
@@ -412,6 +442,10 @@ static int totem_get_crypto(struct totem_config *totem_config)
 	return 0;
 }
 
+/**
+ * @brief totem_config_get_ip_version
+ * @return
+ */
 static int totem_config_get_ip_version(void)
 {
 	int res;
@@ -431,6 +465,11 @@ static int totem_config_get_ip_version(void)
 	return (res);
 }
 
+/**
+ * @brief generate_cluster_id
+ * @param cluster_name
+ * @return
+ */
 static uint16_t generate_cluster_id (const char *cluster_name)
 {
 	int i;
@@ -444,6 +483,15 @@ static uint16_t generate_cluster_id (const char *cluster_name)
 	return (value & 0xFFFF);
 }
 
+/**
+ * @brief get_cluster_mcast_addr
+ * @param cluster_name
+ * @param bindnet
+ * @param ringnumber
+ * @param ip_version
+ * @param res
+ * @return
+ */
 static int get_cluster_mcast_addr (
 		const char *cluster_name,
 		unsigned int ringnumber,
@@ -480,6 +528,12 @@ static int get_cluster_mcast_addr (
 	return (err);
 }
 
+/**
+ * @brief generate_nodeid_for_duplicate_test
+ * @param totem_config
+ * @param addr
+ * @return
+ */
 static unsigned int generate_nodeid_for_duplicate_test(
 	struct totem_config *totem_config,
 	char *addr)
@@ -504,6 +558,12 @@ static unsigned int generate_nodeid_for_duplicate_test(
 	return nodeid;
 }
 
+/**
+ * @brief check_for_duplicate_nodeids
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 static int check_for_duplicate_nodeids(
 	struct totem_config *totem_config,
 	const char **error_string)
@@ -593,7 +653,11 @@ static int check_for_duplicate_nodeids(
 	return retval;
 }
 
-
+/**
+ * @brief find_local_node_in_nodelist
+ * @param totem_config
+ * @return
+ */
 static int find_local_node_in_nodelist(struct totem_config *totem_config)
 {
 	icmap_iter_t iter;
@@ -650,6 +714,12 @@ static int find_local_node_in_nodelist(struct totem_config *totem_config)
  * are changed so for same ring, ip existing in both set1 and set2 are cleared
  * (set to 0), and ips which are only in set1 or set2 remains untouched.
  * totempg_node_add/remove is called.
+ */
+/**
+ * @brief compute_interfaces_diff
+ * @param interface_count
+ * @param set1
+ * @param set2
  */
 static void compute_interfaces_diff(int interface_count,
 	struct totem_interface *set1,
@@ -711,6 +781,11 @@ static void compute_interfaces_diff(int interface_count,
 	}
 }
 
+/**
+ * @brief put_nodelist_members_to_config
+ * @param totem_config
+ * @param reload
+ */
 static void put_nodelist_members_to_config(struct totem_config *totem_config, int reload)
 {
 	icmap_iter_t iter, iter2;
@@ -796,6 +871,14 @@ static void put_nodelist_members_to_config(struct totem_config *totem_config, in
 	}
 }
 
+/**
+ * @brief nodelist_dynamic_notify
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void nodelist_dynamic_notify(
 	int32_t event,
 	const char *key_name,
@@ -839,6 +922,12 @@ static void nodelist_dynamic_notify(
  * match).
  *
  * Returns 1 on success (address was found, node_pos is then correctly set) or 0 on failure.
+ */
+/**
+ * @brief totem_config_find_local_addr_in_nodelist
+ * @param ipaddr_key_prefix
+ * @param node_pos
+ * @return
  */
 int totem_config_find_local_addr_in_nodelist(const char *ipaddr_key_prefix, unsigned int *node_pos)
 {
@@ -932,6 +1021,10 @@ int totem_config_find_local_addr_in_nodelist(const char *ipaddr_key_prefix, unsi
 	return (node_found);
 }
 
+/**
+ * @brief config_convert_nodelist_to_interface
+ * @param totem_config
+ */
 static void config_convert_nodelist_to_interface(struct totem_config *totem_config)
 {
 	int res = 0;
@@ -967,7 +1060,13 @@ static void config_convert_nodelist_to_interface(struct totem_config *totem_conf
 	}
 }
 
-
+/**
+ * @brief totem_config_read
+ * @param totem_config
+ * @param error_string
+ * @param warnings
+ * @return
+ */
 extern int totem_config_read (
 	struct totem_config *totem_config,
 	const char **error_string,
@@ -1255,7 +1354,12 @@ extern int totem_config_read (
 	return 0;
 }
 
-
+/**
+ * @brief totem_config_validate
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 int totem_config_validate (
 	struct totem_config *totem_config,
 	const char **error_string)
@@ -1393,6 +1497,13 @@ parse_error:
 
 }
 
+/**
+ * @brief read_keyfile
+ * @param key_location
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 static int read_keyfile (
 	const char *key_location,
 	struct totem_config *totem_config,
@@ -1442,6 +1553,12 @@ parse_error:
 	return (-1);
 }
 
+/**
+ * @brief totem_config_keyread
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 int totem_config_keyread (
 	struct totem_config *totem_config,
 	const char **error_string)
@@ -1502,6 +1619,10 @@ key_error:
 
 }
 
+/**
+ * @brief debug_dump_totem_config
+ * @param totem_config
+ */
 static void debug_dump_totem_config(const struct totem_config *totem_config)
 {
 
@@ -1538,6 +1659,14 @@ static void debug_dump_totem_config(const struct totem_config *totem_config)
 	log_printf(LOGSYS_LEVEL_DEBUG, "max_network_delay (%d ms)", totem_config->max_network_delay);
 }
 
+/**
+ * @brief totem_change_notify
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void totem_change_notify(
 	int32_t event,
 	const char *key_name,
@@ -1594,6 +1723,14 @@ static void totem_change_notify(
 	}
 }
 
+/**
+ * @brief totem_reload_notify
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void totem_reload_notify(
 	int32_t event,
 	const char *key_name,
@@ -1631,6 +1768,10 @@ static void totem_reload_notify(
 	}
 }
 
+/**
+ * @brief add_totem_config_notification
+ * @param totem_config
+ */
 static void add_totem_config_notification(struct totem_config *totem_config)
 {
 	icmap_track_t icmap_track;

--- a/exec/totemcrypto.c
+++ b/exec/totemcrypto.c
@@ -169,6 +169,9 @@ size_t hash_block_len[] = {
 	SHA512_BLOCK_LENGTH		/* CRYPTO_HASH_TYPE_SHA512 */
 };
 
+/**
+ * @brief The crypto_instance struct
+ */
 struct crypto_instance {
 	PK11SymKey   *nss_sym_key;
 	PK11SymKey   *nss_sym_key_sign;
@@ -210,6 +213,11 @@ do {									\
  * crypt/decrypt functions
  */
 
+/**
+ * @brief string_to_crypto_cipher_type
+ * @param crypto_cipher_type
+ * @return
+ */
 static int string_to_crypto_cipher_type(const char* crypto_cipher_type)
 {
 	if (strcmp(crypto_cipher_type, "none") == 0) {
@@ -226,6 +234,11 @@ static int string_to_crypto_cipher_type(const char* crypto_cipher_type)
 	return CRYPTO_CIPHER_TYPE_AES256;
 }
 
+/**
+ * @brief init_nss_crypto
+ * @param instance
+ * @return
+ */
 static int init_nss_crypto(struct crypto_instance *instance)
 {
 	PK11SlotInfo*	crypt_slot = NULL;
@@ -261,6 +274,15 @@ static int init_nss_crypto(struct crypto_instance *instance)
 	return 0;
 }
 
+/**
+ * @brief encrypt_nss
+ * @param instance
+ * @param buf_in
+ * @param buf_in_len
+ * @param buf_out
+ * @param buf_out_len
+ * @return
+ */
 static int encrypt_nss(
 	struct crypto_instance *instance,
 	const unsigned char *buf_in,
@@ -353,6 +375,13 @@ out:
 	return err;
 }
 
+/**
+ * @brief decrypt_nss
+ * @param instance
+ * @param buf
+ * @param buf_len
+ * @return
+ */
 static int decrypt_nss (
 	struct crypto_instance *instance,
 	unsigned char *buf,
@@ -426,6 +455,11 @@ out:
  * hash/hmac/digest functions
  */
 
+/**
+ * @brief string_to_crypto_hash_type
+ * @param crypto_hash_type
+ * @return
+ */
 static int string_to_crypto_hash_type(const char* crypto_hash_type)
 {
 	if (strcmp(crypto_hash_type, "none") == 0) {
@@ -445,6 +479,11 @@ static int string_to_crypto_hash_type(const char* crypto_hash_type)
 	return CRYPTO_HASH_TYPE_SHA1;
 }
 
+/**
+ * @brief init_nss_hash
+ * @param instance
+ * @return
+ */
 static int init_nss_hash(struct crypto_instance *instance)
 {
 	PK11SlotInfo*	hash_slot = NULL;
@@ -480,6 +519,14 @@ static int init_nss_hash(struct crypto_instance *instance)
 	return 0;
 }
 
+/**
+ * @brief calculate_nss_hash
+ * @param instance
+ * @param buf
+ * @param buf_len
+ * @param hash
+ * @return
+ */
 static int calculate_nss_hash(
 	struct crypto_instance *instance,
 	const unsigned char *buf,
@@ -554,6 +601,11 @@ out:
  * global/glue nss functions
  */
 
+/**
+ * @brief init_nss_db
+ * @param instance
+ * @return
+ */
 static int init_nss_db(struct crypto_instance *instance)
 {
 	if ((!cipher_to_nss[instance->crypto_cipher_type]) &&
@@ -570,6 +622,13 @@ static int init_nss_db(struct crypto_instance *instance)
 	return 0;
 }
 
+/**
+ * @brief init_nss
+ * @param instance
+ * @param crypto_cipher_type
+ * @param crypto_hash_type
+ * @return
+ */
 static int init_nss(struct crypto_instance *instance,
 		    const char *crypto_cipher_type,
 		    const char *crypto_hash_type)
@@ -593,6 +652,15 @@ static int init_nss(struct crypto_instance *instance,
 	return 0;
 }
 
+/**
+ * @brief encrypt_and_sign_nss_2_3
+ * @param instance
+ * @param buf_in
+ * @param buf_in_len
+ * @param buf_out
+ * @param buf_out_len
+ * @return
+ */
 static int encrypt_and_sign_nss_2_3 (
 	struct crypto_instance *instance,
 	const unsigned char *buf_in,
@@ -618,6 +686,13 @@ static int encrypt_and_sign_nss_2_3 (
 	return 0;
 }
 
+/**
+ * @brief authenticate_nss_2_3
+ * @param instance
+ * @param buf
+ * @param buf_len
+ * @return
+ */
 static int authenticate_nss_2_3 (
 	struct crypto_instance *instance,
 	unsigned char *buf,
@@ -641,6 +716,13 @@ static int authenticate_nss_2_3 (
 	return 0;
 }
 
+/**
+ * @brief decrypt_nss_2_3
+ * @param instance
+ * @param buf
+ * @param buf_len
+ * @return
+ */
 static int decrypt_nss_2_3 (
 	struct crypto_instance *instance,
 	unsigned char *buf,
@@ -659,6 +741,12 @@ static int decrypt_nss_2_3 (
  * exported API
  */
 
+/**
+ * @brief crypto_sec_header_size
+ * @param crypto_cipher_type
+ * @param crypto_hash_type
+ * @return
+ */
 size_t crypto_sec_header_size(
 	const char *crypto_cipher_type,
 	const char *crypto_hash_type)
@@ -708,6 +796,15 @@ size_t crypto_sec_header_size(
  *  and extra buffer but values are hashed and verified.
  */
 
+/**
+ * @brief crypto_encrypt_and_sign
+ * @param instance
+ * @param buf_in
+ * @param buf_in_len
+ * @param buf_out
+ * @param buf_out_len
+ * @return
+ */
 int crypto_encrypt_and_sign (
 	struct crypto_instance *instance,
 	const unsigned char *buf_in,
@@ -730,6 +827,13 @@ int crypto_encrypt_and_sign (
 	return err;
 }
 
+/**
+ * @brief crypto_authenticate_and_decrypt
+ * @param instance
+ * @param buf
+ * @param buf_len
+ * @return
+ */
 int crypto_authenticate_and_decrypt (struct crypto_instance *instance,
 	unsigned char *buf,
 	int *buf_len)
@@ -783,6 +887,18 @@ int crypto_authenticate_and_decrypt (struct crypto_instance *instance,
 	return 0;
 }
 
+/**
+ * @brief crypto_init
+ * @param private_key
+ * @param private_key_len
+ * @param crypto_cipher_type
+ * @param crypto_hash_type
+ * @param log_level_security
+ * @param log_level_notice
+ * @param log_level_error
+ * @param log_subsys_id
+ * @return
+ */
 struct crypto_instance *crypto_init(
 	const unsigned char *private_key,
 	unsigned int private_key_len,

--- a/exec/totemiba.c
+++ b/exec/totemiba.c
@@ -251,6 +251,10 @@ void2wrid (void *v) { union u u; u.v = v; return u.wr_id; }
 static void *
 wrid2void (uint64_t wr_id) { union u u; u.wr_id = wr_id; return u.v; }
 
+/**
+ * @brief totemiba_instance_initialize
+ * @param instance
+ */
 static void totemiba_instance_initialize (struct totemiba_instance *instance)
 {
 	memset (instance, 0, sizeof (struct totemiba_instance));
@@ -261,6 +265,11 @@ static void totemiba_instance_initialize (struct totemiba_instance *instance)
 	list_init (&instance->recv_token_recv_buf_head);
 }
 
+/**
+ * @brief mcast_send_buf_get
+ * @param instance
+ * @return
+ */
 static inline struct send_buf *mcast_send_buf_get (
 	struct totemiba_instance *instance)
 {
@@ -290,6 +299,11 @@ static inline struct send_buf *mcast_send_buf_get (
 	return (send_buf);
 }
 
+/**
+ * @brief mcast_send_buf_put
+ * @param instance
+ * @param send_buf
+ */
 static inline void mcast_send_buf_put (
 	struct totemiba_instance *instance,
 	struct send_buf *send_buf)
@@ -298,6 +312,11 @@ static inline void mcast_send_buf_put (
 	list_add_tail (&send_buf->list_free, &instance->mcast_send_buf_free);
 }
 
+/**
+ * @brief token_send_buf_get
+ * @param instance
+ * @return
+ */
 static inline struct send_buf *token_send_buf_get (
 	struct totemiba_instance *instance)
 {
@@ -327,6 +346,10 @@ static inline struct send_buf *token_send_buf_get (
 	return (send_buf);
 }
 
+/**
+ * @brief token_send_buf_destroy
+ * @param instance
+ */
 static inline void token_send_buf_destroy (struct totemiba_instance *instance)
 {
 	struct list_head *list;
@@ -343,6 +366,11 @@ static inline void token_send_buf_destroy (struct totemiba_instance *instance)
 	list_init (&instance->token_send_buf_head);
 }
 
+/**
+ * @brief token_send_buf_put
+ * @param instance
+ * @param send_buf
+ */
 static inline void token_send_buf_put (
 	struct totemiba_instance *instance,
 	struct send_buf *send_buf)
@@ -351,6 +379,11 @@ static inline void token_send_buf_put (
 	list_add_tail (&send_buf->list_free, &instance->token_send_buf_free);
 }
 
+/**
+ * @brief recv_token_recv_buf_create
+ * @param instance
+ * @return
+ */
 static inline struct recv_buf *recv_token_recv_buf_create (
 	struct totemiba_instance *instance)
 {
@@ -379,6 +412,12 @@ static inline struct recv_buf *recv_token_recv_buf_create (
 	return (recv_buf);
 }
 
+/**
+ * @brief recv_token_recv_buf_post
+ * @param instance
+ * @param recv_buf
+ * @return
+ */
 static inline int recv_token_recv_buf_post (struct totemiba_instance *instance, struct recv_buf *recv_buf)
 {
 	struct ibv_recv_wr *fail_recv;
@@ -389,6 +428,10 @@ static inline int recv_token_recv_buf_post (struct totemiba_instance *instance, 
 	return (res);
 }
 
+/**
+ * @brief recv_token_recv_buf_post_initial
+ * @param instance
+ */
 static inline void recv_token_recv_buf_post_initial (struct totemiba_instance *instance)
 {
 	struct recv_buf *recv_buf;
@@ -401,6 +444,10 @@ static inline void recv_token_recv_buf_post_initial (struct totemiba_instance *i
 	}
 }
 
+/**
+ * @brief recv_token_recv_buf_post_destroy
+ * @param instance
+ */
 static inline void recv_token_recv_buf_post_destroy (
 	struct totemiba_instance *instance)
 {
@@ -418,6 +465,11 @@ static inline void recv_token_recv_buf_post_destroy (
 	list_init (&instance->recv_token_recv_buf_head);
 }
 
+/**
+ * @brief mcast_recv_buf_create
+ * @param instance
+ * @return
+ */
 static inline struct recv_buf *mcast_recv_buf_create (struct totemiba_instance *instance)
 {
 	struct recv_buf *recv_buf;
@@ -444,6 +496,12 @@ static inline struct recv_buf *mcast_recv_buf_create (struct totemiba_instance *
 	return (recv_buf);
 }
 
+/**
+ * @brief mcast_recv_buf_post
+ * @param instance
+ * @param recv_buf
+ * @return
+ */
 static inline int mcast_recv_buf_post (struct totemiba_instance *instance, struct recv_buf *recv_buf)
 {
 	struct ibv_recv_wr *fail_recv;
@@ -454,6 +512,10 @@ static inline int mcast_recv_buf_post (struct totemiba_instance *instance, struc
 	return (res);
 }
 
+/**
+ * @brief mcast_recv_buf_post_initial
+ * @param instance
+ */
 static inline void mcast_recv_buf_post_initial (struct totemiba_instance *instance)
 {
 	struct recv_buf *recv_buf;
@@ -466,6 +528,12 @@ static inline void mcast_recv_buf_post_initial (struct totemiba_instance *instan
 	}
 }
 
+/**
+ * @brief iba_deliver_fn
+ * @param instance
+ * @param wr_id
+ * @param bytes
+ */
 static inline void iba_deliver_fn (struct totemiba_instance *instance, uint64_t wr_id, uint32_t bytes)
 {
 	const char *addr;
@@ -478,6 +546,13 @@ static inline void iba_deliver_fn (struct totemiba_instance *instance, uint64_t 
 	instance->totemiba_deliver_fn (instance->rrp_context, addr, bytes);
 }
 
+/**
+ * @brief mcast_cq_send_event_fn
+ * @param fd
+ * @param events
+ * @param context
+ * @return
+ */
 static int mcast_cq_send_event_fn (int fd, int events, void *context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)context;
@@ -501,6 +576,13 @@ static int mcast_cq_send_event_fn (int fd, int events, void *context)
 	return (0);
 }
 
+/**
+ * @brief mcast_cq_recv_event_fn
+ * @param fd
+ * @param events
+ * @param context
+ * @return
+ */
 static int mcast_cq_recv_event_fn (int fd, int events, void *context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)context;
@@ -525,6 +607,10 @@ static int mcast_cq_recv_event_fn (int fd, int events, void *context)
 	return (0);
 }
 
+/**
+ * @brief mcast_rejoin
+ * @param data
+ */
 static void mcast_rejoin (void *data)
 {
 	int res;
@@ -551,6 +637,13 @@ static void mcast_rejoin (void *data)
 	}
 }
 
+/**
+ * @brief mcast_rdma_event_fn
+ * @param fd
+ * @param events
+ * @param context
+ * @return
+ */
 static int mcast_rdma_event_fn (int fd, int events, void *context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)context;
@@ -608,6 +701,13 @@ static int mcast_rdma_event_fn (int fd, int events, void *context)
 	return (0);
 }
 
+/**
+ * @brief recv_token_cq_send_event_fn
+ * @param fd
+ * @param revents
+ * @param context
+ * @return
+ */
 static int recv_token_cq_send_event_fn (
 	int fd,
 	int revents,
@@ -635,6 +735,13 @@ static int recv_token_cq_send_event_fn (
 	return (0);
 }
 
+/**
+ * @brief recv_token_cq_recv_event_fn
+ * @param fd
+ * @param events
+ * @param context
+ * @return
+ */
 static int recv_token_cq_recv_event_fn (int fd, int events, void *context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)context;
@@ -659,6 +766,11 @@ static int recv_token_cq_recv_event_fn (int fd, int events, void *context)
 	return (0);
 }
 
+/**
+ * @brief recv_token_accept_destroy
+ * @param instance
+ * @return
+ */
 static int recv_token_accept_destroy (struct totemiba_instance *instance)
 {
 	if (instance->recv_token_accepted == 0) {
@@ -692,6 +804,11 @@ static int recv_token_accept_destroy (struct totemiba_instance *instance)
 	return (0);
 }
 
+/**
+ * @brief recv_token_accept_setup
+ * @param instance
+ * @return
+ */
 static int recv_token_accept_setup (struct totemiba_instance *instance)
 {
 	struct ibv_qp_init_attr init_qp_attr;
@@ -787,6 +904,13 @@ static int recv_token_accept_setup (struct totemiba_instance *instance)
 	return (res);
 };
 
+/**
+ * @brief recv_token_rdma_event_fn
+ * @param fd
+ * @param events
+ * @param context
+ * @return
+ */
 static int recv_token_rdma_event_fn (int fd, int events, void *context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)context;
@@ -819,6 +943,13 @@ static int recv_token_rdma_event_fn (int fd, int events, void *context)
 	return (0);
 }
 
+/**
+ * @brief send_token_cq_send_event_fn
+ * @param fd
+ * @param events
+ * @param context
+ * @return
+ */
 static int send_token_cq_send_event_fn (int fd, int events, void *context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)context;
@@ -842,6 +973,13 @@ static int send_token_cq_send_event_fn (int fd, int events, void *context)
 	return (0);
 }
 
+/**
+ * @brief send_token_cq_recv_event_fn
+ * @param fd
+ * @param events
+ * @param context
+ * @return
+ */
 static int send_token_cq_recv_event_fn (int fd, int events, void *context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)context;
@@ -865,6 +1003,13 @@ static int send_token_cq_recv_event_fn (int fd, int events, void *context)
 	return (0);
 }
 
+/**
+ * @brief send_token_rdma_event_fn
+ * @param fd
+ * @param events
+ * @param context
+ * @return
+ */
 static int send_token_rdma_event_fn (int fd, int events, void *context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)context;
@@ -924,6 +1069,11 @@ static int send_token_rdma_event_fn (int fd, int events, void *context)
 	return (0);
 }
 
+/**
+ * @brief send_token_bind
+ * @param instance
+ * @return
+ */
 static int send_token_bind (struct totemiba_instance *instance)
 {
 	int res;
@@ -1058,6 +1208,11 @@ static int send_token_bind (struct totemiba_instance *instance)
 	return (0);
 }
 
+/**
+ * @brief send_token_unbind
+ * @param instance
+ * @return
+ */
 static int send_token_unbind (struct totemiba_instance *instance)
 {
 	if (instance->send_token_bound == 0) {
@@ -1092,6 +1247,11 @@ static int send_token_unbind (struct totemiba_instance *instance)
 	return (0);
 }
 
+/**
+ * @brief recv_token_bind
+ * @param instance
+ * @return
+ */
 static int recv_token_bind (struct totemiba_instance *instance)
 {
 	int res;
@@ -1149,6 +1309,11 @@ static int recv_token_bind (struct totemiba_instance *instance)
 	return (0);
 }
 
+/**
+ * @brief mcast_bind
+ * @param instance
+ * @return
+ */
 static int mcast_bind (struct totemiba_instance *instance)
 {
 	int res;
@@ -1276,6 +1441,10 @@ static int mcast_bind (struct totemiba_instance *instance)
 	return (0);
 }
 
+/**
+ * @brief timer_function_netif_check_timeout
+ * @param data
+ */
 static void timer_function_netif_check_timeout (
       void *data)
 {
@@ -1320,6 +1489,13 @@ static void timer_function_netif_check_timeout (
 	res = mcast_bind (instance);
 }
 
+/**
+ * @brief totemiba_crypto_set
+ * @param iba_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemiba_crypto_set (
 	void *iba_context,
 	const char *cipher_type,
@@ -1333,6 +1509,11 @@ int totemiba_crypto_set (
 	return (res);
 }
 
+/**
+ * @brief totemiba_finalize
+ * @param iba_context
+ * @return
+ */
 int totemiba_finalize (
 	void *iba_context)
 {
@@ -1346,6 +1527,16 @@ int totemiba_finalize (
 
 /*
  * Create an instance
+ */
+/**
+ * @brief totemiba_initialize
+ * @param qb_poll_handle
+ * @param iba_context
+ * @param totem_config
+ * @param stats
+ * @param interface_no
+ * @param context
+ * @return
  */
 int totemiba_initialize (
 	qb_loop_t *qb_poll_handle,
@@ -1408,16 +1599,30 @@ int totemiba_initialize (
 	return (res);
 }
 
+/**
+ * @brief totemiba_buffer_alloc
+ * @return
+ */
 void *totemiba_buffer_alloc (void)
 {
 	return malloc (MAX_MTU_SIZE);
 }
 
+/**
+ * @brief totemiba_buffer_release
+ * @param ptr
+ */
 void totemiba_buffer_release (void *ptr)
 {
 	return free (ptr);
 }
 
+/**
+ * @brief totemiba_processor_count_set
+ * @param iba_context
+ * @param processor_count
+ * @return
+ */
 int totemiba_processor_count_set (
 	void *iba_context,
 	int processor_count)
@@ -1430,6 +1635,11 @@ int totemiba_processor_count_set (
 	return (res);
 }
 
+/**
+ * @brief totemiba_recv_flush
+ * @param iba_context
+ * @return
+ */
 int totemiba_recv_flush (void *iba_context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)iba_context;
@@ -1440,6 +1650,11 @@ int totemiba_recv_flush (void *iba_context)
 	return (res);
 }
 
+/**
+ * @brief totemiba_send_flush
+ * @param iba_context
+ * @return
+ */
 int totemiba_send_flush (void *iba_context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)iba_context;
@@ -1450,6 +1665,13 @@ int totemiba_send_flush (void *iba_context)
 	return (res);
 }
 
+/**
+ * @brief totemiba_token_send
+ * @param iba_context
+ * @param ms
+ * @param msg_len
+ * @return
+ */
 int totemiba_token_send (
 	void *iba_context,
 	const void *ms,
@@ -1490,6 +1712,13 @@ int totemiba_token_send (
 	return (res);
 }
 
+/**
+ * @brief totemiba_mcast_flush_send
+ * @param iba_context
+ * @param ms
+ * @param msg_len
+ * @return
+ */
 int totemiba_mcast_flush_send (
 	void *iba_context,
 	const void *ms,
@@ -1531,6 +1760,13 @@ int totemiba_mcast_flush_send (
 	return (res);
 }
 
+/**
+ * @brief totemiba_mcast_noflush_send
+ * @param iba_context
+ * @param ms
+ * @param msg_len
+ * @return
+ */
 int totemiba_mcast_noflush_send (
 	void *iba_context,
 	const void *ms,
@@ -1572,6 +1808,11 @@ int totemiba_mcast_noflush_send (
 	return (res);
 }
 
+/**
+ * @brief totemiba_iface_check
+ * @param iba_context
+ * @return
+ */
 extern int totemiba_iface_check (void *iba_context)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)iba_context;
@@ -1582,12 +1823,22 @@ extern int totemiba_iface_check (void *iba_context)
 	return (res);
 }
 
+/**
+ * @brief totemiba_net_mtu_adjust
+ * @param iba_context
+ * @param totem_config
+ */
 extern void totemiba_net_mtu_adjust (void *iba_context, struct totem_config *totem_config)
 {
 	struct totemiba_instance *instance = (struct totemiba_instance *)iba_context;
 	instance = NULL;
 }
 
+/**
+ * @brief totemiba_iface_print
+ * @param iba_context
+ * @return
+ */
 const char *totemiba_iface_print (void *iba_context)  {
 	struct totemiba_instance *instance = (struct totemiba_instance *)iba_context;
 
@@ -1598,6 +1849,12 @@ const char *totemiba_iface_print (void *iba_context)  {
         return (ret_char);
 }
 
+/**
+ * @brief totemiba_iface_get
+ * @param iba_context
+ * @param addr
+ * @return
+ */
 int totemiba_iface_get (
 	void *iba_context,
 	struct totem_ip_address *addr)
@@ -1610,6 +1867,12 @@ int totemiba_iface_get (
 	return (res);
 }
 
+/**
+ * @brief totemiba_token_target_set
+ * @param iba_context
+ * @param token_target
+ * @return
+ */
 int totemiba_token_target_set (
 	void *iba_context,
 	const struct totem_ip_address *token_target)
@@ -1629,6 +1892,11 @@ int totemiba_token_target_set (
 	return (res);
 }
 
+/**
+ * @brief totemiba_recv_mcast_empty
+ * @param iba_context
+ * @return
+ */
 extern int totemiba_recv_mcast_empty (
 	void *iba_context)
 {

--- a/exec/totemip.c
+++ b/exec/totemip.c
@@ -68,6 +68,12 @@ void totemip_nosigpipe(int s)
 #endif
 
 /* Compare two addresses */
+/**
+ * @brief totemip_equal
+ * @param addr1
+ * @param addr2
+ * @return
+ */
 int totemip_equal(const struct totem_ip_address *addr1,
 		  const struct totem_ip_address *addr2)
 {
@@ -92,12 +98,22 @@ int totemip_equal(const struct totem_ip_address *addr1,
 }
 
 /* Copy a totem_ip_address */
+/**
+ * @brief totemip_copy
+ * @param addr1
+ * @param addr2
+ */
 void totemip_copy(struct totem_ip_address *addr1,
 		  const struct totem_ip_address *addr2)
 {
 	memcpy(addr1, addr2, sizeof(struct totem_ip_address));
 }
 
+/**
+ * @brief totemip_copy_endian_convert
+ * @param addr1
+ * @param addr2
+ */
 void totemip_copy_endian_convert(struct totem_ip_address *addr1,
 				 const struct totem_ip_address *addr2)
 {
@@ -110,6 +126,11 @@ void totemip_copy_endian_convert(struct totem_ip_address *addr1,
  * Multicast address range is 224.0.0.0 to 239.255.255.255 this
  * translates to the first 4 bits == 1110 (0xE).
  * http://en.wikipedia.org/wiki/Multicast_address
+ */
+/**
+ * @brief totemip_is_mcast
+ * @param ip_addr
+ * @return
  */
 int32_t totemip_is_mcast(struct totem_ip_address *ip_addr)
 {
@@ -127,6 +148,12 @@ int32_t totemip_is_mcast(struct totem_ip_address *ip_addr)
 }
 
 /* For sorting etc. params are void * for qsort's benefit */
+/**
+ * @brief totemip_compare
+ * @param a
+ * @param b
+ * @return
+ */
 int totemip_compare(const void *a, const void *b)
 {
 	int i;
@@ -179,6 +206,12 @@ int totemip_compare(const void *a, const void *b)
 }
 
 /* Build a localhost totem_ip_address */
+/**
+ * @brief totemip_localhost
+ * @param family
+ * @param localhost
+ * @return
+ */
 int totemip_localhost(int family, struct totem_ip_address *localhost)
 {
 	const char *addr_text;
@@ -202,6 +235,11 @@ int totemip_localhost(int family, struct totem_ip_address *localhost)
 	return 0;
 }
 
+/**
+ * @brief totemip_localhost_check
+ * @param addr
+ * @return
+ */
 int totemip_localhost_check(const struct totem_ip_address *addr)
 {
 	struct totem_ip_address localhost;
@@ -211,6 +249,11 @@ int totemip_localhost_check(const struct totem_ip_address *addr)
 	return totemip_equal(addr, &localhost);
 }
 
+/**
+ * @brief totemip_print
+ * @param addr
+ * @return
+ */
 const char *totemip_print(const struct totem_ip_address *addr)
 {
 	static char buf[INET6_ADDRSTRLEN];
@@ -219,6 +262,14 @@ const char *totemip_print(const struct totem_ip_address *addr)
 }
 
 /* Make a totem_ip_address into a usable sockaddr_storage */
+/**
+ * @brief totemip_totemip_to_sockaddr_convert
+ * @param ip_addr
+ * @param port
+ * @param saddr
+ * @param addrlen
+ * @return
+ */
 int totemip_totemip_to_sockaddr_convert(struct totem_ip_address *ip_addr,
 					uint16_t port, struct sockaddr_storage *saddr, int *addrlen)
 {
@@ -260,6 +311,13 @@ int totemip_totemip_to_sockaddr_convert(struct totem_ip_address *ip_addr,
 /* Converts an address string string into a totem_ip_address.
    family can be AF_INET, AF_INET6 or 0 ("for "don't care")
 */
+/**
+ * @brief totemip_parse
+ * @param totemip
+ * @param addr
+ * @param family
+ * @return
+ */
 int totemip_parse(struct totem_ip_address *totemip, const char *addr, int family)
 {
 	struct addrinfo *ainfo;
@@ -292,6 +350,12 @@ int totemip_parse(struct totem_ip_address *totemip, const char *addr, int family
 }
 
 /* Make a sockaddr_* into a totem_ip_address */
+/**
+ * @brief totemip_sockaddr_to_totemip_convert
+ * @param saddr
+ * @param ip_addr
+ * @return
+ */
 int totemip_sockaddr_to_totemip_convert(const struct sockaddr_storage *saddr,
 					struct totem_ip_address *ip_addr)
 {
@@ -318,6 +382,11 @@ int totemip_sockaddr_to_totemip_convert(const struct sockaddr_storage *saddr,
 	return ret;
 }
 
+/**
+ * @brief totemip_getifaddrs
+ * @param addrs
+ * @return
+ */
 int totemip_getifaddrs(struct list_head *addrs)
 {
 	struct ifaddrs *ifap, *ifa;
@@ -386,6 +455,10 @@ error_free_ifaddrs:
 	return (-1);
 }
 
+/**
+ * @brief totemip_freeifaddrs
+ * @param addrs
+ */
 void totemip_freeifaddrs(struct list_head *addrs)
 {
 	struct totem_ip_if_address *if_addr;
@@ -402,6 +475,15 @@ void totemip_freeifaddrs(struct list_head *addrs)
 	list_init(addrs);
 }
 
+/**
+ * @brief totemip_iface_check
+ * @param bindnet
+ * @param boundto
+ * @param interface_up
+ * @param interface_num
+ * @param mask_high_bit
+ * @return
+ */
 int totemip_iface_check(struct totem_ip_address *bindnet,
 			struct totem_ip_address *boundto,
 			int *interface_up,
@@ -493,6 +575,11 @@ finished:
 #define TOTEMIP_IPV4_HEADER_SIZE	20
 #define TOTEMIP_IPV6_HEADER_SIZE	40
 
+/**
+ * @brief totemip_udpip_header_size
+ * @param family
+ * @return
+ */
 size_t totemip_udpip_header_size(int family)
 {
 	size_t header_size;

--- a/exec/totemmrp.c
+++ b/exec/totemmrp.c
@@ -63,12 +63,30 @@
 
 void *totemsrp_context;
 
+/**
+ * @brief totemmrp_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 void totemmrp_deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
 	unsigned int msg_len,
 	int endian_conversion_required);
 
+/**
+ * @brief totemmrp_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 void totemmrp_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -76,12 +94,18 @@ void totemmrp_confchg_fn (
 	const unsigned int *joined_list, size_t joined_list_entries,
 	const struct memb_ring_id *ring_id);
 
+/**
+ *
+ */
 void (*pg_deliver_fn) (
 	unsigned int nodeid,
 	const void *msg,
 	unsigned int msg_len,
 	int endian_conversion_required) = 0;
 
+/**
+ *
+ */
 void (*pg_confchg_fn) (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -89,6 +113,13 @@ void (*pg_confchg_fn) (
 	const unsigned int *joined_list, size_t joined_list_entries,
 	const struct memb_ring_id *ring_id) = 0;
 
+/**
+ * @brief totemmrp_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 void totemmrp_deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
@@ -98,6 +129,17 @@ void totemmrp_deliver_fn (
 	pg_deliver_fn (nodeid, msg, msg_len, endian_conversion_required);
 }
 
+/**
+ * @brief totemmrp_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 void totemmrp_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -114,6 +156,13 @@ void totemmrp_confchg_fn (
 
 /*
  * Initialize the totem multiple ring protocol
+ */
+/**
+ * @brief totemmrp_initialize
+ * @param poll_handle
+ * @param totem_config
+ * @param stats
+ * @return
  */
 int totemmrp_initialize (
 	qb_loop_t *poll_handle,
@@ -151,6 +200,9 @@ int totemmrp_initialize (
 	return (result);
 }
 
+/**
+ * @brief totemmrp_finalize
+ */
 void totemmrp_finalize (void)
 {
 	totemsrp_finalize (totemsrp_context);
@@ -158,6 +210,13 @@ void totemmrp_finalize (void)
 
 /*
  * Multicast a message
+ */
+/**
+ * @brief totemmrp_mcast
+ * @param iovec
+ * @param iov_len
+ * @param priority
+ * @return
  */
 int totemmrp_mcast (
 	struct iovec *iovec,
@@ -169,6 +228,10 @@ int totemmrp_mcast (
 
 /*
  * Return number of available messages that can be queued
+ */
+/**
+ * @brief totemmrp_avail
+ * @return
  */
 int totemmrp_avail (void)
 {
@@ -185,17 +248,35 @@ int totemmrp_callback_token_create (
 	return totemsrp_callback_token_create (totemsrp_context, handle_out, type, delete, callback_fn, data);
 }
 
+/**
+ * @brief totemmrp_callback_token_destroy
+ * @param handle_out
+ */
 void totemmrp_callback_token_destroy (
 	void *handle_out)
 {
 	totemsrp_callback_token_destroy (totemsrp_context, handle_out);
 }
 
+/**
+ * @brief totemmrp_event_signal
+ * @param type
+ * @param value
+ */
 void totemmrp_event_signal (enum totem_event_type type, int value)
 {
 	totemsrp_event_signal (totemsrp_context, type, value);
 }
 
+/**
+ * @brief totemmrp_ifaces_get
+ * @param nodeid
+ * @param interfaces
+ * @param interfaces_size
+ * @param status
+ * @param iface_count
+ * @return
+ */
 int totemmrp_ifaces_get (
 	unsigned int nodeid,
 	struct totem_ip_address *interfaces,
@@ -216,6 +297,12 @@ int totemmrp_ifaces_get (
 	return (res);
 }
 
+/**
+ * @brief totemmrp_crypto_set
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemmrp_crypto_set (
 	const char *cipher_type,
 	const char *hash_type)
@@ -225,16 +312,28 @@ int totemmrp_crypto_set (
 				    hash_type);
 }
 
+/**
+ * @brief totemmrp_my_nodeid_get
+ * @return
+ */
 unsigned int totemmrp_my_nodeid_get (void)
 {
 	return (totemsrp_my_nodeid_get (totemsrp_context));
 }
 
+/**
+ * @brief totemmrp_my_family_get
+ * @return
+ */
 int totemmrp_my_family_get (void)
 {
 	return (totemsrp_my_family_get (totemsrp_context));
 }
 
+/**
+ * @brief totemmrp_ring_reenable
+ * @return
+ */
 extern int totemmrp_ring_reenable (void)
 {
 	int res;
@@ -245,6 +344,9 @@ extern int totemmrp_ring_reenable (void)
 	return (res);
 }
 
+/**
+ * @brief totemmrp_service_ready_register
+ */
 extern void totemmrp_service_ready_register (
         void (*totem_service_ready) (void))
 {
@@ -253,6 +355,12 @@ extern void totemmrp_service_ready_register (
 		totem_service_ready);
 }
 
+/**
+ * @brief totemmrp_member_add
+ * @param member
+ * @param ring_no
+ * @return
+ */
 int totemmrp_member_add (
         const struct totem_ip_address *member,
         int ring_no)
@@ -264,6 +372,12 @@ int totemmrp_member_add (
 	return (res);
 }
 
+/**
+ * @brief totemmrp_member_remove
+ * @param member
+ * @param ring_no
+ * @return
+ */
 int totemmrp_member_remove (
        const struct totem_ip_address *member,
         int ring_no)
@@ -275,11 +389,17 @@ int totemmrp_member_remove (
 	return (res);
 }
 
+/**
+ * @brief totemmrp_threaded_mode_enable
+ */
 void totemmrp_threaded_mode_enable (void)
 {
 	totemsrp_threaded_mode_enable (totemsrp_context);
 }
 
+/**
+ * @brief totemmrp_trans_ack
+ */
 void totemmrp_trans_ack (void)
 {
 	totemsrp_trans_ack (totemsrp_context);

--- a/exec/totemnet.c
+++ b/exec/totemnet.c
@@ -48,6 +48,9 @@
 #define LOGSYS_UTILS_ONLY 1
 #include <corosync/logsys.h>
 
+/**
+ * @brief The transport struct
+ */
 struct transport {
 	const char *name;
 	
@@ -205,7 +208,10 @@ struct transport transport_entries[] = {
 	}
 #endif
 };
-	
+
+/**
+ * @brief The totemnet_instance struct
+ */
 struct totemnet_instance {
 	void *transport_context;
 
@@ -232,6 +238,11 @@ do {									\
 		(const char *)format, ##args);				\
 } while (0);
 
+/**
+ * @brief totemnet_instance_initialize
+ * @param instance
+ * @param config
+ */
 static void totemnet_instance_initialize (
 	struct totemnet_instance *instance,
 	struct totem_config *config)
@@ -250,6 +261,13 @@ static void totemnet_instance_initialize (
 	instance->transport = &transport_entries[transport];
 }
 
+/**
+ * @brief totemnet_crypto_set
+ * @param net_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemnet_crypto_set (
 	void *net_context,
 	const char *cipher_type,
@@ -264,6 +282,11 @@ int totemnet_crypto_set (
 	return res;
 }
 
+/**
+ * @brief totemnet_finalize
+ * @param net_context
+ * @return
+ */
 int totemnet_finalize (
 	void *net_context)
 {
@@ -275,6 +298,16 @@ int totemnet_finalize (
 	return (res);
 }
 
+/**
+ * @brief totemnet_initialize
+ * @param loop_pt
+ * @param net_context
+ * @param totem_config
+ * @param stats
+ * @param interface_no
+ * @param context
+ * @return
+ */
 int totemnet_initialize (
 	qb_loop_t *loop_pt,
 	void **net_context,
@@ -320,6 +353,11 @@ error_destroy:
 	return (-1);
 }
 
+/**
+ * @brief totemnet_buffer_alloc
+ * @param net_context
+ * @return
+ */
 void *totemnet_buffer_alloc (void *net_context)
 {
 	struct totemnet_instance *instance = net_context;
@@ -328,6 +366,11 @@ void *totemnet_buffer_alloc (void *net_context)
 	return instance->transport->buffer_alloc();
 }
 
+/**
+ * @brief totemnet_buffer_release
+ * @param net_context
+ * @param ptr
+ */
 void totemnet_buffer_release (void *net_context, void *ptr)
 {
 	struct totemnet_instance *instance = net_context;
@@ -336,6 +379,12 @@ void totemnet_buffer_release (void *net_context, void *ptr)
 	instance->transport->buffer_release (ptr);
 }
 
+/**
+ * @brief totemnet_processor_count_set
+ * @param net_context
+ * @param processor_count
+ * @return
+ */
 int totemnet_processor_count_set (
 	void *net_context,
 	int processor_count)
@@ -347,6 +396,11 @@ int totemnet_processor_count_set (
 	return (res);
 }
 
+/**
+ * @brief totemnet_recv_flush
+ * @param net_context
+ * @return
+ */
 int totemnet_recv_flush (void *net_context)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
@@ -357,6 +411,11 @@ int totemnet_recv_flush (void *net_context)
 	return (res);
 }
 
+/**
+ * @brief totemnet_send_flush
+ * @param net_context
+ * @return
+ */
 int totemnet_send_flush (void *net_context)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
@@ -367,6 +426,13 @@ int totemnet_send_flush (void *net_context)
 	return (res);
 }
 
+/**
+ * @brief totemnet_token_send
+ * @param net_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemnet_token_send (
 	void *net_context,
 	const void *msg,
@@ -379,6 +445,14 @@ int totemnet_token_send (
 
 	return (res);
 }
+
+/**
+ * @brief totemnet_mcast_flush_send
+ * @param net_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemnet_mcast_flush_send (
 	void *net_context,
 	const void *msg,
@@ -392,6 +466,13 @@ int totemnet_mcast_flush_send (
 	return (res);
 }
 
+/**
+ * @brief totemnet_mcast_noflush_send
+ * @param net_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemnet_mcast_noflush_send (
 	void *net_context,
 	const void *msg,
@@ -405,6 +486,11 @@ int totemnet_mcast_noflush_send (
 	return (res);
 }
 
+/**
+ * @brief totemnet_iface_check
+ * @param net_context
+ * @return
+ */
 extern int totemnet_iface_check (void *net_context)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
@@ -415,6 +501,12 @@ extern int totemnet_iface_check (void *net_context)
 	return (res);
 }
 
+/**
+ * @brief totemnet_net_mtu_adjust
+ * @param net_context
+ * @param totem_config
+ * @return
+ */
 extern int totemnet_net_mtu_adjust (void *net_context, struct totem_config *totem_config)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
@@ -424,6 +516,11 @@ extern int totemnet_net_mtu_adjust (void *net_context, struct totem_config *tote
 	return (res);
 }
 
+/**
+ * @brief totemnet_iface_print
+ * @param net_context
+ * @return
+ */
 const char *totemnet_iface_print (void *net_context)  {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
 	const char *ret_char;
@@ -432,6 +529,12 @@ const char *totemnet_iface_print (void *net_context)  {
 	return (ret_char);
 }
 
+/**
+ * @brief totemnet_iface_get
+ * @param net_context
+ * @param addr
+ * @return
+ */
 int totemnet_iface_get (
 	void *net_context,
 	struct totem_ip_address *addr)
@@ -444,6 +547,12 @@ int totemnet_iface_get (
 	return (res);
 }
 
+/**
+ * @brief totemnet_token_target_set
+ * @param net_context
+ * @param token_target
+ * @return
+ */
 int totemnet_token_target_set (
 	void *net_context,
 	const struct totem_ip_address *token_target)
@@ -456,6 +565,11 @@ int totemnet_token_target_set (
 	return (res);
 }
 
+/**
+ * @brief totemnet_recv_mcast_empty
+ * @param net_context
+ * @return
+ */
 extern int totemnet_recv_mcast_empty (
 	void *net_context)
 {
@@ -467,6 +581,12 @@ extern int totemnet_recv_mcast_empty (
 	return (res);
 }
 
+/**
+ * @brief totemnet_member_add
+ * @param net_context
+ * @param member
+ * @return
+ */
 extern int totemnet_member_add (
 	void *net_context,
 	const struct totem_ip_address *member)
@@ -483,6 +603,12 @@ extern int totemnet_member_add (
 	return (res);
 }
 
+/**
+ * @brief totemnet_member_remove
+ * @param net_context
+ * @param member
+ * @return
+ */
 extern int totemnet_member_remove (
 	void *net_context,
 	const struct totem_ip_address *member)
@@ -499,6 +625,13 @@ extern int totemnet_member_remove (
 	return (res);
 }
 
+/**
+ * @brief totemnet_member_set_active
+ * @param net_context
+ * @param member
+ * @param active
+ * @return
+ */
 int totemnet_member_set_active (
 	void *net_context,
 	const struct totem_ip_address *member,

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -281,12 +281,21 @@ static int msg_count_send_ok (int msg_count);
 
 static int byte_count_send_ok (int byte_count);
 
+/**
+ * @brief totempg_waiting_trans_ack_cb
+ * @param waiting_trans_ack
+ */
 static void totempg_waiting_trans_ack_cb (int waiting_trans_ack)
 {
 	log_printf(LOG_DEBUG, "waiting_trans_ack changed to %u", waiting_trans_ack);
 	totempg_waiting_transack = waiting_trans_ack;
 }
 
+/**
+ * @brief assembly_ref
+ * @param nodeid
+ * @return
+ */
 static struct assembly *assembly_ref (unsigned int nodeid)
 {
 	struct assembly *assembly;
@@ -346,6 +355,10 @@ static struct assembly *assembly_ref (unsigned int nodeid)
 	return (assembly);
 }
 
+/**
+ * @brief assembly_deref
+ * @param assembly
+ */
 static void assembly_deref (struct assembly *assembly)
 {
 
@@ -353,6 +366,10 @@ static void assembly_deref (struct assembly *assembly)
 	list_add (&assembly->list, &assembly_list_free);
 }
 
+/**
+ * @brief assembly_deref_from_normal_and_trans
+ * @param nodeid
+ */
 static void assembly_deref_from_normal_and_trans (int nodeid)
 {
 	int j;
@@ -383,6 +400,17 @@ static void assembly_deref_from_normal_and_trans (int nodeid)
 
 }
 
+/**
+ * @brief app_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static inline void app_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -423,6 +451,11 @@ static inline void app_confchg_fn (
 	}
 }
 
+/**
+ * @brief group_endian_convert
+ * @param msg
+ * @param msg_len
+ */
 static inline void group_endian_convert (
 	void *msg,
 	int msg_len)
@@ -456,6 +489,15 @@ static inline void group_endian_convert (
 	}
 }
 
+/**
+ * @brief group_matches
+ * @param iovec
+ * @param iov_len
+ * @param groups_b
+ * @param group_b_cnt
+ * @param adjust_iovec
+ * @return
+ */
 static inline int group_matches (
 	struct iovec *iovec,
 	unsigned int iov_len,
@@ -514,6 +556,13 @@ static inline int group_matches (
 }
 
 
+/**
+ * @brief app_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static inline void app_deliver_fn (
 	unsigned int nodeid,
 	void *msg,
@@ -585,6 +634,17 @@ static inline void app_deliver_fn (
 	}
 }
 
+/**
+ * @brief totempg_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void totempg_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -600,6 +660,13 @@ static void totempg_confchg_fn (
 		ring_id);
 }
 
+/**
+ * @brief totempg_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static void totempg_deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
@@ -728,8 +795,17 @@ static void totempg_deliver_fn (
  * depends on poll abstraction, POSIX, IPV4
  */
 
+/**
+ * @brief callback_token_received_handle
+ */
 void *callback_token_received_handle;
 
+/**
+ * @brief callback_token_received_fn
+ * @param type
+ * @param data
+ * @return
+ */
 int callback_token_received_fn (enum totem_callback_token_type type,
 				const void *data)
 {
@@ -784,6 +860,12 @@ int callback_token_received_fn (enum totem_callback_token_type type,
 /*
  * Initialize the totem process group abstraction
  */
+/**
+ * @brief totempg_initialize
+ * @param poll_handle
+ * @param totem_config
+ * @return
+ */
 int totempg_initialize (
 	qb_loop_t *poll_handle,
 	struct totem_config *totem_config)
@@ -830,6 +912,9 @@ int totempg_initialize (
 	return (res);
 }
 
+/**
+ * @brief totempg_finalize
+ */
 void totempg_finalize (void)
 {
 	if (totempg_threaded_mode == 1) {
@@ -843,6 +928,13 @@ void totempg_finalize (void)
 
 /*
  * Multicast a message
+ */
+/**
+ * @brief mcast_msg
+ * @param iovec_in
+ * @param iov_len
+ * @param guarantee
+ * @return
  */
 static int mcast_msg (
 	struct iovec *iovec_in,
@@ -1021,6 +1113,11 @@ error_exit:
 /*
  * Determine if a message of msg_size could be queued
  */
+/**
+ * @brief msg_count_send_ok
+ * @param msg_count
+ * @return
+ */
 static int msg_count_send_ok (
 	int msg_count)
 {
@@ -1032,6 +1129,11 @@ static int msg_count_send_ok (
 	return ((avail - totempg_reserved) > msg_count);
 }
 
+/**
+ * @brief byte_count_send_ok
+ * @param byte_count
+ * @return
+ */
 static int byte_count_send_ok (
 	int byte_count)
 {
@@ -1045,6 +1147,11 @@ static int byte_count_send_ok (
 	return (avail >= msg_count);
 }
 
+/**
+ * @brief send_reserve
+ * @param msg_size
+ * @return
+ */
 static int send_reserve (
 	int msg_size)
 {
@@ -1057,6 +1164,10 @@ static int send_reserve (
 	return (msg_count);
 }
 
+/**
+ * @brief send_release
+ * @param msg_count
+ */
 static void send_release (
 	int msg_count)
 {
@@ -1069,6 +1180,10 @@ static void send_release (
 #define MESSAGE_QUEUE_MAX	((4 * MESSAGE_SIZE_MAX) / totempg_totem_config->net_mtu)
 #endif /* HAVE_SMALL_MEMORY_FOOTPRINT */
 
+/**
+ * @brief q_level_precent_used
+ * @return
+ */
 static uint32_t q_level_precent_used(void)
 {
 	return (100 - (((totemmrp_avail() - totempg_reserved) * 100) / MESSAGE_QUEUE_MAX));
@@ -1093,6 +1208,10 @@ int totempg_callback_token_create (
 	return (res);
 }
 
+/**
+ * @brief totempg_callback_token_destroy
+ * @param handle_out
+ */
 void totempg_callback_token_destroy (
 	void *handle_out)
 {
@@ -1105,10 +1224,11 @@ void totempg_callback_token_destroy (
 	}
 }
 
-/*
- *	vi: set autoindent tabstop=4 shiftwidth=4 :
+/**
+ * @brief totempg_groups_initialize
+ * @param totempg_groups_instance
+ * @return
  */
-
 int totempg_groups_initialize (
 	void **totempg_groups_instance,
 
@@ -1157,6 +1277,13 @@ error_exit:
 	return (-1);
 }
 
+/**
+ * @brief totempg_groups_join
+ * @param totempg_groups_instance
+ * @param groups
+ * @param group_cnt
+ * @return
+ */
 int totempg_groups_join (
 	void *totempg_groups_instance,
 	const struct totempg_group *groups,
@@ -1189,6 +1316,13 @@ error_exit:
 	return (res);
 }
 
+/**
+ * @brief totempg_groups_leave
+ * @param totempg_groups_instance
+ * @param groups
+ * @param group_cnt
+ * @return
+ */
 int totempg_groups_leave (
 	void *totempg_groups_instance,
 	const struct totempg_group *groups,
@@ -1207,6 +1341,14 @@ int totempg_groups_leave (
 #define MAX_IOVECS_FROM_APP 32
 #define MAX_GROUPS_PER_MSG 32
 
+/**
+ * @brief totempg_groups_mcast_joined
+ * @param totempg_groups_instance
+ * @param iovec
+ * @param iov_len
+ * @param guarantee
+ * @return
+ */
 int totempg_groups_mcast_joined (
 	void *totempg_groups_instance,
 	const struct iovec *iovec,
@@ -1248,6 +1390,10 @@ int totempg_groups_mcast_joined (
 	return (res);
 }
 
+/**
+ * @brief check_q_level
+ * @param totempg_groups_instance
+ */
 static void check_q_level(
 	void *totempg_groups_instance)
 {
@@ -1269,6 +1415,10 @@ static void check_q_level(
 	}
 }
 
+/**
+ * @brief totempg_check_q_level
+ * @param totempg_groups_instance
+ */
 void totempg_check_q_level(
 	void *totempg_groups_instance)
 {
@@ -1277,6 +1427,13 @@ void totempg_check_q_level(
 	check_q_level(instance);
 }
 
+/**
+ * @brief totempg_groups_joined_reserve
+ * @param totempg_groups_instance
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 int totempg_groups_joined_reserve (
 	void *totempg_groups_instance,
 	const struct iovec *iovec,
@@ -1321,6 +1478,11 @@ error_exit:
 }
 
 
+/**
+ * @brief totempg_groups_joined_release
+ * @param msg_count
+ * @return
+ */
 int totempg_groups_joined_release (int msg_count)
 {
 	if (totempg_threaded_mode == 1) {
@@ -1335,6 +1497,16 @@ int totempg_groups_joined_release (int msg_count)
 	return 0;
 }
 
+/**
+ * @brief totempg_groups_mcast_groups
+ * @param totempg_groups_instance
+ * @param guarantee
+ * @param groups
+ * @param groups_cnt
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 int totempg_groups_mcast_groups (
 	void *totempg_groups_instance,
 	int guarantee,
@@ -1379,6 +1551,15 @@ int totempg_groups_mcast_groups (
 /*
  * Returns -1 if error, 0 if can't send, 1 if can send the message
  */
+/**
+ * @brief totempg_groups_send_ok_groups
+ * @param totempg_groups_instance
+ * @param groups
+ * @param groups_cnt
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 int totempg_groups_send_ok_groups (
 	void *totempg_groups_instance,
 	const struct totempg_group *groups,
@@ -1409,6 +1590,15 @@ int totempg_groups_send_ok_groups (
 	return (res);
 }
 
+/**
+ * @brief totempg_ifaces_get
+ * @param nodeid
+ * @param interfaces
+ * @param interfaces_size
+ * @param status
+ * @param iface_count
+ * @return
+ */
 int totempg_ifaces_get (
 	unsigned int nodeid,
 	struct totem_ip_address *interfaces,
@@ -1428,16 +1618,31 @@ int totempg_ifaces_get (
 	return (res);
 }
 
+/**
+ * @brief totempg_event_signal
+ * @param type
+ * @param value
+ */
 void totempg_event_signal (enum totem_event_type type, int value)
 {
 	totemmrp_event_signal (type, value);
 }
 
+/**
+ * @brief totempg_get_stats
+ * @return
+ */
 void* totempg_get_stats (void)
 {
 	return &totempg_stats;
 }
 
+/**
+ * @brief totempg_crypto_set
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totempg_crypto_set (
 	const char *cipher_type,
 	const char *hash_type)
@@ -1449,6 +1654,10 @@ int totempg_crypto_set (
 	return (res);
 }
 
+/**
+ * @brief totempg_ring_reenable
+ * @return
+ */
 int totempg_ring_reenable (void)
 {
 	int res;
@@ -1459,6 +1668,11 @@ int totempg_ring_reenable (void)
 }
 
 #define ONE_IFACE_LEN 63
+/**
+ * @brief totempg_ifaces_print
+ * @param nodeid
+ * @return
+ */
 const char *totempg_ifaces_print (unsigned int nodeid)
 {
 	static char iface_string[256 * INTERFACE_MAX];
@@ -1487,26 +1701,48 @@ const char *totempg_ifaces_print (unsigned int nodeid)
 	return (iface_string);
 }
 
+/**
+ * @brief totempg_my_nodeid_get
+ * @return
+ */
 unsigned int totempg_my_nodeid_get (void)
 {
 	return (totemmrp_my_nodeid_get());
 }
 
+/**
+ * @brief totempg_my_family_get
+ * @return
+ */
 int totempg_my_family_get (void)
 {
 	return (totemmrp_my_family_get());
 }
+
+/**
+ * @brief totempg_service_ready_register
+ */
 extern void totempg_service_ready_register (
 	void (*totem_service_ready) (void))
 {
 	totemmrp_service_ready_register (totem_service_ready);
 }
 
+/**
+ * @brief totempg_queue_level_register_callback
+ * @param fn
+ */
 void totempg_queue_level_register_callback (totem_queue_level_changed_fn fn)
 {
 	totem_queue_level_changed = fn;
 }
 
+/**
+ * @brief totempg_member_add
+ * @param member
+ * @param ring_no
+ * @return
+ */
 extern int totempg_member_add (
 	const struct totem_ip_address *member,
 	int ring_no)
@@ -1514,6 +1750,12 @@ extern int totempg_member_add (
 	return totemmrp_member_add (member, ring_no);
 }
 
+/**
+ * @brief totempg_member_remove
+ * @param member
+ * @param ring_no
+ * @return
+ */
 extern int totempg_member_remove (
 	const struct totem_ip_address *member,
 	int ring_no)
@@ -1521,12 +1763,18 @@ extern int totempg_member_remove (
 	return totemmrp_member_remove (member, ring_no);
 }
 
+/**
+ * @brief totempg_threaded_mode_enable
+ */
 void totempg_threaded_mode_enable (void)
 {
 	totempg_threaded_mode = 1;
 	totemmrp_threaded_mode_enable ();
 }
 
+/**
+ * @brief totempg_trans_ack
+ */
 void totempg_trans_ack (void)
 {
 	totemmrp_trans_ack ();

--- a/exec/totemrrp.c
+++ b/exec/totemrrp.c
@@ -639,12 +639,23 @@ do {								\
 		format, ##args);				\
 } while (0);
 
+/**
+ * @brief stats_set_interface_faulty
+ * @param rrp_instance
+ * @param iface_no
+ * @param is_faulty
+ */
 static void stats_set_interface_faulty(struct totemrrp_instance *rrp_instance,
 		unsigned int iface_no, int is_faulty)
 {
 	rrp_instance->stats.faulty[iface_no] = (is_faulty ? 1 : 0);
 }
 
+/**
+ * @brief test_active_msg_endian_convert
+ * @param in
+ * @param out
+ */
 static void test_active_msg_endian_convert(const struct message_header *in, struct message_header *out)
 {
 	out->type = in->type;
@@ -654,6 +665,10 @@ static void test_active_msg_endian_convert(const struct message_header *in, stru
 	out->nodeid_activator = swab32(in->nodeid_activator);
 }
 
+/**
+ * @brief timer_function_test_ring_timeout
+ * @param context
+ */
 static void timer_function_test_ring_timeout (void *context)
 {
 	struct deliver_fn_context *deliver_fn_context = (struct deliver_fn_context *)context;
@@ -691,6 +706,14 @@ static void timer_function_test_ring_timeout (void *context)
  * None Replication Implementation
  */
 
+/**
+ * @brief none_mcast_recv
+ * @param rrp_instance
+ * @param iface_no
+ * @param context
+ * @param msg
+ * @param msg_len
+ */
 static void none_mcast_recv (
 	struct totemrrp_instance *rrp_instance,
 	unsigned int iface_no,
@@ -704,6 +727,12 @@ static void none_mcast_recv (
 		msg_len);
 }
 
+/**
+ * @brief none_mcast_flush_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void none_mcast_flush_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -712,6 +741,12 @@ static void none_mcast_flush_send (
 	totemnet_mcast_flush_send (instance->net_handles[0], msg, msg_len);
 }
 
+/**
+ * @brief none_mcast_noflush_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void none_mcast_noflush_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -720,6 +755,15 @@ static void none_mcast_noflush_send (
 	totemnet_mcast_noflush_send (instance->net_handles[0], msg, msg_len);
 }
 
+/**
+ * @brief none_token_recv
+ * @param rrp_instance
+ * @param iface_no
+ * @param context
+ * @param msg
+ * @param msg_len
+ * @param token_seq
+ */
 static void none_token_recv (
 	struct totemrrp_instance *rrp_instance,
 	unsigned int iface_no,
@@ -734,6 +778,12 @@ static void none_token_recv (
 		msg_len);
 }
 
+/**
+ * @brief none_token_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void none_token_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -744,21 +794,38 @@ static void none_token_send (
 		msg, msg_len);
 }
 
+/**
+ * @brief none_recv_flush
+ * @param instance
+ */
 static void none_recv_flush (struct totemrrp_instance *instance)
 {
 	totemnet_recv_flush (instance->net_handles[0]);
 }
 
+/**
+ * @brief none_send_flush
+ * @param instance
+ */
 static void none_send_flush (struct totemrrp_instance *instance)
 {
 	totemnet_send_flush (instance->net_handles[0]);
 }
 
+/**
+ * @brief none_iface_check
+ * @param instance
+ */
 static void none_iface_check (struct totemrrp_instance *instance)
 {
 	totemnet_iface_check (instance->net_handles[0]);
 }
 
+/**
+ * @brief none_processor_count_set
+ * @param instance
+ * @param processor_count
+ */
 static void none_processor_count_set (
 	struct totemrrp_instance *instance,
 	unsigned int processor_count)
@@ -767,6 +834,12 @@ static void none_processor_count_set (
 		processor_count);
 }
 
+/**
+ * @brief none_token_target_set
+ * @param instance
+ * @param token_target
+ * @param iface_no
+ */
 static void none_token_target_set (
 	struct totemrrp_instance *instance,
 	struct totem_ip_address *token_target,
@@ -775,6 +848,11 @@ static void none_token_target_set (
 	totemnet_token_target_set (instance->net_handles[0], token_target);
 }
 
+/**
+ * @brief none_ring_reenable
+ * @param instance
+ * @param iface_no
+ */
 static void none_ring_reenable (
 	struct totemrrp_instance *instance,
 	unsigned int iface_no)
@@ -784,6 +862,11 @@ static void none_ring_reenable (
 	 */
 }
 
+/**
+ * @brief none_mcast_recv_empty
+ * @param instance
+ * @return
+ */
 static int none_mcast_recv_empty (
 	struct totemrrp_instance *instance)
 {
@@ -794,6 +877,13 @@ static int none_mcast_recv_empty (
 	return (res);
 }
 
+/**
+ * @brief none_member_add
+ * @param instance
+ * @param member
+ * @param iface_no
+ * @return
+ */
 static int none_member_add (
 	struct totemrrp_instance *instance,
 	const struct totem_ip_address *member,
@@ -804,6 +894,13 @@ static int none_member_add (
 	return (res);
 }
 
+/**
+ * @brief none_member_remove
+ * @param instance
+ * @param member
+ * @param iface_no
+ * @return
+ */
 static int none_member_remove (
 	struct totemrrp_instance *instance,
 	const struct totem_ip_address *member,
@@ -814,6 +911,18 @@ static int none_member_remove (
 	return (res);
 }
 
+/**
+ * @brief none_membership_changed
+ * @param rrp_instance
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void none_membership_changed (
 	struct totemrrp_instance *rrp_instance,
 	enum totem_configuration_type configuration_type,
@@ -851,6 +960,12 @@ static void none_membership_changed (
 
 /*
  * Passive Replication Implementation
+ */
+/**
+ * @brief passive_instance_initialize
+ * @param rrp_instance
+ * @param interface_count
+ * @return
  */
 void *passive_instance_initialize (
 	struct totemrrp_instance *rrp_instance,
@@ -900,6 +1015,10 @@ error_exit:
 	return ((void *)instance);
 }
 
+/**
+ * @brief timer_function_passive_token_expired
+ * @param context
+ */
 static void timer_function_passive_token_expired (void *context)
 {
 	struct passive_instance *passive_instance = (struct passive_instance *)context;
@@ -921,6 +1040,10 @@ static void timer_function_passive_problem_decrementer (void *context)
 */
 
 
+/**
+ * @brief passive_timer_expired_token_start
+ * @param passive_instance
+ */
 static void passive_timer_expired_token_start (
 	struct passive_instance *passive_instance)
 {
@@ -933,6 +1056,10 @@ static void passive_timer_expired_token_start (
 		&passive_instance->timer_expired_token);
 }
 
+/**
+ * @brief passive_timer_expired_token_cancel
+ * @param passive_instance
+ */
 static void passive_timer_expired_token_cancel (
 	struct passive_instance *passive_instance)
 {
@@ -968,6 +1095,12 @@ static void passive_timer_problem_decrementer_cancel (
  * rrp_instance is passive rrp instance, iface_no is interface with received messgae/token and
  * is_token_recv_count is boolean variable which donates if message is token (>1) or regular
  * message (= 0)
+ */
+/**
+ * @brief passive_monitor
+ * @param rrp_instance
+ * @param iface_no
+ * @param is_token_recv_count
  */
 static void passive_monitor (
 	struct totemrrp_instance *rrp_instance,
@@ -1075,6 +1208,14 @@ static void passive_monitor (
 	}
 }
 
+/**
+ * @brief passive_mcast_recv
+ * @param rrp_instance
+ * @param iface_no
+ * @param context
+ * @param msg
+ * @param msg_len
+ */
 static void passive_mcast_recv (
 	struct totemrrp_instance *rrp_instance,
 	unsigned int iface_no,
@@ -1104,6 +1245,12 @@ static void passive_mcast_recv (
 	passive_monitor (rrp_instance, iface_no, 0);
 }
 
+/**
+ * @brief passive_mcast_flush_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void passive_mcast_flush_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -1122,6 +1269,12 @@ static void passive_mcast_flush_send (
 	}
 }
 
+/**
+ * @brief passive_mcast_noflush_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void passive_mcast_noflush_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -1140,6 +1293,15 @@ static void passive_mcast_noflush_send (
 	}
 }
 
+/**
+ * @brief passive_token_recv
+ * @param rrp_instance
+ * @param iface_no
+ * @param context
+ * @param msg
+ * @param msg_len
+ * @param token_seq
+ */
 static void passive_token_recv (
 	struct totemrrp_instance *rrp_instance,
 	unsigned int iface_no,
@@ -1166,6 +1328,12 @@ static void passive_token_recv (
 	passive_monitor (rrp_instance, iface_no, 1);
 }
 
+/**
+ * @brief passive_token_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void passive_token_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -1187,6 +1355,10 @@ static void passive_token_send (
 
 }
 
+/**
+ * @brief passive_recv_flush
+ * @param instance
+ */
 static void passive_recv_flush (struct totemrrp_instance *instance)
 {
 	struct passive_instance *rrp_algo_instance = (struct passive_instance *)instance->rrp_algo_instance;
@@ -1200,6 +1372,10 @@ static void passive_recv_flush (struct totemrrp_instance *instance)
 	}
 }
 
+/**
+ * @brief passive_send_flush
+ * @param instance
+ */
 static void passive_send_flush (struct totemrrp_instance *instance)
 {
 	struct passive_instance *rrp_algo_instance = (struct passive_instance *)instance->rrp_algo_instance;
@@ -1213,6 +1389,10 @@ static void passive_send_flush (struct totemrrp_instance *instance)
 	}
 }
 
+/**
+ * @brief passive_iface_check
+ * @param instance
+ */
 static void passive_iface_check (struct totemrrp_instance *instance)
 {
 	struct passive_instance *rrp_algo_instance = (struct passive_instance *)instance->rrp_algo_instance;
@@ -1226,6 +1406,11 @@ static void passive_iface_check (struct totemrrp_instance *instance)
 	}
 }
 
+/**
+ * @brief passive_processor_count_set
+ * @param instance
+ * @param processor_count
+ */
 static void passive_processor_count_set (
 	struct totemrrp_instance *instance,
 	unsigned int processor_count)
@@ -1242,6 +1427,12 @@ static void passive_processor_count_set (
 	}
 }
 
+/**
+ * @brief passive_token_target_set
+ * @param instance
+ * @param token_target
+ * @param iface_no
+ */
 static void passive_token_target_set (
 	struct totemrrp_instance *instance,
 	struct totem_ip_address *token_target,
@@ -1250,6 +1441,11 @@ static void passive_token_target_set (
 	totemnet_token_target_set (instance->net_handles[iface_no], token_target);
 }
 
+/**
+ * @brief passive_mcast_recv_empty
+ * @param instance
+ * @return
+ */
 static int passive_mcast_recv_empty (
 	struct totemrrp_instance *instance)
 {
@@ -1270,6 +1466,13 @@ static int passive_mcast_recv_empty (
 	return (msgs_emptied);
 }
 
+/**
+ * @brief passive_member_add
+ * @param instance
+ * @param member
+ * @param iface_no
+ * @return
+ */
 static int passive_member_add (
 	struct totemrrp_instance *instance,
 	const struct totem_ip_address *member,
@@ -1280,6 +1483,13 @@ static int passive_member_add (
 	return (res);
 }
 
+/**
+ * @brief passive_member_remove
+ * @param instance
+ * @param member
+ * @param iface_no
+ * @return
+ */
 static int passive_member_remove (
 	struct totemrrp_instance *instance,
 	const struct totem_ip_address *member,
@@ -1290,6 +1500,18 @@ static int passive_member_remove (
 	return (res);
 }
 
+/**
+ * @brief passive_membership_changed
+ * @param rrp_instance
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void passive_membership_changed (
 	struct totemrrp_instance *rrp_instance,
 	enum totem_configuration_type configuration_type,
@@ -1330,6 +1552,11 @@ static void passive_membership_changed (
 	}
 }
 
+/**
+ * @brief passive_ring_reenable
+ * @param instance
+ * @param iface_no
+ */
 static void passive_ring_reenable (
 	struct totemrrp_instance *instance,
 	unsigned int iface_no)
@@ -1356,6 +1583,13 @@ static void passive_ring_reenable (
 
 /*
  * Active Replication Implementation
+ */
+
+/**
+ * @brief active_instance_initialize
+ * @param rrp_instance
+ * @param interface_count
+ * @return
  */
 void *active_instance_initialize (
 	struct totemrrp_instance *rrp_instance,
@@ -1412,6 +1646,11 @@ void *active_instance_initialize (
 error_exit:
 	return ((void *)instance);
 }
+
+/**
+ * @brief timer_function_active_problem_decrementer
+ * @param context
+ */
 static void timer_function_active_problem_decrementer (void *context)
 {
 	struct active_instance *active_instance = (struct active_instance *)context;
@@ -1446,6 +1685,10 @@ static void timer_function_active_problem_decrementer (void *context)
 	}
 }
 
+/**
+ * @brief timer_function_active_token_expired
+ * @param context
+ */
 static void timer_function_active_token_expired (void *context)
 {
 	struct active_instance *active_instance = (struct active_instance *)context;
@@ -1504,6 +1747,10 @@ static void timer_function_active_token_expired (void *context)
 		active_instance->token_len);
 }
 
+/**
+ * @brief active_timer_expired_token_start
+ * @param active_instance
+ */
 static void active_timer_expired_token_start (
 	struct active_instance *active_instance)
 {
@@ -1516,6 +1763,10 @@ static void active_timer_expired_token_start (
 		&active_instance->timer_expired_token);
 }
 
+/**
+ * @brief active_timer_expired_token_cancel
+ * @param active_instance
+ */
 static void active_timer_expired_token_cancel (
 	struct active_instance *active_instance)
 {
@@ -1524,6 +1775,10 @@ static void active_timer_expired_token_cancel (
 		active_instance->timer_expired_token);
 }
 
+/**
+ * @brief active_timer_problem_decrementer_start
+ * @param active_instance
+ */
 static void active_timer_problem_decrementer_start (
 	struct active_instance *active_instance)
 {
@@ -1536,6 +1791,10 @@ static void active_timer_problem_decrementer_start (
 		&active_instance->timer_problem_decrementer);
 }
 
+/**
+ * @brief active_timer_problem_decrementer_cancel
+ * @param active_instance
+ */
 static void active_timer_problem_decrementer_cancel (
 	struct active_instance *active_instance)
 {
@@ -1548,6 +1807,15 @@ static void active_timer_problem_decrementer_cancel (
 
 /*
  * active replication
+ */
+
+/**
+ * @brief active_mcast_recv
+ * @param instance
+ * @param iface_no
+ * @param context
+ * @param msg
+ * @param msg_len
  */
 static void active_mcast_recv (
 	struct totemrrp_instance *instance,
@@ -1562,6 +1830,12 @@ static void active_mcast_recv (
 		msg_len);
 }
 
+/**
+ * @brief active_mcast_flush_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void active_mcast_flush_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -1577,6 +1851,12 @@ static void active_mcast_flush_send (
 	}
 }
 
+/**
+ * @brief active_mcast_noflush_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void active_mcast_noflush_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -1592,6 +1872,15 @@ static void active_mcast_noflush_send (
 	}
 }
 
+/**
+ * @brief active_token_recv
+ * @param rrp_instance
+ * @param iface_no
+ * @param context
+ * @param msg
+ * @param msg_len
+ * @param token_seq
+ */
 static void active_token_recv (
 	struct totemrrp_instance *rrp_instance,
 	unsigned int iface_no,
@@ -1638,6 +1927,12 @@ static void active_token_recv (
 	}
 }
 
+/**
+ * @brief active_token_send
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static void active_token_send (
 	struct totemrrp_instance *instance,
 	const void *msg,
@@ -1656,6 +1951,10 @@ static void active_token_send (
 	}
 }
 
+/**
+ * @brief active_recv_flush
+ * @param instance
+ */
 static void active_recv_flush (struct totemrrp_instance *instance)
 {
 	struct active_instance *rrp_algo_instance = (struct active_instance *)instance->rrp_algo_instance;
@@ -1669,6 +1968,10 @@ static void active_recv_flush (struct totemrrp_instance *instance)
 	}
 }
 
+/**
+ * @brief active_send_flush
+ * @param instance
+ */
 static void active_send_flush (struct totemrrp_instance *instance)
 {
 	struct active_instance *rrp_algo_instance = (struct active_instance *)instance->rrp_algo_instance;
@@ -1682,6 +1985,13 @@ static void active_send_flush (struct totemrrp_instance *instance)
 	}
 }
 
+/**
+ * @brief active_member_add
+ * @param instance
+ * @param member
+ * @param iface_no
+ * @return
+ */
 static int active_member_add (
 	struct totemrrp_instance *instance,
 	const struct totem_ip_address *member,
@@ -1692,6 +2002,13 @@ static int active_member_add (
 	return (res);
 }
 
+/**
+ * @brief active_member_remove
+ * @param instance
+ * @param member
+ * @param iface_no
+ * @return
+ */
 static int active_member_remove (
 	struct totemrrp_instance *instance,
 	const struct totem_ip_address *member,
@@ -1702,6 +2019,18 @@ static int active_member_remove (
 	return (res);
 }
 
+/**
+ * @brief active_membership_changed
+ * @param rrp_instance
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void active_membership_changed (
 	struct totemrrp_instance *rrp_instance,
 	enum totem_configuration_type configuration_type,
@@ -1742,6 +2071,10 @@ static void active_membership_changed (
 	}
 }
 
+/**
+ * @brief active_iface_check
+ * @param instance
+ */
 static void active_iface_check (struct totemrrp_instance *instance)
 {
 	struct active_instance *rrp_algo_instance = (struct active_instance *)instance->rrp_algo_instance;
@@ -1755,6 +2088,11 @@ static void active_iface_check (struct totemrrp_instance *instance)
 	}
 }
 
+/**
+ * @brief active_processor_count_set
+ * @param instance
+ * @param processor_count
+ */
 static void active_processor_count_set (
 	struct totemrrp_instance *instance,
 	unsigned int processor_count)
@@ -1771,6 +2109,12 @@ static void active_processor_count_set (
 	}
 }
 
+/**
+ * @brief active_token_target_set
+ * @param instance
+ * @param token_target
+ * @param iface_no
+ */
 static void active_token_target_set (
 	struct totemrrp_instance *instance,
 	struct totem_ip_address *token_target,
@@ -1779,6 +2123,11 @@ static void active_token_target_set (
 	totemnet_token_target_set (instance->net_handles[iface_no], token_target);
 }
 
+/**
+ * @brief active_mcast_recv_empty
+ * @param instance
+ * @return
+ */
 static int active_mcast_recv_empty (
 	struct totemrrp_instance *instance)
 {
@@ -1799,6 +2148,11 @@ static int active_mcast_recv_empty (
 	return (msgs_emptied);
 }
 
+/**
+ * @brief active_ring_reenable
+ * @param instance
+ * @param iface_no
+ */
 static void active_ring_reenable (
 	struct totemrrp_instance *instance,
 	unsigned int iface_no)
@@ -1826,11 +2180,21 @@ static void active_ring_reenable (
 	}
 }
 
+/**
+ * @brief totemrrp_instance_initialize
+ * @param instance
+ */
 static void totemrrp_instance_initialize (struct totemrrp_instance *instance)
 {
 	memset (instance, 0, sizeof (struct totemrrp_instance));
 }
 
+/**
+ * @brief totemrrp_algorithm_set
+ * @param totem_config
+ * @param instance
+ * @return
+ */
 static int totemrrp_algorithm_set (
 	struct totem_config *totem_config,
 	struct totemrrp_instance *instance)
@@ -1858,6 +2222,12 @@ static int totemrrp_algorithm_set (
 	return (res);
 }
 
+/**
+ * @brief rrp_deliver_fn
+ * @param context
+ * @param msg
+ * @param msg_len
+ */
 void rrp_deliver_fn (
 	void *context,
 	const void *msg,
@@ -1958,6 +2328,11 @@ void rrp_deliver_fn (
 	}
 }
 
+/**
+ * @brief rrp_iface_change_fn
+ * @param context
+ * @param iface_addr
+ */
 void rrp_iface_change_fn (
 	void *context,
 	const struct totem_ip_address *iface_addr)
@@ -1971,6 +2346,11 @@ void rrp_iface_change_fn (
 		deliver_fn_context->iface_no);
 }
 
+/**
+ * @brief totemrrp_finalize
+ * @param rrp_context
+ * @return
+ */
 int totemrrp_finalize (
 	void *rrp_context)
 {
@@ -1985,6 +2365,10 @@ int totemrrp_finalize (
 	return (0);
 }
 
+/**
+ * @brief rrp_target_set_completed
+ * @param context
+ */
 static void rrp_target_set_completed (void *context)
 {
 	struct deliver_fn_context *deliver_fn_context = (struct deliver_fn_context *)context;
@@ -1999,6 +2383,15 @@ static void rrp_target_set_completed (void *context)
 
 /*
  * Create an instance
+ */
+/**
+ * @brief totemrrp_initialize
+ * @param poll_handle
+ * @param rrp_context
+ * @param totem_config
+ * @param stats
+ * @param context
+ * @return
  */
 int totemrrp_initialize (
 	qb_loop_t *poll_handle,
@@ -2115,6 +2508,11 @@ error_destroy:
 	return (res);
 }
 
+/**
+ * @brief totemrrp_buffer_alloc
+ * @param rrp_context
+ * @return
+ */
 void *totemrrp_buffer_alloc (void *rrp_context)
 {
 	struct totemrrp_instance *instance = rrp_context;
@@ -2122,6 +2520,11 @@ void *totemrrp_buffer_alloc (void *rrp_context)
 	return totemnet_buffer_alloc (instance->net_handles[0]);
 }
 
+/**
+ * @brief totemrrp_buffer_release
+ * @param rrp_context
+ * @param ptr
+ */
 void totemrrp_buffer_release (void *rrp_context, void *ptr)
 {
 	struct totemrrp_instance *instance = rrp_context;
@@ -2129,6 +2532,12 @@ void totemrrp_buffer_release (void *rrp_context, void *ptr)
 	totemnet_buffer_release (instance->net_handles[0], ptr);
 }
 
+/**
+ * @brief totemrrp_processor_count_set
+ * @param rrp_context
+ * @param processor_count
+ * @return
+ */
 int totemrrp_processor_count_set (
 	void *rrp_context,
 	unsigned int processor_count)
@@ -2141,6 +2550,13 @@ int totemrrp_processor_count_set (
 	return (0);
 }
 
+/**
+ * @brief totemrrp_token_target_set
+ * @param rrp_context
+ * @param addr
+ * @param iface_no
+ * @return
+ */
 int totemrrp_token_target_set (
 	void *rrp_context,
 	struct totem_ip_address *addr,
@@ -2151,6 +2567,12 @@ int totemrrp_token_target_set (
 
 	return (0);
 }
+
+/**
+ * @brief totemrrp_recv_flush
+ * @param rrp_context
+ * @return
+ */
 int totemrrp_recv_flush (void *rrp_context)
 {
 	struct totemrrp_instance *instance = (struct totemrrp_instance *)rrp_context;
@@ -2160,6 +2582,11 @@ int totemrrp_recv_flush (void *rrp_context)
 	return (0);
 }
 
+/**
+ * @brief totemrrp_send_flush
+ * @param rrp_context
+ * @return
+ */
 int totemrrp_send_flush (void *rrp_context)
 {
 	struct totemrrp_instance *instance = (struct totemrrp_instance *)rrp_context;
@@ -2168,6 +2595,13 @@ int totemrrp_send_flush (void *rrp_context)
 	return (0);
 }
 
+/**
+ * @brief totemrrp_token_send
+ * @param rrp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemrrp_token_send (
 	void *rrp_context,
 	const void *msg,
@@ -2179,6 +2613,13 @@ int totemrrp_token_send (
 	return (0);
 }
 
+/**
+ * @brief totemrrp_mcast_flush_send
+ * @param rrp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemrrp_mcast_flush_send (
 	void *rrp_context,
 	const void *msg,
@@ -2193,6 +2634,13 @@ int totemrrp_mcast_flush_send (
 	return (res);
 }
 
+/**
+ * @brief totemrrp_mcast_noflush_send
+ * @param rrp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemrrp_mcast_noflush_send (
 	void *rrp_context,
 	const void *msg,
@@ -2213,6 +2661,11 @@ int totemrrp_mcast_noflush_send (
 	return (0);
 }
 
+/**
+ * @brief totemrrp_iface_check
+ * @param rrp_context
+ * @return
+ */
 int totemrrp_iface_check (void *rrp_context)
 {
 	struct totemrrp_instance *instance = (struct totemrrp_instance *)rrp_context;
@@ -2222,6 +2675,13 @@ int totemrrp_iface_check (void *rrp_context)
 	return (0);
 }
 
+/**
+ * @brief totemrrp_ifaces_get
+ * @param rrp_context
+ * @param status
+ * @param iface_count
+ * @return
+ */
 int totemrrp_ifaces_get (
 	void *rrp_context,
 	char ***status,
@@ -2237,6 +2697,13 @@ int totemrrp_ifaces_get (
 	return (0);
 }
 
+/**
+ * @brief totemrrp_crypto_set
+ * @param rrp_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemrrp_crypto_set (
 	void *rrp_context,
 	const char *cipher_type,
@@ -2255,6 +2722,12 @@ int totemrrp_crypto_set (
  * iface_no indicates the interface number [0, ..., interface_count-1] of the
  * specific ring which will be reenabled. We specify iface_no == interface_count
  * means reenabling all the rings.
+ */
+/**
+ * @brief totemrrp_ring_reenable
+ * @param rrp_context
+ * @param iface_no
+ * @return
  */
 int totemrrp_ring_reenable (
         void *rrp_context,
@@ -2279,6 +2752,11 @@ int totemrrp_ring_reenable (
 	return (res);
 }
 
+/**
+ * @brief totemrrp_mcast_recv_empty
+ * @param rrp_context
+ * @return
+ */
 extern int totemrrp_mcast_recv_empty (
 	void *rrp_context)
 {
@@ -2290,6 +2768,13 @@ extern int totemrrp_mcast_recv_empty (
 	return (res);
 }
 
+/**
+ * @brief totemrrp_member_add
+ * @param rrp_context
+ * @param member
+ * @param iface_no
+ * @return
+ */
 int totemrrp_member_add (
         void *rrp_context,
         const struct totem_ip_address *member,
@@ -2303,6 +2788,13 @@ int totemrrp_member_add (
 	return (res);
 }
 
+/**
+ * @brief totemrrp_member_remove
+ * @param rrp_context
+ * @param member
+ * @param iface_no
+ * @return
+ */
 int totemrrp_member_remove (
         void *rrp_context,
         const struct totem_ip_address *member,
@@ -2316,6 +2808,18 @@ int totemrrp_member_remove (
 	return (res);
 }
 
+/**
+ * @brief totemrrp_membership_changed
+ * @param rrp_context
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 void totemrrp_membership_changed (
         void *rrp_context,
 	enum totem_configuration_type configuration_type,

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -705,6 +705,11 @@ do {												\
 		fmt ": %s (%d)\n", ##args, _error_ptr, err_num);				\
 	} while(0)
 
+/**
+ * @brief gsfrom_to_msg
+ * @param gsfrom
+ * @return
+ */
 static const char* gsfrom_to_msg(enum gather_state_from gsfrom)
 {
 	if (gsfrom <= TOTEMSRP_GSFROM_MAX) {
@@ -715,6 +720,10 @@ static const char* gsfrom_to_msg(enum gather_state_from gsfrom)
 	}
 }
 
+/**
+ * @brief totemsrp_instance_initialize
+ * @param instance
+ */
 static void totemsrp_instance_initialize (struct totemsrp_instance *instance)
 {
 	memset (instance, 0, sizeof (struct totemsrp_instance));
@@ -748,6 +757,12 @@ static void totemsrp_instance_initialize (struct totemsrp_instance *instance)
 	instance->waiting_trans_ack = 1;
 }
 
+/**
+ * @brief main_token_seqid_get
+ * @param msg
+ * @param seqid
+ * @param token_is
+ */
 static void main_token_seqid_get (
 	const void *msg,
 	unsigned int *seqid,
@@ -763,12 +778,21 @@ static void main_token_seqid_get (
 	}
 }
 
+/**
+ * @brief main_msgs_missing
+ * @return
+ */
 static unsigned int main_msgs_missing (void)
 {
 // TODO
 	return (0);
 }
 
+/**
+ * @brief pause_flush
+ * @param instance
+ * @return
+ */
 static int pause_flush (struct totemsrp_instance *instance)
 {
 	uint64_t now_msec;
@@ -791,6 +815,12 @@ static int pause_flush (struct totemsrp_instance *instance)
 	return (res);
 }
 
+/**
+ * @brief token_event_stats_collector
+ * @param type
+ * @param void_instance
+ * @return
+ */
 static int token_event_stats_collector (enum totem_callback_token_type type, const void *void_instance)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)void_instance;
@@ -828,6 +858,14 @@ static int token_event_stats_collector (enum totem_callback_token_type type, con
 
 /*
  * Exported interfaces
+ */
+/**
+ * @brief totemsrp_initialize
+ * @param poll_handle
+ * @param srp_context
+ * @param totem_config
+ * @param stats
+ * @return
  */
 int totemsrp_initialize (
 	qb_loop_t *poll_handle,
@@ -1035,6 +1073,10 @@ error_exit:
 	return (-1);
 }
 
+/**
+ * @brief totemsrp_finalize
+ * @param srp_context
+ */
 void totemsrp_finalize (
 	void *srp_context)
 {
@@ -1058,6 +1100,16 @@ void totemsrp_finalize (
  *
  * Function returns 0 on success, otherwise if interfaces array is not big enough, -2 is returned,
  * and if interface was not found, -1 is returned.
+ */
+/**
+ * @brief totemsrp_ifaces_get
+ * @param srp_context
+ * @param nodeid
+ * @param interfaces
+ * @param interfaces_size
+ * @param status
+ * @param iface_count
+ * @return
  */
 int totemsrp_ifaces_get (
 	void *srp_context,
@@ -1117,6 +1169,13 @@ finish:
 	return (res);
 }
 
+/**
+ * @brief totemsrp_crypto_set
+ * @param srp_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemsrp_crypto_set (
 	void *srp_context,
 	const char *cipher_type,
@@ -1130,7 +1189,11 @@ int totemsrp_crypto_set (
 	return (res);
 }
 
-
+/**
+ * @brief totemsrp_my_nodeid_get
+ * @param srp_context
+ * @return
+ */
 unsigned int totemsrp_my_nodeid_get (
 	void *srp_context)
 {
@@ -1142,6 +1205,11 @@ unsigned int totemsrp_my_nodeid_get (
 	return (res);
 }
 
+/**
+ * @brief totemsrp_my_family_get
+ * @param srp_context
+ * @return
+ */
 int totemsrp_my_family_get (
 	void *srp_context)
 {
@@ -1153,7 +1221,11 @@ int totemsrp_my_family_get (
 	return (res);
 }
 
-
+/**
+ * @brief totemsrp_ring_reenable
+ * @param srp_context
+ * @return
+ */
 int totemsrp_ring_reenable (
         void *srp_context)
 {
@@ -1169,6 +1241,12 @@ int totemsrp_ring_reenable (
 /*
  * Set operations for use by the membership algorithm
  */
+/**
+ * @brief srp_addr_equal
+ * @param a
+ * @param b
+ * @return
+ */
 static int srp_addr_equal (const struct srp_addr *a, const struct srp_addr *b)
 {
 	unsigned int i;
@@ -1183,6 +1261,11 @@ static int srp_addr_equal (const struct srp_addr *a, const struct srp_addr *b)
 	return (1);
 }
 
+/**
+ * @brief srp_addr_copy
+ * @param dest
+ * @param src
+ */
 static void srp_addr_copy (struct srp_addr *dest, const struct srp_addr *src)
 {
 	unsigned int i;
@@ -1194,6 +1277,12 @@ static void srp_addr_copy (struct srp_addr *dest, const struct srp_addr *src)
 	}
 }
 
+/**
+ * @brief srp_addr_to_nodeid
+ * @param nodeid_out
+ * @param srp_addr_in
+ * @param entries
+ */
 static void srp_addr_to_nodeid (
 	unsigned int *nodeid_out,
 	struct srp_addr *srp_addr_in,
@@ -1206,6 +1295,11 @@ static void srp_addr_to_nodeid (
 	}
 }
 
+/**
+ * @brief srp_addr_copy_endian_convert
+ * @param out
+ * @param in
+ */
 static void srp_addr_copy_endian_convert (struct srp_addr *out, const struct srp_addr *in)
 {
 	int i;
@@ -1215,11 +1309,24 @@ static void srp_addr_copy_endian_convert (struct srp_addr *out, const struct srp
 	}
 }
 
+/**
+ * @brief memb_consensus_reset
+ * @param instance
+ */
 static void memb_consensus_reset (struct totemsrp_instance *instance)
 {
 	instance->consensus_list_entries = 0;
 }
 
+/**
+ * @brief memb_set_subtract
+ * @param out_list
+ * @param out_list_entries
+ * @param one_list
+ * @param one_list_entries
+ * @param two_list
+ * @param two_list_entries
+ */
 static void memb_set_subtract (
         struct srp_addr *out_list, int *out_list_entries,
         struct srp_addr *one_list, int one_list_entries,
@@ -1249,6 +1356,11 @@ static void memb_set_subtract (
 /*
  * Set consensus for a specific processor
  */
+/**
+ * @brief memb_consensus_set
+ * @param instance
+ * @param addr
+ */
 static void memb_consensus_set (
 	struct totemsrp_instance *instance,
 	const struct srp_addr *addr)
@@ -1276,6 +1388,12 @@ static void memb_consensus_set (
 /*
  * Is consensus set for a specific processor
  */
+/**
+ * @brief memb_consensus_isset
+ * @param instance
+ * @param addr
+ * @return
+ */
 static int memb_consensus_isset (
 	struct totemsrp_instance *instance,
 	const struct srp_addr *addr)
@@ -1292,6 +1410,11 @@ static int memb_consensus_isset (
 
 /*
  * Is consensus agreed upon based upon consensus database
+ */
+/**
+ * @brief memb_consensus_agreed
+ * @param instance
+ * @return
  */
 static int memb_consensus_agreed (
 	struct totemsrp_instance *instance)
@@ -1326,6 +1449,14 @@ static int memb_consensus_agreed (
 	return (agreed);
 }
 
+/**
+ * @brief memb_consensus_notset
+ * @param instance
+ * @param no_consensus_list
+ * @param no_consensus_list_entries
+ * @param comparison_list
+ * @param comparison_list_entries
+ */
 static void memb_consensus_notset (
 	struct totemsrp_instance *instance,
 	struct srp_addr *no_consensus_list,
@@ -1347,6 +1478,14 @@ static void memb_consensus_notset (
 
 /*
  * Is set1 equal to set2 Entries can be in different orders
+ */
+/**
+ * @brief memb_set_equal
+ * @param set1
+ * @param set1_entries
+ * @param set2
+ * @param set2_entries
+ * @return
  */
 static int memb_set_equal (
 	struct srp_addr *set1, int set1_entries,
@@ -1378,6 +1517,14 @@ static int memb_set_equal (
 /*
  * Is subset fully contained in fullset
  */
+/**
+ * @brief memb_set_subset
+ * @param subset
+ * @param subset_entries
+ * @param fullset
+ * @param fullset_entries
+ * @return
+ */
 static int memb_set_subset (
 	const struct srp_addr *subset, int subset_entries,
 	const struct srp_addr *fullset, int fullset_entries)
@@ -1405,6 +1552,13 @@ static int memb_set_subset (
 /*
  * merge subset into fullset taking care not to add duplicates
  */
+/**
+ * @brief memb_set_merge
+ * @param subset
+ * @param subset_entries
+ * @param fullset
+ * @param fullset_entries
+ */
 static void memb_set_merge (
 	const struct srp_addr *subset, int subset_entries,
 	struct srp_addr *fullset, int *fullset_entries)
@@ -1429,6 +1583,16 @@ static void memb_set_merge (
 	return;
 }
 
+/**
+ * @brief memb_set_and_with_ring_id
+ * @param set1
+ * @param set1_ring_ids
+ * @param set1_entries
+ * @param set2
+ * @param set2_entries
+ * @param old_ring_id
+ * @param and_entries
+ */
 static void memb_set_and_with_ring_id (
 	struct srp_addr *set1,
 	struct memb_ring_id *set1_ring_ids,
@@ -1464,6 +1628,12 @@ static void memb_set_and_with_ring_id (
 }
 
 #ifdef CODE_COVERAGE
+/**
+ * @brief memb_set_print
+ * @param string
+ * @param list
+ * @param list_entries
+ */
 static void memb_set_print (
 	char *string,
         struct srp_addr *list,
@@ -1489,6 +1659,12 @@ static void my_leave_memb_clear(
         instance->my_leave_memb_entries = 0;
 }
 
+/**
+ * @brief my_leave_memb_match
+ * @param instance
+ * @param nodeid
+ * @return
+ */
 static unsigned int my_leave_memb_match(
         struct totemsrp_instance *instance,
         unsigned int nodeid)
@@ -1505,6 +1681,11 @@ static unsigned int my_leave_memb_match(
         return ret;
 }
 
+/**
+ * @brief my_leave_memb_set
+ * @param instance
+ * @param nodeid
+ */
 static void my_leave_memb_set(
         struct totemsrp_instance *instance,
         unsigned int nodeid)
@@ -1528,19 +1709,32 @@ static void my_leave_memb_set(
         }
 }
 
-
+/**
+ * @brief totemsrp_buffer_alloc
+ * @param instance
+ * @return
+ */
 static void *totemsrp_buffer_alloc (struct totemsrp_instance *instance)
 {
 	assert (instance != NULL);
 	return totemrrp_buffer_alloc (instance->totemrrp_context);
 }
 
+/**
+ * @brief totemsrp_buffer_release
+ * @param instance
+ * @param ptr
+ */
 static void totemsrp_buffer_release (struct totemsrp_instance *instance, void *ptr)
 {
 	assert (instance != NULL);
 	totemrrp_buffer_release (instance->totemrrp_context, ptr);
 }
 
+/**
+ * @brief reset_token_retransmit_timeout
+ * @param instance
+ */
 static void reset_token_retransmit_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_del (instance->totemsrp_poll_handle,
@@ -1554,6 +1748,10 @@ static void reset_token_retransmit_timeout (struct totemsrp_instance *instance)
 
 }
 
+/**
+ * @brief start_merge_detect_timeout
+ * @param instance
+ */
 static void start_merge_detect_timeout (struct totemsrp_instance *instance)
 {
 	if (instance->my_merge_detect_timeout_outstanding == 0) {
@@ -1568,6 +1766,10 @@ static void start_merge_detect_timeout (struct totemsrp_instance *instance)
 	}
 }
 
+/**
+ * @brief cancel_merge_detect_timeout
+ * @param instance
+ */
 static void cancel_merge_detect_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_merge_detect_timeout);
@@ -1577,6 +1779,10 @@ static void cancel_merge_detect_timeout (struct totemsrp_instance *instance)
 /*
  * ring_state_* is used to save and restore the sort queue
  * state when a recovery operation fails (and enters gather)
+ */
+/**
+ * @brief old_ring_state_save
+ * @param instance
  */
 static void old_ring_state_save (struct totemsrp_instance *instance)
 {
@@ -1592,6 +1798,10 @@ static void old_ring_state_save (struct totemsrp_instance *instance)
 	}
 }
 
+/**
+ * @brief old_ring_state_restore
+ * @param instance
+ */
 static void old_ring_state_restore (struct totemsrp_instance *instance)
 {
 	instance->my_aru = instance->old_ring_state_aru;
@@ -1601,6 +1811,10 @@ static void old_ring_state_restore (struct totemsrp_instance *instance)
 		instance->my_aru, instance->my_high_seq_received);
 }
 
+/**
+ * @brief old_ring_state_reset
+ * @param instance
+ */
 static void old_ring_state_reset (struct totemsrp_instance *instance)
 {
 	log_printf (instance->totemsrp_log_level_debug,
@@ -1608,6 +1822,10 @@ static void old_ring_state_reset (struct totemsrp_instance *instance)
 	instance->old_ring_state_saved = 0;
 }
 
+/**
+ * @brief reset_pause_timeout
+ * @param instance
+ */
 static void reset_pause_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_pause_timeout);
@@ -1619,6 +1837,10 @@ static void reset_pause_timeout (struct totemsrp_instance *instance)
 		&instance->timer_pause_timeout);
 }
 
+/**
+ * @brief reset_token_timeout
+ * @param instance
+ */
 static void reset_token_timeout (struct totemsrp_instance *instance) {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_orf_token_timeout);
 	qb_loop_timer_add (instance->totemsrp_poll_handle,
@@ -1629,6 +1851,10 @@ static void reset_token_timeout (struct totemsrp_instance *instance) {
 		&instance->timer_orf_token_timeout);
 }
 
+/**
+ * @brief reset_heartbeat_timeout
+ * @param instance
+ */
 static void reset_heartbeat_timeout (struct totemsrp_instance *instance) {
         qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_heartbeat_timeout);
         qb_loop_timer_add (instance->totemsrp_poll_handle,
@@ -1640,19 +1866,35 @@ static void reset_heartbeat_timeout (struct totemsrp_instance *instance) {
 }
 
 
+/**
+ * @brief cancel_token_timeout
+ * @param instance
+ */
 static void cancel_token_timeout (struct totemsrp_instance *instance) {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_orf_token_timeout);
 }
 
+/**
+ * @brief cancel_heartbeat_timeout
+ * @param instance
+ */
 static void cancel_heartbeat_timeout (struct totemsrp_instance *instance) {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_heartbeat_timeout);
 }
 
+/**
+ * @brief cancel_token_retransmit_timeout
+ * @param instance
+ */
 static void cancel_token_retransmit_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_orf_token_retransmit_timeout);
 }
 
+/**
+ * @brief start_token_hold_retransmit_timeout
+ * @param instance
+ */
 static void start_token_hold_retransmit_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_add (instance->totemsrp_poll_handle,
@@ -1663,12 +1905,20 @@ static void start_token_hold_retransmit_timeout (struct totemsrp_instance *insta
 		&instance->timer_orf_token_hold_retransmit_timeout);
 }
 
+/**
+ * @brief cancel_token_hold_retransmit_timeout
+ * @param instance
+ */
 static void cancel_token_hold_retransmit_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_del (instance->totemsrp_poll_handle,
 		instance->timer_orf_token_hold_retransmit_timeout);
 }
 
+/**
+ * @brief memb_state_consensus_timeout_expired
+ * @param instance
+ */
 static void memb_state_consensus_timeout_expired (
 		struct totemsrp_instance *instance)
 {
@@ -1703,6 +1953,10 @@ static void memb_merge_detect_transmit (struct totemsrp_instance *instance);
 /*
  * Timers used for various states of the membership algorithm
  */
+/**
+ * @brief timer_function_pause_timeout
+ * @param data
+ */
 static void timer_function_pause_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -1711,6 +1965,10 @@ static void timer_function_pause_timeout (void *data)
 	reset_pause_timeout (instance);
 }
 
+/**
+ * @brief memb_recovery_state_token_loss
+ * @param instance
+ */
 static void memb_recovery_state_token_loss (struct totemsrp_instance *instance)
 {
 	old_ring_state_restore (instance);
@@ -1718,6 +1976,10 @@ static void memb_recovery_state_token_loss (struct totemsrp_instance *instance)
 	instance->stats.recovery_token_lost++;
 }
 
+/**
+ * @brief timer_function_orf_token_timeout
+ * @param data
+ */
 static void timer_function_orf_token_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -1757,6 +2019,10 @@ static void timer_function_orf_token_timeout (void *data)
 	}
 }
 
+/**
+ * @brief timer_function_heartbeat_timeout
+ * @param data
+ */
 static void timer_function_heartbeat_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -1765,6 +2031,10 @@ static void timer_function_heartbeat_timeout (void *data)
 	timer_function_orf_token_timeout(data);
 }
 
+/**
+ * @brief memb_timer_function_state_gather
+ * @param data
+ */
 static void memb_timer_function_state_gather (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -1793,12 +2063,20 @@ static void memb_timer_function_state_gather (void *data)
 	}
 }
 
+/**
+ * @brief memb_timer_function_gather_consensus_timeout
+ * @param data
+ */
 static void memb_timer_function_gather_consensus_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
 	memb_state_consensus_timeout_expired (instance);
 }
 
+/**
+ * @brief deliver_messages_from_recovery_to_regular
+ * @param instance
+ */
 static void deliver_messages_from_recovery_to_regular (struct totemsrp_instance *instance)
 {
 	unsigned int i;
@@ -1875,6 +2153,10 @@ static void deliver_messages_from_recovery_to_regular (struct totemsrp_instance 
 
 /*
  * Change states in the state machine of the membership algorithm
+ */
+/**
+ * @brief memb_state_operational_enter
+ * @param instance
  */
 static void memb_state_operational_enter (struct totemsrp_instance *instance)
 {
@@ -2120,6 +2402,11 @@ static void memb_state_operational_enter (struct totemsrp_instance *instance)
 	return;
 }
 
+/**
+ * @brief memb_state_gather_enter
+ * @param instance
+ * @param gather_from
+ */
 static void memb_state_gather_enter (
 	struct totemsrp_instance *instance,
 	enum gather_state_from gather_from)
@@ -2187,8 +2474,16 @@ static void memb_state_gather_enter (
 	return;
 }
 
+/**
+ * @brief timer_function_token_retransmit_timeout
+ * @param data
+ */
 static void timer_function_token_retransmit_timeout (void *data);
 
+/**
+ * @brief target_set_completed
+ * @param context
+ */
 static void target_set_completed (
 	void *context)
 {
@@ -2198,6 +2493,10 @@ static void target_set_completed (
 
 }
 
+/**
+ * @brief memb_state_commit_enter
+ * @param instance
+ */
 static void memb_state_commit_enter (
 	struct totemsrp_instance *instance)
 {
@@ -2241,6 +2540,11 @@ static void memb_state_commit_enter (
 	 */
 }
 
+/**
+ * @brief memb_state_recovery_enter
+ * @param instance
+ * @param commit_token
+ */
 static void memb_state_recovery_enter (
 	struct totemsrp_instance *instance,
 	struct memb_commit_token *commit_token)
@@ -2432,6 +2736,12 @@ originated:
 	return;
 }
 
+/**
+ * @brief totemsrp_event_signal
+ * @param srp_context
+ * @param type
+ * @param value
+ */
 void totemsrp_event_signal (void *srp_context, enum totem_event_type type, int value)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)srp_context;
@@ -2441,6 +2751,14 @@ void totemsrp_event_signal (void *srp_context, enum totem_event_type type, int v
 	return;
 }
 
+/**
+ * @brief totemsrp_mcast
+ * @param srp_context
+ * @param iovec
+ * @param iov_len
+ * @param guarantee
+ * @return
+ */
 int totemsrp_mcast (
 	void *srp_context,
 	struct iovec *iovec,
@@ -2510,6 +2828,11 @@ error_mcast:
 /*
  * Determine if there is room to queue a new message
  */
+/**
+ * @brief totemsrp_avail
+ * @param srp_context
+ * @return
+ */
 int totemsrp_avail (void *srp_context)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)srp_context;
@@ -2531,6 +2854,12 @@ int totemsrp_avail (void *srp_context)
  */
 /*
  * Recast message to mcast group if it is available
+ */
+/**
+ * @brief orf_token_remcast
+ * @param instance
+ * @param seq
+ * @return
  */
 static int orf_token_remcast (
 	struct totemsrp_instance *instance,
@@ -2575,6 +2904,11 @@ static int orf_token_remcast (
 
 /*
  * Free all freeable messages from ring
+ */
+/**
+ * @brief messages_free
+ * @param instance
+ * @param token_aru
  */
 static void messages_free (
 	struct totemsrp_instance *instance,
@@ -2630,6 +2964,10 @@ static void messages_free (
 	}
 }
 
+/**
+ * @brief update_aru
+ * @param instance
+ */
 static void update_aru (
 	struct totemsrp_instance *instance)
 {
@@ -2665,6 +3003,13 @@ static void update_aru (
 
 /*
  * Multicasts pending messages onto the ring (requires orf_token possession)
+ */
+/**
+ * @brief orf_token_mcast
+ * @param instance
+ * @param token
+ * @param fcc_mcasts_allowed
+ * @return
  */
 static int orf_token_mcast (
 	struct totemsrp_instance *instance,
@@ -2744,6 +3089,13 @@ static int orf_token_mcast (
 /*
  * Remulticasts messages in orf_token's retransmit list (requires orf_token)
  * Modify's orf_token's rtr to include retransmits required by this process
+ */
+/**
+ * @brief orf_token_rtr
+ * @param instance
+ * @param orf_token
+ * @param fcc_allowed
+ * @return
  */
 static int orf_token_rtr (
 	struct totemsrp_instance *instance,
@@ -2876,6 +3228,10 @@ static int orf_token_rtr (
 	return (instance->fcc_remcast_current);
 }
 
+/**
+ * @brief token_retransmit
+ * @param instance
+ */
 static void token_retransmit (struct totemsrp_instance *instance)
 {
 	totemrrp_token_send (instance->totemrrp_context,
@@ -2887,6 +3243,10 @@ static void token_retransmit (struct totemsrp_instance *instance)
  * Retransmit the regular token if no mcast or token has
  * been received in retransmit token period retransmit
  * the token to the next processor
+ */
+/**
+ * @brief timer_function_token_retransmit_timeout
+ * @param data
  */
 static void timer_function_token_retransmit_timeout (void *data)
 {
@@ -2904,6 +3264,10 @@ static void timer_function_token_retransmit_timeout (void *data)
 	}
 }
 
+/**
+ * @brief timer_function_token_hold_retransmit_timeout
+ * @param data
+ */
 static void timer_function_token_hold_retransmit_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -2920,6 +3284,10 @@ static void timer_function_token_hold_retransmit_timeout (void *data)
 	}
 }
 
+/**
+ * @brief timer_function_merge_detect_timeout
+ * @param data
+ */
 static void timer_function_merge_detect_timeout(void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -2941,6 +3309,13 @@ static void timer_function_merge_detect_timeout(void *data)
 
 /*
  * Send orf_token to next member (requires orf_token)
+ */
+/**
+ * @brief token_send
+ * @param instance
+ * @param orf_token
+ * @param forward_token
+ * @return
  */
 static int token_send (
 	struct totemsrp_instance *instance,
@@ -2969,6 +3344,11 @@ static int token_send (
 	return (res);
 }
 
+/**
+ * @brief token_hold_cancel_send
+ * @param instance
+ * @return
+ */
 static int token_hold_cancel_send (struct totemsrp_instance *instance)
 {
 	struct token_hold_cancel token_hold_cancel;
@@ -3000,6 +3380,11 @@ static int token_hold_cancel_send (struct totemsrp_instance *instance)
 	return (0);
 }
 
+/**
+ * @brief orf_token_send_initial
+ * @param instance
+ * @return
+ */
 static int orf_token_send_initial (struct totemsrp_instance *instance)
 {
 	struct orf_token orf_token;
@@ -3039,6 +3424,10 @@ static int orf_token_send_initial (struct totemsrp_instance *instance)
 	return (res);
 }
 
+/**
+ * @brief memb_state_commit_token_update
+ * @param instance
+ */
 static void memb_state_commit_token_update (
 	struct totemsrp_instance *instance)
 {
@@ -3106,6 +3495,10 @@ static void memb_state_commit_token_update (
 	assert (instance->commit_token->header.nodeid);
 }
 
+/**
+ * @brief memb_state_commit_token_target_set
+ * @param instance
+ */
 static void memb_state_commit_token_target_set (
 	struct totemsrp_instance *instance)
 {
@@ -3123,6 +3516,12 @@ static void memb_state_commit_token_target_set (
 	}
 }
 
+/**
+ * @brief memb_state_commit_token_send_recovery
+ * @param instance
+ * @param commit_token
+ * @return
+ */
 static int memb_state_commit_token_send_recovery (
 	struct totemsrp_instance *instance,
 	struct memb_commit_token *commit_token)
@@ -3153,6 +3552,11 @@ static int memb_state_commit_token_send_recovery (
 	return (0);
 }
 
+/**
+ * @brief memb_state_commit_token_send
+ * @param instance
+ * @return
+ */
 static int memb_state_commit_token_send (
 	struct totemsrp_instance *instance)
 {
@@ -3182,7 +3586,11 @@ static int memb_state_commit_token_send (
 	return (0);
 }
 
-
+/**
+ * @brief memb_lowest_in_config
+ * @param instance
+ * @return
+ */
 static int memb_lowest_in_config (struct totemsrp_instance *instance)
 {
 	struct srp_addr token_memb[PROCESSOR_COUNT_MAX];
@@ -3207,6 +3615,12 @@ static int memb_lowest_in_config (struct totemsrp_instance *instance)
 	return (totemip_compare (lowest_addr, &instance->my_id.addr[0]) == 0);
 }
 
+/**
+ * @brief srp_addr_compare
+ * @param a
+ * @param b
+ * @return
+ */
 static int srp_addr_compare (const void *a, const void *b)
 {
 	const struct srp_addr *srp_a = (const struct srp_addr *)a;
@@ -3215,6 +3629,10 @@ static int srp_addr_compare (const void *a, const void *b)
 	return (totemip_compare (&srp_a->addr[0], &srp_b->addr[0]));
 }
 
+/**
+ * @brief memb_state_commit_token_create
+ * @param instance
+ */
 static void memb_state_commit_token_create (
 	struct totemsrp_instance *instance)
 {
@@ -3260,6 +3678,10 @@ static void memb_state_commit_token_create (
 		sizeof (struct memb_commit_token_memb_entry) * token_memb_entries);
 }
 
+/**
+ * @brief memb_join_message_send
+ * @param instance
+ */
 static void memb_join_message_send (struct totemsrp_instance *instance)
 {
 	char memb_join_data[40000];
@@ -3312,6 +3734,10 @@ static void memb_join_message_send (struct totemsrp_instance *instance)
 		addr_idx);
 }
 
+/**
+ * @brief memb_leave_message_send
+ * @param instance
+ */
 static void memb_leave_message_send (struct totemsrp_instance *instance)
 {
 	char memb_join_data[40000];
@@ -3382,6 +3808,10 @@ static void memb_leave_message_send (struct totemsrp_instance *instance)
 		addr_idx);
 }
 
+/**
+ * @brief memb_merge_detect_transmit
+ * @param instance
+ */
 static void memb_merge_detect_transmit (struct totemsrp_instance *instance)
 {
 	struct memb_merge_detect memb_merge_detect;
@@ -3401,6 +3831,11 @@ static void memb_merge_detect_transmit (struct totemsrp_instance *instance)
 		sizeof (struct memb_merge_detect));
 }
 
+/**
+ * @brief memb_ring_id_set
+ * @param instance
+ * @param ring_id
+ */
 static void memb_ring_id_set (
 	struct totemsrp_instance *instance,
 	const struct memb_ring_id *ring_id)
@@ -3409,6 +3844,9 @@ static void memb_ring_id_set (
 	memcpy (&instance->my_ring_id, ring_id, sizeof (struct memb_ring_id));
 }
 
+/**
+ *
+ */
 int totemsrp_callback_token_create (
 	void *srp_context,
 	void **handle_out,
@@ -3444,6 +3882,11 @@ int totemsrp_callback_token_create (
 	return (0);
 }
 
+/**
+ * @brief totemsrp_callback_token_destroy
+ * @param srp_context
+ * @param handle_out
+ */
 void totemsrp_callback_token_destroy (void *srp_context, void **handle_out)
 {
 	struct token_callback_instance *h;
@@ -3457,6 +3900,11 @@ void totemsrp_callback_token_destroy (void *srp_context, void **handle_out)
 	}
 }
 
+/**
+ * @brief token_callbacks_execute
+ * @param instance
+ * @param type
+ */
 static void token_callbacks_execute (
 	struct totemsrp_instance *instance,
 	enum totem_callback_token_type type)
@@ -3507,6 +3955,11 @@ static void token_callbacks_execute (
 /*
  * Flow control functions
  */
+/**
+ * @brief backlog_get
+ * @param instance
+ * @return
+ */
 static unsigned int backlog_get (struct totemsrp_instance *instance)
 {
 	unsigned int backlog = 0;
@@ -3531,6 +3984,12 @@ static unsigned int backlog_get (struct totemsrp_instance *instance)
 	return (backlog);
 }
 
+/**
+ * @brief fcc_calculate
+ * @param instance
+ * @param token
+ * @return
+ */
 static int fcc_calculate (
 	struct totemsrp_instance *instance,
 	struct orf_token *token)
@@ -3564,6 +4023,12 @@ static int fcc_calculate (
 /*
  * don't overflow the RTR sort queue
  */
+/**
+ * @brief fcc_rtr_limit
+ * @param instance
+ * @param token
+ * @param transmits_allowed
+ */
 static void fcc_rtr_limit (
 	struct totemsrp_instance *instance,
 	struct orf_token *token,
@@ -3582,6 +4047,12 @@ static void fcc_rtr_limit (
 	}
 }
 
+/**
+ * @brief fcc_token_update
+ * @param instance
+ * @param token
+ * @param msgs_transmitted
+ */
 static void fcc_token_update (
 	struct totemsrp_instance *instance,
 	struct orf_token *token,
@@ -3600,6 +4071,15 @@ static void fcc_token_update (
 unsigned long long int tv_old;
 /*
  * message handler called when TOKEN message type received
+ */
+
+/**
+ * @brief message_handler_orf_token
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
  */
 static int message_handler_orf_token (
 	struct totemsrp_instance *instance,
@@ -3907,6 +4387,12 @@ printf ("token seq %d\n", token->seq);
 	return (0);
 }
 
+/**
+ * @brief messages_deliver_to_app
+ * @param instance
+ * @param skip
+ * @param end_point
+ */
 static void messages_deliver_to_app (
 	struct totemsrp_instance *instance,
 	int skip,
@@ -4011,6 +4497,14 @@ static void messages_deliver_to_app (
 
 /*
  * recv message handler called when MCAST message type received
+ */
+/**
+ * @brief message_handler_mcast
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
  */
 static int message_handler_mcast (
 	struct totemsrp_instance *instance,
@@ -4126,6 +4620,14 @@ static int message_handler_mcast (
 	return (0);
 }
 
+/**
+ * @brief message_handler_memb_merge_detect
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
+ */
 static int message_handler_memb_merge_detect (
 	struct totemsrp_instance *instance,
 	const void *msg,
@@ -4186,6 +4688,11 @@ static int message_handler_memb_merge_detect (
 	return (0);
 }
 
+/**
+ * @brief memb_join_process
+ * @param instance
+ * @param memb_join
+ */
 static void memb_join_process (
 	struct totemsrp_instance *instance,
 	const struct memb_join *memb_join)
@@ -4335,6 +4842,11 @@ out:
 	}
 }
 
+/**
+ * @brief memb_join_endian_convert
+ * @param in
+ * @param out
+ */
 static void memb_join_endian_convert (const struct memb_join *in, struct memb_join *out)
 {
 	int i;
@@ -4364,6 +4876,11 @@ static void memb_join_endian_convert (const struct memb_join *in, struct memb_jo
 	}
 }
 
+/**
+ * @brief memb_commit_token_endian_convert
+ * @param in
+ * @param out
+ */
 static void memb_commit_token_endian_convert (const struct memb_commit_token *in, struct memb_commit_token *out)
 {
 	int i;
@@ -4403,6 +4920,11 @@ static void memb_commit_token_endian_convert (const struct memb_commit_token *in
 	}
 }
 
+/**
+ * @brief orf_token_endian_convert
+ * @param in
+ * @param out
+ */
 static void orf_token_endian_convert (const struct orf_token *in, struct orf_token *out)
 {
 	int i;
@@ -4427,6 +4949,11 @@ static void orf_token_endian_convert (const struct orf_token *in, struct orf_tok
 	}
 }
 
+/**
+ * @brief mcast_endian_convert
+ * @param in
+ * @param out
+ */
 static void mcast_endian_convert (const struct mcast *in, struct mcast *out)
 {
 	out->header.type = in->header.type;
@@ -4443,6 +4970,11 @@ static void mcast_endian_convert (const struct mcast *in, struct mcast *out)
 	srp_addr_copy_endian_convert (&out->system_from, &in->system_from);
 }
 
+/**
+ * @brief memb_merge_detect_endian_convert
+ * @param in
+ * @param out
+ */
 static void memb_merge_detect_endian_convert (
 	const struct memb_merge_detect *in,
 	struct memb_merge_detect *out)
@@ -4455,6 +4987,12 @@ static void memb_merge_detect_endian_convert (
 	srp_addr_copy_endian_convert (&out->system_from, &in->system_from);
 }
 
+/**
+ * @brief ignore_join_under_operational
+ * @param instance
+ * @param memb_join
+ * @return
+ */
 static int ignore_join_under_operational (
 	struct totemsrp_instance *instance,
 	const struct memb_join *memb_join)
@@ -4485,6 +5023,14 @@ static int ignore_join_under_operational (
 	return (0);
 }
 
+/**
+ * @brief message_handler_memb_join
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
+ */
 static int message_handler_memb_join (
 	struct totemsrp_instance *instance,
 	const void *msg,
@@ -4554,6 +5100,14 @@ static int message_handler_memb_join (
 	return (0);
 }
 
+/**
+ * @brief message_handler_memb_commit_token
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
+ */
 static int message_handler_memb_commit_token (
 	struct totemsrp_instance *instance,
 	const void *msg,
@@ -4641,6 +5195,14 @@ static int message_handler_memb_commit_token (
 	return (0);
 }
 
+/**
+ * @brief message_handler_token_hold_cancel
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
+ */
 static int message_handler_token_hold_cancel (
 	struct totemsrp_instance *instance,
 	const void *msg,
@@ -4660,6 +5222,12 @@ static int message_handler_token_hold_cancel (
 	return (0);
 }
 
+/**
+ * @brief main_deliver_fn
+ * @param context
+ * @param msg
+ * @param msg_len
+ */
 void main_deliver_fn (
 	void *context,
 	const void *msg,
@@ -4711,6 +5279,12 @@ printf ("wrong message type\n");
 		message_header->endian_detector != ENDIAN_LOCAL);
 }
 
+/**
+ * @brief main_iface_change_fn
+ * @param context
+ * @param iface_addr
+ * @param iface_no
+ */
 void main_iface_change_fn (
 	void *context,
 	const struct totem_ip_address *iface_addr,
@@ -4751,10 +5325,18 @@ void main_iface_change_fn (
 	}
 }
 
+/**
+ * @brief totemsrp_net_mtu_adjust
+ * @param totem_config
+ */
 void totemsrp_net_mtu_adjust (struct totem_config *totem_config) {
 	totem_config->net_mtu -= sizeof (struct mcast);
 }
 
+/**
+ * @brief totemsrp_service_ready_register
+ * @param context
+ */
 void totemsrp_service_ready_register (
 	void *context,
         void (*totem_service_ready) (void))
@@ -4764,6 +5346,13 @@ void totemsrp_service_ready_register (
 	instance->totemsrp_service_ready_fn = totem_service_ready;
 }
 
+/**
+ * @brief totemsrp_member_add
+ * @param context
+ * @param member
+ * @param ring_no
+ * @return
+ */
 int totemsrp_member_add (
         void *context,
         const struct totem_ip_address *member,
@@ -4777,6 +5366,13 @@ int totemsrp_member_add (
 	return (res);
 }
 
+/**
+ * @brief totemsrp_member_remove
+ * @param context
+ * @param member
+ * @param ring_no
+ * @return
+ */
 int totemsrp_member_remove (
         void *context,
         const struct totem_ip_address *member,
@@ -4790,6 +5386,10 @@ int totemsrp_member_remove (
 	return (res);
 }
 
+/**
+ * @brief totemsrp_threaded_mode_enable
+ * @param context
+ */
 void totemsrp_threaded_mode_enable (void *context)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)context;
@@ -4797,6 +5397,10 @@ void totemsrp_threaded_mode_enable (void *context)
 	instance->threaded_mode_enabled = 1;
 }
 
+/**
+ * @brief totemsrp_trans_ack
+ * @param context
+ */
 void totemsrp_trans_ack (void *context)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)context;

--- a/exec/totemudp.c
+++ b/exec/totemudp.c
@@ -90,6 +90,9 @@
 
 #define MESSAGE_TYPE_MEMB_JOIN	3
 
+/**
+ * @brief The totemudp_socket struct
+ */
 struct totemudp_socket {
 	int mcast_recv;
 	int mcast_send;
@@ -103,6 +106,9 @@ struct totemudp_socket {
 	int local_mcast_loop[2];
 };
 
+/**
+ * @brief The totemudp_instance struct
+ */
 struct totemudp_instance {
 	struct crypto_instance *crypto_inst;
 
@@ -194,12 +200,24 @@ struct totemudp_instance {
 	struct totem_ip_address token_target;
 };
 
+/**
+ * @brief The work_item struct
+ */
 struct work_item {
 	const void *msg;
 	unsigned int msg_len;
 	struct totemudp_instance *instance;
 };
 
+/**
+ * @brief totemudp_build_sockets
+ * @param instance
+ * @param bindnet_address
+ * @param mcastaddress
+ * @param sockets
+ * @param bound_to
+ * @return
+ */
 static int totemudp_build_sockets (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *bindnet_address,
@@ -209,6 +227,10 @@ static int totemudp_build_sockets (
 
 static struct totem_ip_address localhost;
 
+/**
+ * @brief totemudp_instance_initialize
+ * @param instance
+ */
 static void totemudp_instance_initialize (struct totemudp_instance *instance)
 {
 	memset (instance, 0, sizeof (struct totemudp_instance));
@@ -246,6 +268,13 @@ do {												\
 		fmt ": %s (%d)\n", ##args, _error_ptr, err_num);				\
 	} while(0)
 
+/**
+ * @brief totemudp_crypto_set
+ * @param udp_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemudp_crypto_set (
 	void *udp_context,
 	const char *cipher_type,
@@ -256,6 +285,13 @@ int totemudp_crypto_set (
 }
 
 
+/**
+ * @brief ucast_sendmsg
+ * @param instance
+ * @param system_to
+ * @param msg
+ * @param msg_len
+ */
 static inline void ucast_sendmsg (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *system_to,
@@ -325,6 +361,12 @@ static inline void ucast_sendmsg (
 	}
 }
 
+/**
+ * @brief mcast_sendmsg
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static inline void mcast_sendmsg (
 	struct totemudp_instance *instance,
 	const void *msg,
@@ -410,6 +452,11 @@ static inline void mcast_sendmsg (
 }
 
 
+/**
+ * @brief totemudp_finalize
+ * @param udp_context
+ * @return
+ */
 int totemudp_finalize (
 	void *udp_context)
 {
@@ -443,6 +490,13 @@ int totemudp_finalize (
  * Only designed to work with a message with one iov
  */
 
+/**
+ * @brief net_deliver_fn
+ * @param fd
+ * @param revents
+ * @param data
+ * @return
+ */
 static int net_deliver_fn (
 	int fd,
 	int revents,
@@ -528,6 +582,15 @@ static int net_deliver_fn (
 	return (0);
 }
 
+/**
+ * @brief netif_determine
+ * @param instance
+ * @param bindnet
+ * @param bound_to
+ * @param interface_up
+ * @param interface_num
+ * @return
+ */
 static int netif_determine (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *bindnet,
@@ -549,6 +612,10 @@ static int netif_determine (
 /*
  * If the interface is up, the sockets for totem are built.  If the interface is down
  * this function is requeued in the timer list to retry building the sockets later.
+ */
+/**
+ * @brief timer_function_netif_check_timeout
+ * @param data
  */
 static void timer_function_netif_check_timeout (
 	void *data)
@@ -697,6 +764,12 @@ static void timer_function_netif_check_timeout (
 
 /* Set the socket priority to INTERACTIVE to ensure
    that our messages don't get queued behind anything else */
+
+/**
+ * @brief totemudp_traffic_control_set
+ * @param instance
+ * @param sock
+ */
 static void totemudp_traffic_control_set(struct totemudp_instance *instance, int sock)
 {
 #ifdef SO_PRIORITY
@@ -708,6 +781,16 @@ static void totemudp_traffic_control_set(struct totemudp_instance *instance, int
 #endif
 }
 
+/**
+ * @brief totemudp_build_sockets_ip
+ * @param instance
+ * @param mcast_address
+ * @param bindnet_address
+ * @param sockets
+ * @param bound_to
+ * @param interface_num
+ * @return
+ */
 static int totemudp_build_sockets_ip (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *mcast_address,
@@ -1059,6 +1142,15 @@ static int totemudp_build_sockets_ip (
 	return 0;
 }
 
+/**
+ * @brief totemudp_build_sockets
+ * @param instance
+ * @param mcast_address
+ * @param bindnet_address
+ * @param sockets
+ * @param bound_to
+ * @return
+ */
 static int totemudp_build_sockets (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *mcast_address,
@@ -1196,16 +1288,30 @@ int totemudp_initialize (
 	return (0);
 }
 
+/**
+ * @brief totemudp_buffer_alloc
+ * @return
+ */
 void *totemudp_buffer_alloc (void)
 {
 	return malloc (FRAME_SIZE_MAX);
 }
 
+/**
+ * @brief totemudp_buffer_release
+ * @param ptr
+ */
 void totemudp_buffer_release (void *ptr)
 {
 	return free (ptr);
 }
 
+/**
+ * @brief totemudp_processor_count_set
+ * @param udp_context
+ * @param processor_count
+ * @return
+ */
 int totemudp_processor_count_set (
 	void *udp_context,
 	int processor_count)
@@ -1228,6 +1334,11 @@ int totemudp_processor_count_set (
 	return (res);
 }
 
+/**
+ * @brief totemudp_recv_flush
+ * @param udp_context
+ * @return
+ */
 int totemudp_recv_flush (void *udp_context)
 {
 	struct totemudp_instance *instance = (struct totemudp_instance *)udp_context;
@@ -1264,11 +1375,23 @@ int totemudp_recv_flush (void *udp_context)
 	return (res);
 }
 
+/**
+ * @brief totemudp_send_flush
+ * @param udp_context
+ * @return
+ */
 int totemudp_send_flush (void *udp_context)
 {
 	return 0;
 }
 
+/**
+ * @brief totemudp_token_send
+ * @param udp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudp_token_send (
 	void *udp_context,
 	const void *msg,
@@ -1281,6 +1404,14 @@ int totemudp_token_send (
 
 	return (res);
 }
+
+/**
+ * @brief totemudp_mcast_flush_send
+ * @param udp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudp_mcast_flush_send (
 	void *udp_context,
 	const void *msg,
@@ -1294,6 +1425,13 @@ int totemudp_mcast_flush_send (
 	return (res);
 }
 
+/**
+ * @brief totemudp_mcast_noflush_send
+ * @param udp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudp_mcast_noflush_send (
 	void *udp_context,
 	const void *msg,
@@ -1307,6 +1445,11 @@ int totemudp_mcast_noflush_send (
 	return (res);
 }
 
+/**
+ * @brief totemudp_iface_check
+ * @param udp_context
+ * @return
+ */
 extern int totemudp_iface_check (void *udp_context)
 {
 	struct totemudp_instance *instance = (struct totemudp_instance *)udp_context;
@@ -1317,6 +1460,11 @@ extern int totemudp_iface_check (void *udp_context)
 	return (res);
 }
 
+/**
+ * @brief totemudp_net_mtu_adjust
+ * @param udp_context
+ * @param totem_config
+ */
 extern void totemudp_net_mtu_adjust (void *udp_context, struct totem_config *totem_config)
 {
 
@@ -1327,6 +1475,11 @@ extern void totemudp_net_mtu_adjust (void *udp_context, struct totem_config *tot
 				 totemip_udpip_header_size(totem_config->interfaces[0].bindnet.family);
 }
 
+/**
+ * @brief totemudp_iface_print
+ * @param udp_context
+ * @return
+ */
 const char *totemudp_iface_print (void *udp_context)  {
 	struct totemudp_instance *instance = (struct totemudp_instance *)udp_context;
 	const char *ret_char;
@@ -1336,6 +1489,12 @@ const char *totemudp_iface_print (void *udp_context)  {
 	return (ret_char);
 }
 
+/**
+ * @brief totemudp_iface_get
+ * @param udp_context
+ * @param addr
+ * @return
+ */
 int totemudp_iface_get (
 	void *udp_context,
 	struct totem_ip_address *addr)
@@ -1348,6 +1507,12 @@ int totemudp_iface_get (
 	return (res);
 }
 
+/**
+ * @brief totemudp_token_target_set
+ * @param udp_context
+ * @param token_target
+ * @return
+ */
 int totemudp_token_target_set (
 	void *udp_context,
 	const struct totem_ip_address *token_target)
@@ -1363,6 +1528,11 @@ int totemudp_token_target_set (
 	return (res);
 }
 
+/**
+ * @brief totemudp_recv_mcast_empty
+ * @param udp_context
+ * @return
+ */
 extern int totemudp_recv_mcast_empty (
 	void *udp_context)
 {

--- a/exec/totemudpu.c
+++ b/exec/totemudpu.c
@@ -212,6 +212,10 @@ static void totemudpu_stop_merge_detect_timeout(
 
 static struct totem_ip_address localhost;
 
+/**
+ * @brief totemudpu_instance_initialize
+ * @param instance
+ */
 static void totemudpu_instance_initialize (struct totemudpu_instance *instance)
 {
 	memset (instance, 0, sizeof (struct totemudpu_instance));
@@ -247,6 +251,13 @@ do {												\
 		fmt ": %s (%d)", ##args, _error_ptr, err_num);				\
 	} while(0)
 
+/**
+ * @brief totemudpu_crypto_set
+ * @param udpu_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemudpu_crypto_set (
 	void *udpu_context,
 	const char *cipher_type,
@@ -256,7 +267,13 @@ int totemudpu_crypto_set (
 	return (0);
 }
 
-
+/**
+ * @brief ucast_sendmsg
+ * @param instance
+ * @param system_to
+ * @param msg
+ * @param msg_len
+ */
 static inline void ucast_sendmsg (
 	struct totemudpu_instance *instance,
 	struct totem_ip_address *system_to,
@@ -325,6 +342,13 @@ static inline void ucast_sendmsg (
 	}
 }
 
+/**
+ * @brief mcast_sendmsg
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param only_active
+ */
 static inline void mcast_sendmsg (
 	struct totemudpu_instance *instance,
 	const void *msg,
@@ -418,6 +442,11 @@ static inline void mcast_sendmsg (
 	}
 }
 
+/**
+ * @brief totemudpu_finalize
+ * @param udpu_context
+ * @return
+ */
 int totemudpu_finalize (
 	void *udpu_context)
 {
@@ -435,6 +464,13 @@ int totemudpu_finalize (
 	return (res);
 }
 
+/**
+ * @brief net_deliver_fn
+ * @param fd
+ * @param revents
+ * @param data
+ * @return
+ */
 static int net_deliver_fn (
 	int fd,
 	int revents,
@@ -505,6 +541,16 @@ static int net_deliver_fn (
 	return (0);
 }
 
+
+/**
+ * @brief netif_determine
+ * @param instance
+ * @param bindnet
+ * @param bound_to
+ * @param interface_up
+ * @param interface_num
+ * @return
+ */
 static int netif_determine (
 	struct totemudpu_instance *instance,
 	struct totem_ip_address *bindnet,
@@ -526,6 +572,11 @@ static int netif_determine (
 /*
  * If the interface is up, the sockets for totem are built.  If the interface is down
  * this function is requeued in the timer list to retry building the sockets later.
+ */
+
+/**
+ * @brief timer_function_netif_check_timeout
+ * @param data
  */
 static void timer_function_netif_check_timeout (
 	void *data)
@@ -645,6 +696,12 @@ static void timer_function_netif_check_timeout (
 
 /* Set the socket priority to INTERACTIVE to ensure
    that our messages don't get queued behind anything else */
+
+/**
+ * @brief totemudpu_traffic_control_set
+ * @param instance
+ * @param sock
+ */
 static void totemudpu_traffic_control_set(struct totemudpu_instance *instance, int sock)
 {
 #ifdef SO_PRIORITY
@@ -657,6 +714,14 @@ static void totemudpu_traffic_control_set(struct totemudpu_instance *instance, i
 #endif
 }
 
+/**
+ * @brief totemudpu_build_sockets_ip
+ * @param instance
+ * @param bindnet_address
+ * @param bound_to
+ * @param interface_num
+ * @return
+ */
 static int totemudpu_build_sockets_ip (
 	struct totemudpu_instance *instance,
 	struct totem_ip_address *bindnet_address,
@@ -714,6 +779,13 @@ static int totemudpu_build_sockets_ip (
 	return 0;
 }
 
+/**
+ * @brief totemudpu_build_sockets
+ * @param instance
+ * @param bindnet_address
+ * @param bound_to
+ * @return
+ */
 static int totemudpu_build_sockets (
 	struct totemudpu_instance *instance,
 	struct totem_ip_address *bindnet_address,
@@ -759,6 +831,17 @@ static int totemudpu_build_sockets (
 
 /*
  * Create an instance
+ */
+
+/**
+ * @brief totemudpu_initialize
+ * @param poll_handle
+ * @param udpu_context
+ * @param totem_config
+ * @param stats
+ * @param interface_no
+ * @param context
+ * @return
  */
 int totemudpu_initialize (
 	qb_loop_t *poll_handle,
@@ -856,16 +939,30 @@ int totemudpu_initialize (
 	return (0);
 }
 
+/**
+ * @brief totemudpu_buffer_alloc
+ * @return
+ */
 void *totemudpu_buffer_alloc (void)
 {
 	return malloc (FRAME_SIZE_MAX);
 }
 
+/**
+ * @brief totemudpu_buffer_release
+ * @param ptr
+ */
 void totemudpu_buffer_release (void *ptr)
 {
 	return free (ptr);
 }
 
+/**
+ * @brief totemudpu_processor_count_set
+ * @param udpu_context
+ * @param processor_count
+ * @return
+ */
 int totemudpu_processor_count_set (
 	void *udpu_context,
 	int processor_count)
@@ -888,6 +985,11 @@ int totemudpu_processor_count_set (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_recv_flush
+ * @param udpu_context
+ * @return
+ */
 int totemudpu_recv_flush (void *udpu_context)
 {
 	int res = 0;
@@ -895,6 +997,11 @@ int totemudpu_recv_flush (void *udpu_context)
 	return (res);
 }
 
+/**
+ * @brief totemudpu_send_flush
+ * @param udpu_context
+ * @return
+ */
 int totemudpu_send_flush (void *udpu_context)
 {
 	int res = 0;
@@ -902,6 +1009,13 @@ int totemudpu_send_flush (void *udpu_context)
 	return (res);
 }
 
+/**
+ * @brief totemudpu_token_send
+ * @param udpu_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudpu_token_send (
 	void *udpu_context,
 	const void *msg,
@@ -914,6 +1028,14 @@ int totemudpu_token_send (
 
 	return (res);
 }
+
+/**
+ * @brief totemudpu_mcast_flush_send
+ * @param udpu_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudpu_mcast_flush_send (
 	void *udpu_context,
 	const void *msg,
@@ -927,6 +1049,13 @@ int totemudpu_mcast_flush_send (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_mcast_noflush_send
+ * @param udpu_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudpu_mcast_noflush_send (
 	void *udpu_context,
 	const void *msg,
@@ -940,6 +1069,11 @@ int totemudpu_mcast_noflush_send (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_iface_check
+ * @param udpu_context
+ * @return
+ */
 extern int totemudpu_iface_check (void *udpu_context)
 {
 	struct totemudpu_instance *instance = (struct totemudpu_instance *)udpu_context;
@@ -950,6 +1084,11 @@ extern int totemudpu_iface_check (void *udpu_context)
 	return (res);
 }
 
+/**
+ * @brief totemudpu_net_mtu_adjust
+ * @param udpu_context
+ * @param totem_config
+ */
 extern void totemudpu_net_mtu_adjust (void *udpu_context, struct totem_config *totem_config)
 {
 
@@ -960,6 +1099,11 @@ extern void totemudpu_net_mtu_adjust (void *udpu_context, struct totem_config *t
 				 totemip_udpip_header_size(totem_config->interfaces[0].bindnet.family);
 }
 
+/**
+ * @brief totemudpu_iface_print
+ * @param udpu_context
+ * @return
+ */
 const char *totemudpu_iface_print (void *udpu_context)  {
 	struct totemudpu_instance *instance = (struct totemudpu_instance *)udpu_context;
 	const char *ret_char;
@@ -969,6 +1113,12 @@ const char *totemudpu_iface_print (void *udpu_context)  {
 	return (ret_char);
 }
 
+/**
+ * @brief totemudpu_iface_get
+ * @param udpu_context
+ * @param addr
+ * @return
+ */
 int totemudpu_iface_get (
 	void *udpu_context,
 	struct totem_ip_address *addr)
@@ -981,6 +1131,12 @@ int totemudpu_iface_get (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_token_target_set
+ * @param udpu_context
+ * @param token_target
+ * @return
+ */
 int totemudpu_token_target_set (
 	void *udpu_context,
 	const struct totem_ip_address *token_target)
@@ -996,6 +1152,11 @@ int totemudpu_token_target_set (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_recv_mcast_empty
+ * @param udpu_context
+ * @return
+ */
 extern int totemudpu_recv_mcast_empty (
 	void *udpu_context)
 {
@@ -1047,6 +1208,12 @@ extern int totemudpu_recv_mcast_empty (
 	return (msg_processed);
 }
 
+/**
+ * @brief totemudpu_create_sending_socket
+ * @param udpu_context
+ * @param member
+ * @return
+ */
 static int totemudpu_create_sending_socket(
 	void *udpu_context,
 	const struct totem_ip_address *member)
@@ -1106,6 +1273,12 @@ error_close_fd:
 	return (-1);
 }
 
+/**
+ * @brief totemudpu_member_add
+ * @param udpu_context
+ * @param member
+ * @return
+ */
 int totemudpu_member_add (
 	void *udpu_context,
 	const struct totem_ip_address *member)
@@ -1132,6 +1305,12 @@ int totemudpu_member_add (
 	return (0);
 }
 
+/**
+ * @brief totemudpu_member_remove
+ * @param udpu_context
+ * @param token_target
+ * @return
+ */
 int totemudpu_member_remove (
 	void *udpu_context,
 	const struct totem_ip_address *token_target)
@@ -1182,6 +1361,11 @@ int totemudpu_member_remove (
 	return (0);
 }
 
+/**
+ * @brief totemudpu_member_list_rebind_ip
+ * @param udpu_context
+ * @return
+ */
 int totemudpu_member_list_rebind_ip (
 	void *udpu_context)
 {
@@ -1208,6 +1392,13 @@ int totemudpu_member_list_rebind_ip (
 	return (0);
 }
 
+/**
+ * @brief totemudpu_member_set_active
+ * @param udpu_context
+ * @param member_ip
+ * @param active
+ * @return
+ */
 int totemudpu_member_set_active (
 	void *udpu_context,
 	const struct totem_ip_address *member_ip,
@@ -1248,6 +1439,10 @@ int totemudpu_member_set_active (
 	return (0);
 }
 
+/**
+ * @brief timer_function_merge_detect_timeout
+ * @param data
+ */
 static void timer_function_merge_detect_timeout (
 	void *data)
 {
@@ -1262,6 +1457,10 @@ static void timer_function_merge_detect_timeout (
 	totemudpu_start_merge_detect_timeout(instance);
 }
 
+/**
+ * @brief totemudpu_start_merge_detect_timeout
+ * @param udpu_context
+ */
 static void totemudpu_start_merge_detect_timeout(
 	void *udpu_context)
 {
@@ -1276,6 +1475,10 @@ static void totemudpu_start_merge_detect_timeout(
 
 }
 
+/**
+ * @brief totemudpu_stop_merge_detect_timeout
+ * @param udpu_context
+ */
 static void totemudpu_stop_merge_detect_timeout(
 	void *udpu_context)
 {

--- a/exec/util.c
+++ b/exec/util.c
@@ -51,6 +51,9 @@
 
 LOGSYS_DECLARE_SUBSYS ("MAIN");
 
+/**
+ * @brief The service_names struct
+ */
 struct service_names {
 	const char *c_name;
 	int32_t c_val;
@@ -69,6 +72,13 @@ static struct service_names servicenames[] =
 	{ NULL, -1 }
 };
 
+/**
+ * @brief short_service_name_get
+ * @param service_id
+ * @param buf
+ * @param buf_size
+ * @return
+ */
 const char * short_service_name_get(uint32_t service_id,
 	char *buf, size_t buf_size)
 {
@@ -114,15 +124,31 @@ cs_time_t clust_time_now(void)
 }
 
 void _corosync_out_of_memory_error (void) __attribute__((noreturn));
+
+/**
+ * @brief _corosync_out_of_memory_error
+ */
 void _corosync_out_of_memory_error (void)
 {
 	assert (0==1);
 	exit (EXIT_FAILURE);
 }
 
+/**
+ * @brief _corosync_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 void _corosync_exit_error (
 	enum e_corosync_done err, const char *file, unsigned int line)  __attribute__((noreturn));
 
+/**
+ * @brief _corosync_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 void _corosync_exit_error (
 	enum e_corosync_done err, const char *file, unsigned int line)
 {
@@ -137,8 +163,16 @@ void _corosync_exit_error (
 	exit (err);
 }
 
+/**
+ *
+ */
 #define min(a,b) ((a) < (b) ? (a) : (b))
 
+/**
+ * @brief getcs_name_t
+ * @param name
+ * @return
+ */
 char *getcs_name_t (cs_name_t *name)
 {
 	static char ret_name[CS_MAX_NAME_LENGTH];
@@ -152,6 +186,11 @@ char *getcs_name_t (cs_name_t *name)
 	return ((char *)name->value);
 }
 
+/**
+ * @brief setcs_name_t
+ * @param name
+ * @param str
+ */
 void setcs_name_t (cs_name_t *name, char *str) {
 	strncpy ((char *)name->value, str, sizeof (name->value));
 	((char *)name->value)[sizeof (name->value) - 1] = '\0';
@@ -162,6 +201,12 @@ void setcs_name_t (cs_name_t *name, char *str) {
 	}
 }
 
+/**
+ * @brief cs_name_tisEqual
+ * @param str1
+ * @param str2
+ * @return
+ */
 int cs_name_tisEqual (cs_name_t *str1, char *str2) {
 	if (str1->length == strlen (str2)) {
 		return ((strncmp ((char *)str1->value, (char *)str2,
@@ -171,6 +216,10 @@ int cs_name_tisEqual (cs_name_t *str1, char *str2) {
 	}
 }
 
+/**
+ * @brief get_run_dir
+ * @return
+ */
 const char *get_run_dir(void)
 {
 	static char path[PATH_MAX] = {'\0'};

--- a/exec/util.h
+++ b/exec/util.h
@@ -44,6 +44,9 @@
  */
 extern cs_time_t clust_time_now(void);
 
+/**
+ * @brief The e_corosync_done enum
+ */
 enum e_corosync_done {
 	COROSYNC_DONE_EXIT = 0,
 	COROSYNC_DONE_FORK = 4,
@@ -68,12 +71,43 @@ enum e_corosync_done {
  */
 extern int name_match(cs_name_t *name1, cs_name_t *name2);
 #define corosync_exit_error(err) _corosync_exit_error ((err), __FILE__, __LINE__)
+
+/**
+ * @brief _corosync_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 extern void _corosync_exit_error (enum e_corosync_done err, const char *file,
 				  unsigned int line) __attribute__((noreturn));
+
+/**
+ * @brief _corosync_out_of_memory_error
+ */
 void _corosync_out_of_memory_error (void) __attribute__((noreturn));
+
+/**
+ * @brief getcs_name_t
+ * @param name
+ * @return
+ */
 extern char *getcs_name_t (cs_name_t *name);
+
+/**
+ * @brief setcs_name_t
+ * @param name
+ * @param str
+ */
 extern void setcs_name_t (cs_name_t *name, char *str);
+
+/**
+ * @brief cs_name_tisEqual
+ * @param str1
+ * @param str2
+ * @return
+ */
 extern int cs_name_tisEqual (cs_name_t *str1, char *str2);
+
 /**
  * Get the short name of a service from the service_id.
  */

--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -346,6 +346,9 @@ static void message_handler_req_lib_votequorum_qdevice_poll (void *conn,
 static void message_handler_req_lib_votequorum_qdevice_master_wins (void *conn,
 							     const void *message);
 
+/**
+ *
+ */
 static struct corosync_lib_handler quorum_lib_service[] =
 {
 	{ /* 0 */
@@ -390,6 +393,9 @@ static struct corosync_lib_handler quorum_lib_service[] =
 	}
 };
 
+/**
+ *
+ */
 static struct corosync_service_engine votequorum_service_engine = {
 	.name				= "corosync vote quorum service v1.0",
 	.id				= VOTEQUORUM_SERVICE,
@@ -411,11 +417,18 @@ static struct corosync_service_engine votequorum_service_engine = {
 	.sync_abort			= votequorum_sync_abort
 };
 
+/**
+ * @brief votequorum_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *votequorum_get_service_engine_ver0 (void)
 {
 	return (&votequorum_service_engine);
 }
 
+/**
+ *
+ */
 static struct default_service votequorum_service[] = {
 	{
 		.name		= "corosync_votequorum",
@@ -433,6 +446,10 @@ static struct default_service votequorum_service[] = {
 #define list_iterate(v, head) \
 	for (v = (head)->next; v != head; v = v->next)
 
+/**
+ * @brief node_add_ordered
+ * @param newnode
+ */
 static void node_add_ordered(struct cluster_node *newnode)
 {
 	struct cluster_node *node = NULL;
@@ -460,6 +477,11 @@ static void node_add_ordered(struct cluster_node *newnode)
 	LEAVE();
 }
 
+/**
+ * @brief allocate_node
+ * @param nodeid
+ * @return
+ */
 static struct cluster_node *allocate_node(unsigned int nodeid)
 {
 	struct cluster_node *cl = NULL;
@@ -499,6 +521,11 @@ out:
 	return cl;
 }
 
+/**
+ * @brief find_node_by_nodeid
+ * @param nodeid
+ * @return
+ */
 static struct cluster_node *find_node_by_nodeid(unsigned int nodeid)
 {
 	struct cluster_node *node;
@@ -528,6 +555,9 @@ static struct cluster_node *find_node_by_nodeid(unsigned int nodeid)
 	return NULL;
 }
 
+/**
+ * @brief get_lowest_node_id
+ */
 static void get_lowest_node_id(void)
 {
 	struct cluster_node *node = NULL;
@@ -550,6 +580,9 @@ static void get_lowest_node_id(void)
 	LEAVE();
 }
 
+/**
+ * @brief get_highest_node_id
+ */
 static void get_highest_node_id(void)
 {
 	struct cluster_node *node = NULL;
@@ -572,6 +605,10 @@ static void get_highest_node_id(void)
 	LEAVE();
 }
 
+/**
+ * @brief check_low_node_id_partition
+ * @return
+ */
 static int check_low_node_id_partition(void)
 {
 	struct cluster_node *node = NULL;
@@ -592,6 +629,10 @@ static int check_low_node_id_partition(void)
 	return found;
 }
 
+/**
+ * @brief check_high_node_id_partition
+ * @return
+ */
 static int check_high_node_id_partition(void)
 {
 	struct cluster_node *node = NULL;
@@ -612,6 +653,13 @@ static int check_high_node_id_partition(void)
 	return found;
 }
 
+/**
+ * @brief is_in_nodelist
+ * @param nodeid
+ * @param members
+ * @param entries
+ * @return
+ */
 static int is_in_nodelist(int nodeid, unsigned int *members, int entries)
 {
 	int i;
@@ -639,6 +687,10 @@ static int is_in_nodelist(int nodeid, unsigned int *members, int entries)
  * partition then we are quorate.
  *
  * Special cases lowest nodeid, and highest nodeid are handled separately.
+ */
+/**
+ * @brief check_auto_tie_breaker
+ * @return
  */
 static int check_auto_tie_breaker(void)
 {
@@ -696,6 +748,11 @@ static int check_auto_tie_breaker(void)
  *   'highest'
  *   a list of nodeids
  */
+
+/**
+ * @brief parse_atb_string
+ * @param atb_string
+ */
 static void parse_atb_string(char *atb_string)
 {
 	char *ptr;
@@ -737,6 +794,10 @@ static void parse_atb_string(char *atb_string)
 	LEAVE();
 }
 
+/**
+ * @brief check_qdevice_master
+ * @return
+ */
 static int check_qdevice_master(void)
 {
 	struct cluster_node *node = NULL;
@@ -758,6 +819,10 @@ static int check_qdevice_master(void)
 	return found;
 }
 
+/**
+ * @brief decode_flags
+ * @param flags
+ */
 static void decode_flags(uint32_t flags)
 {
 	ENTER();
@@ -778,6 +843,10 @@ static void decode_flags(uint32_t flags)
 
 /*
  * load/save are copied almost pristine from totemsrp,c
+ */
+/**
+ * @brief load_ev_tracking_barrier
+ * @return
  */
 static int load_ev_tracking_barrier(void)
 {
@@ -817,6 +886,10 @@ static int load_ev_tracking_barrier(void)
 	return -1;
 }
 
+/**
+ * @brief update_wait_for_all_status
+ * @param wfa_status
+ */
 static void update_wait_for_all_status(uint8_t wfa_status)
 {
 	ENTER(); 
@@ -833,6 +906,9 @@ static void update_wait_for_all_status(uint8_t wfa_status)
 	LEAVE();
 }
 
+/**
+ * @brief update_two_node
+ */
 static void update_two_node(void)
 {
 	ENTER();
@@ -842,6 +918,10 @@ static void update_two_node(void)
 	LEAVE();
 }
 
+/**
+ * @brief update_ev_barrier
+ * @param expected_votes
+ */
 static void update_ev_barrier(uint32_t expected_votes)
 {
 	ENTER();
@@ -852,6 +932,10 @@ static void update_ev_barrier(uint32_t expected_votes)
 	LEAVE();
 }
 
+/**
+ * @brief update_qdevice_can_operate
+ * @param status
+ */
 static void update_qdevice_can_operate(uint8_t status)
 {
 	ENTER();
@@ -862,6 +946,10 @@ static void update_qdevice_can_operate(uint8_t status)
 	LEAVE();
 }
 
+/**
+ * @brief update_qdevice_master_wins
+ * @param allow
+ */
 static void update_qdevice_master_wins(uint8_t allow)
 {
 	ENTER();
@@ -872,6 +960,10 @@ static void update_qdevice_master_wins(uint8_t allow)
 	LEAVE();
 }
 
+/**
+ * @brief update_ev_tracking_barrier
+ * @param ev_t_barrier
+ */
 static void update_ev_tracking_barrier(uint32_t ev_t_barrier)
 {
 	int res;
@@ -905,7 +997,13 @@ static void update_ev_tracking_barrier(uint32_t ev_t_barrier)
 /*
  * quorum calculation core bits
  */
-
+/**
+ * @brief calculate_quorum
+ * @param allow_decrease
+ * @param max_expected
+ * @param ret_total_votes
+ * @return
+ */
 static int calculate_quorum(int allow_decrease, unsigned int max_expected, unsigned int *ret_total_votes)
 {
 	struct list_head *nodelist;
@@ -983,6 +1081,10 @@ static int calculate_quorum(int allow_decrease, unsigned int max_expected, unsig
 	return newquorum;
 }
 
+/**
+ * @brief are_we_quorate
+ * @param total_votes
+ */
 static void are_we_quorate(unsigned int total_votes)
 {
 	int quorate;
@@ -1064,6 +1166,11 @@ static void are_we_quorate(unsigned int total_votes)
 	LEAVE();
 }
 
+/**
+ * @brief get_total_votes
+ * @param totalvotes
+ * @param current_members
+ */
 static void get_total_votes(unsigned int *totalvotes, unsigned int *current_members)
 {
 	unsigned int total_votes = 0;
@@ -1094,6 +1201,11 @@ static void get_total_votes(unsigned int *totalvotes, unsigned int *current_memb
 
 /*
  * Recalculate cluster quorum, set quorate and notify changes
+ */
+/**
+ * @brief recalculate_quorum
+ * @param allow_decrease
+ * @param by_current_nodes
  */
 static void recalculate_quorum(int allow_decrease, int by_current_nodes)
 {
@@ -1131,7 +1243,13 @@ static void recalculate_quorum(int allow_decrease, int by_current_nodes)
 /*
  * configuration bits and pieces
  */
-
+/**
+ * @brief votequorum_read_nodelist_configuration
+ * @param votes
+ * @param nodes
+ * @param expected_votes
+ * @return
+ */
 static int votequorum_read_nodelist_configuration(uint32_t *votes,
 						  uint32_t *nodes,
 						  uint32_t *expected_votes)
@@ -1190,6 +1308,11 @@ static int votequorum_read_nodelist_configuration(uint32_t *votes,
 	return 1;
 }
 
+/**
+ * @brief votequorum_qdevice_is_configured
+ * @param qdevice_votes
+ * @return
+ */
 static int votequorum_qdevice_is_configured(uint32_t *qdevice_votes)
 {
 	char *qdevice_model = NULL;
@@ -1223,6 +1346,11 @@ static int votequorum_qdevice_is_configured(uint32_t *qdevice_votes)
 #define VOTEQUORUM_READCONFIG_STARTUP 0
 #define VOTEQUORUM_READCONFIG_RUNTIME 1
 
+/**
+ * @brief votequorum_readconfig
+ * @param runtime
+ * @return
+ */
 static char *votequorum_readconfig(int runtime)
 {
 	uint32_t node_votes = 0, qdevice_votes = 0;
@@ -1526,6 +1654,14 @@ out:
 	return error;
 }
 
+/**
+ * @brief votequorum_refresh_config
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void votequorum_refresh_config(
 	int32_t event,
 	const char *key_name,
@@ -1581,6 +1717,9 @@ static void votequorum_refresh_config(
 	LEAVE();
 }
 
+/**
+ * @brief votequorum_exec_add_config_notification
+ */
 static void votequorum_exec_add_config_notification(void)
 {
 	icmap_track_t icmap_track_nodelist = NULL;
@@ -1613,7 +1752,13 @@ static void votequorum_exec_add_config_notification(void)
 /*
  * votequorum_exec core
  */
-
+/**
+ * @brief votequorum_exec_send_reconfigure
+ * @param param
+ * @param nodeid
+ * @param value
+ * @return
+ */
 static int votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, uint32_t value)
 {
 	struct req_exec_quorum_reconfigure req_exec_quorum_reconfigure;
@@ -1641,6 +1786,11 @@ static int votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, 
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_send_nodeinfo
+ * @param nodeid
+ * @return
+ */
 static int votequorum_exec_send_nodeinfo(uint32_t nodeid)
 {
 	struct req_exec_quorum_nodeinfo req_exec_quorum_nodeinfo;
@@ -1675,6 +1825,12 @@ static int votequorum_exec_send_nodeinfo(uint32_t nodeid)
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_send_qdevice_reconfigure
+ * @param oldname
+ * @param newname
+ * @return
+ */
 static int votequorum_exec_send_qdevice_reconfigure(const char *oldname, const char *newname)
 {
 	struct req_exec_quorum_qdevice_reconfigure req_exec_quorum_qdevice_reconfigure;
@@ -1697,6 +1853,12 @@ static int votequorum_exec_send_qdevice_reconfigure(const char *oldname, const c
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_send_qdevice_reg
+ * @param operation
+ * @param qdevice_name_req
+ * @return
+ */
 static int votequorum_exec_send_qdevice_reg(uint32_t operation, const char *qdevice_name_req)
 {
 	struct req_exec_quorum_qdevice_reg req_exec_quorum_qdevice_reg;
@@ -1719,6 +1881,12 @@ static int votequorum_exec_send_qdevice_reg(uint32_t operation, const char *qdev
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_send_quorum_notification
+ * @param conn
+ * @param context
+ * @return
+ */
 static int votequorum_exec_send_quorum_notification(void *conn, uint64_t context)
 {
 	struct res_lib_votequorum_notification *res_lib_votequorum_notification;
@@ -1780,6 +1948,9 @@ static int votequorum_exec_send_quorum_notification(void *conn, uint64_t context
 	return 0;
 }
 
+/**
+ * @brief votequorum_exec_send_expectedvotes_notification
+ */
 static void votequorum_exec_send_expectedvotes_notification(void)
 {
 	struct res_lib_votequorum_expectedvotes_notification res_lib_votequorum_expectedvotes_notification;
@@ -1805,6 +1976,10 @@ static void votequorum_exec_send_expectedvotes_notification(void)
 	LEAVE();
 }
 
+/**
+ * @brief exec_votequorum_qdevice_reconfigure_endian_convert
+ * @param message
+ */
 static void exec_votequorum_qdevice_reconfigure_endian_convert (void *message)
 {
 	ENTER();
@@ -1812,6 +1987,11 @@ static void exec_votequorum_qdevice_reconfigure_endian_convert (void *message)
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_votequorum_qdevice_reconfigure
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_votequorum_qdevice_reconfigure (
 	const void *message,
 	unsigned int nodeid)
@@ -1839,6 +2019,10 @@ static void message_handler_req_exec_votequorum_qdevice_reconfigure (
 	LEAVE();
 }
 
+/**
+ * @brief exec_votequorum_qdevice_reg_endian_convert
+ * @param message
+ */
 static void exec_votequorum_qdevice_reg_endian_convert (void *message)
 {
 	struct req_exec_quorum_qdevice_reg *req_exec_quorum_qdevice_reg = message;
@@ -1850,6 +2034,11 @@ static void exec_votequorum_qdevice_reg_endian_convert (void *message)
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_votequorum_qdevice_reg
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_votequorum_qdevice_reg (
 	const void *message,
 	unsigned int nodeid)
@@ -1944,6 +2133,10 @@ static void message_handler_req_exec_votequorum_qdevice_reg (
 	LEAVE();
 }
 
+/**
+ * @brief exec_votequorum_nodeinfo_endian_convert
+ * @param message
+ */
 static void exec_votequorum_nodeinfo_endian_convert (void *message)
 {
 	struct req_exec_quorum_nodeinfo *nodeinfo = message;
@@ -1958,6 +2151,11 @@ static void exec_votequorum_nodeinfo_endian_convert (void *message)
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_votequorum_nodeinfo
+ * @param message
+ * @param sender_nodeid
+ */
 static void message_handler_req_exec_votequorum_nodeinfo (
 	const void *message,
 	unsigned int sender_nodeid)
@@ -2076,6 +2274,10 @@ recalculate:
 	LEAVE();
 }
 
+/**
+ * @brief exec_votequorum_reconfigure_endian_convert
+ * @param message
+ */
 static void exec_votequorum_reconfigure_endian_convert (void *message)
 {
 	struct req_exec_quorum_reconfigure *reconfigure = message;
@@ -2088,6 +2290,11 @@ static void exec_votequorum_reconfigure_endian_convert (void *message)
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_votequorum_reconfigure
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_votequorum_reconfigure (
 	const void *message,
 	unsigned int nodeid)
@@ -2141,6 +2348,10 @@ static void message_handler_req_exec_votequorum_reconfigure (
 	LEAVE();
 }
 
+/**
+ * @brief votequorum_exec_exit_fn
+ * @return
+ */
 static int votequorum_exec_exit_fn (void)
 {
 	int ret = 0;
@@ -2165,6 +2376,11 @@ static int votequorum_exec_exit_fn (void)
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_init_fn
+ * @param api
+ * @return
+ */
 static char *votequorum_exec_init_fn (struct corosync_api_v1 *api)
 {
 	char *error = NULL;
@@ -2230,7 +2446,10 @@ static char *votequorum_exec_init_fn (struct corosync_api_v1 *api)
 /*
  * votequorum service core
  */
-
+/**
+ * @brief votequorum_last_man_standing_timer_fn
+ * @param arg
+ */
 static void votequorum_last_man_standing_timer_fn(void *arg)
 {
 	ENTER();
@@ -2243,6 +2462,14 @@ static void votequorum_last_man_standing_timer_fn(void *arg)
 	LEAVE();
 }
 
+/**
+ * @brief votequorum_sync_init
+ * @param trans_list
+ * @param trans_list_entries
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void votequorum_sync_init (
 	const unsigned int *trans_list, size_t trans_list_entries,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -2326,6 +2553,10 @@ static void votequorum_sync_init (
 	LEAVE();
 }
 
+/**
+ * @brief votequorum_sync_process
+ * @return
+ */
 static int votequorum_sync_process (void)
 {
 
@@ -2350,6 +2581,9 @@ static int votequorum_sync_process (void)
 	return 0;
 }
 
+/**
+ * @brief votequorum_sync_activate
+ */
 static void votequorum_sync_activate (void)
 {
 	recalculate_quorum(0, 0);
@@ -2360,11 +2594,20 @@ static void votequorum_sync_activate (void)
 	sync_in_progress = 0;
 }
 
+/**
+ * @brief votequorum_sync_abort
+ */
 static void votequorum_sync_abort (void)
 {
 
 }
 
+/**
+ * @brief votequorum_init
+ * @param api
+ * @param q_set_quorate_fn
+ * @return
+ */
 char *votequorum_init(struct corosync_api_v1 *api,
 	quorum_set_quorate_fn_t q_set_quorate_fn)
 {
@@ -2394,6 +2637,11 @@ char *votequorum_init(struct corosync_api_v1 *api,
  * Library Handler init/fini
  */
 
+/**
+ * @brief quorum_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int quorum_lib_init_fn (void *conn)
 {
 	struct quorum_pd *pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
@@ -2407,6 +2655,11 @@ static int quorum_lib_init_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief quorum_lib_exit_fn
+ * @param conn
+ * @return
+ */
 static int quorum_lib_exit_fn (void *conn)
 {
 	struct quorum_pd *quorum_pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
@@ -2427,6 +2680,10 @@ static int quorum_lib_exit_fn (void *conn)
  * library internal functions
  */
 
+/**
+ * @brief qdevice_timer_fn
+ * @param arg
+ */
 static void qdevice_timer_fn(void *arg)
 {
 	ENTER();
@@ -2452,6 +2709,11 @@ static void qdevice_timer_fn(void *arg)
  * Library Handler Functions
  */
 
+/**
+ * @brief message_handler_req_lib_votequorum_getinfo
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_getinfo (void *conn, const void *message)
 {
 	const struct req_lib_votequorum_getinfo *req_lib_votequorum_getinfo = message;
@@ -2561,6 +2823,11 @@ static void message_handler_req_lib_votequorum_getinfo (void *conn, const void *
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_setexpected
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_setexpected (void *conn, const void *message)
 {
 	const struct req_lib_votequorum_setexpected *req_lib_votequorum_setexpected = message;
@@ -2598,6 +2865,11 @@ error_exit:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_setvotes
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_setvotes (void *conn, const void *message)
 {
 	const struct req_lib_votequorum_setvotes *req_lib_votequorum_setvotes = message;
@@ -2645,6 +2917,11 @@ error_exit:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_trackstart
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_trackstart (void *conn,
 							   const void *message)
 {
@@ -2692,6 +2969,11 @@ response_send:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_trackstop
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_trackstop (void *conn,
 							  const void *message)
 {
@@ -2718,6 +3000,11 @@ static void message_handler_req_lib_votequorum_trackstop (void *conn,
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_register
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_register (void *conn,
 								 const void *message)
 {
@@ -2774,6 +3061,11 @@ out:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_unregister
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_unregister (void *conn,
 								   const void *message)
 {
@@ -2813,6 +3105,11 @@ out:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_update
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_update (void *conn,
 							       const void *message)
 {
@@ -2842,6 +3139,11 @@ out:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_poll
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_poll (void *conn,
 							     const void *message)
 {
@@ -2908,6 +3210,11 @@ out:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_master_wins
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_master_wins (void *conn,
 							     const void *message)
 {

--- a/exec/votequorum.h
+++ b/exec/votequorum.h
@@ -39,6 +39,12 @@
 #include <corosync/list.h>
 #include <corosync/coroapi.h>
 
+/**
+ * @brief votequorum_init
+ * @param api
+ * @param q_set_quorate_fn
+ * @return
+ */
 char *votequorum_init(struct corosync_api_v1 *api,
 	quorum_set_quorate_fn_t q_set_quorate_fn);
 

--- a/exec/vsf.h
+++ b/exec/vsf.h
@@ -39,6 +39,9 @@ struct corosync_vsf_iface_ver0 {
 
 	/**
 	 * Executes a callback whenever component changes
+         * @param api
+         * @param primary_callback_fn
+         * @returns ???
 	 */
 	int (*init) (
 	    struct corosync_api_v1 *api,
@@ -49,8 +52,10 @@ struct corosync_vsf_iface_ver0 {
 		struct memb_ring_id *ring_id));
 
 	/**
-	 * @retval 1 if we are primary component
-	 * @retval 0 if not primary component
+         * Call to determine if we are the primary component.
+         *
+         * @returns 1 if we are primary component
+         * @returns 0 if not primary component
 	 */
 	int (*primary) (void);
 };

--- a/exec/vsf_quorum.c
+++ b/exec/vsf_quorum.c
@@ -73,6 +73,9 @@
 
 LOGSYS_DECLARE_SUBSYS ("QUORUM");
 
+/**
+ * @brief The quorum_pd struct
+ */
 struct quorum_pd {
 	unsigned char track_flags;
 	int tracking_enabled;
@@ -80,6 +83,9 @@ struct quorum_pd {
 	void *conn;
 };
 
+/**
+ * @brief The internal_callback_pd struct
+ */
 struct internal_callback_pd {
 	struct list_head list;
 	quorum_callback_fn_t callback;
@@ -111,6 +117,11 @@ static int quorum_view_list[PROCESSOR_COUNT_MAX];
 struct quorum_services_api_ver1 *quorum_iface = NULL;
 static char view_buf[64];
 
+/**
+ * @brief log_view_list
+ * @param view_list
+ * @param view_list_entries
+ */
 static void log_view_list(const unsigned int *view_list, size_t view_list_entries)
 {
 	int total = (int)view_list_entries;
@@ -137,6 +148,13 @@ static void log_view_list(const unsigned int *view_list, size_t view_list_entrie
 }
 
 /* Internal quorum API function */
+/**
+ * @brief quorum_api_set_quorum
+ * @param view_list
+ * @param view_list_entries
+ * @param quorum
+ * @param ring_id
+ */
 static void quorum_api_set_quorum(const unsigned int *view_list,
 				  size_t view_list_entries,
 				  int quorum, struct memb_ring_id *ring_id)
@@ -163,6 +181,9 @@ static void quorum_api_set_quorum(const unsigned int *view_list,
 	send_library_notification(NULL);
 }
 
+/**
+ *
+ */
 static struct corosync_lib_handler quorum_lib_service[] =
 {
 	{ /* 0 */
@@ -183,6 +204,9 @@ static struct corosync_lib_handler quorum_lib_service[] =
 	}
 };
 
+/**
+ *
+ */
 static struct corosync_service_engine quorum_service_handler = {
 	.name				        = "corosync cluster quorum service v0.1",
 	.id					= QUORUM_SERVICE,
@@ -197,6 +221,10 @@ static struct corosync_service_engine quorum_service_handler = {
 	.lib_engine_count			= sizeof (quorum_lib_service) / sizeof (struct corosync_lib_handler)
 };
 
+/**
+ * @brief vsf_quorum_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *vsf_quorum_get_service_engine_ver0 (void)
 {
 	return (&quorum_service_handler);
@@ -209,12 +237,21 @@ struct corosync_service_engine *vsf_quorum_get_service_engine_ver0 (void)
  * Internal API functions for corosync
  */
 
+/**
+ * @brief quorum_quorate
+ * @return
+ */
 static int quorum_quorate(void)
 {
 	return primary_designated;
 }
 
-
+/**
+ * @brief quorum_register_callback
+ * @param function
+ * @param context
+ * @return
+ */
 static int quorum_register_callback(quorum_callback_fn_t function, void *context)
 {
 	struct internal_callback_pd *pd = malloc(sizeof(struct internal_callback_pd));
@@ -228,6 +265,12 @@ static int quorum_register_callback(quorum_callback_fn_t function, void *context
 	return 0;
 }
 
+/**
+ * @brief quorum_unregister_callback
+ * @param function
+ * @param context
+ * @return
+ */
 static int quorum_unregister_callback(quorum_callback_fn_t function, void *context)
 {
 	struct internal_callback_pd *pd;
@@ -245,14 +288,20 @@ static int quorum_unregister_callback(quorum_callback_fn_t function, void *conte
 	return -1;
 }
 
+/**
+ *
+ */
 static struct quorum_callin_functions callins = {
 	.quorate = quorum_quorate,
 	.register_callback = quorum_register_callback,
 	.unregister_callback = quorum_unregister_callback
 };
 
-/* --------------------------------------------------------------------- */
-
+/**
+ * @brief quorum_exec_init_fn
+ * @param api
+ * @return
+ */
 static char *quorum_exec_init_fn (struct corosync_api_v1 *api)
 {
 	char *quorum_module = NULL;
@@ -310,6 +359,11 @@ static char *quorum_exec_init_fn (struct corosync_api_v1 *api)
 	return (NULL);
 }
 
+/**
+ * @brief quorum_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int quorum_lib_init_fn (void *conn)
 {
 	struct quorum_pd *pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
@@ -322,6 +376,11 @@ static int quorum_lib_init_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief quorum_lib_exit_fn
+ * @param conn
+ * @return
+ */
 static int quorum_lib_exit_fn (void *conn)
 {
 	struct quorum_pd *quorum_pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
@@ -335,7 +394,9 @@ static int quorum_lib_exit_fn (void *conn)
 	return (0);
 }
 
-
+/**
+ * @brief send_internal_notification
+ */
 static void send_internal_notification(void)
 {
 	struct list_head *tmp;
@@ -349,6 +410,10 @@ static void send_internal_notification(void)
 	}
 }
 
+/**
+ * @brief send_library_notification
+ * @param conn
+ */
 static void send_library_notification(void *conn)
 {
 	int size = sizeof(struct res_lib_quorum_notification) + sizeof(unsigned int)*quorum_view_list_entries;
@@ -388,6 +453,11 @@ static void send_library_notification(void *conn)
 	return;
 }
 
+/**
+ * @brief message_handler_req_lib_quorum_getquorate
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_quorum_getquorate (void *conn,
 						       const void *msg)
 {
@@ -403,6 +473,11 @@ static void message_handler_req_lib_quorum_getquorate (void *conn,
 	corosync_api->ipc_response_send(conn, &res_lib_quorum_getquorate, sizeof(res_lib_quorum_getquorate));
 }
 
+/**
+ * @brief message_handler_req_lib_quorum_trackstart
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_quorum_trackstart (void *conn,
 						       const void *msg)
 {
@@ -448,6 +523,11 @@ response_send:
 	corosync_api->ipc_response_send(conn, &res, sizeof(struct qb_ipc_response_header));
 }
 
+/**
+ * @brief message_handler_req_lib_quorum_trackstop
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_quorum_trackstop (void *conn, const void *msg)
 {
 	struct qb_ipc_response_header res;
@@ -471,6 +551,11 @@ static void message_handler_req_lib_quorum_trackstop (void *conn, const void *ms
 	corosync_api->ipc_response_send(conn, &res, sizeof(struct qb_ipc_response_header));
 }
 
+/**
+ * @brief message_handler_req_lib_quorum_gettype
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_quorum_gettype (void *conn,
 						       const void *msg)
 {

--- a/exec/vsf_ykd.c
+++ b/exec/vsf_ykd.c
@@ -70,26 +70,41 @@ LOGSYS_DECLARE_SUBSYS ("YKD");
 
 #define YKD_PROCESSOR_COUNT_MAX 32
 
+/**
+ * @brief The ykd_header_values enum
+ */
 enum ykd_header_values {
 	YKD_HEADER_SENDSTATE = 0,
 	YKD_HEADER_ATTEMPT = 1
 };
 
+/**
+ * @brief The ykd_mode enum
+ */
 enum ykd_mode {
 	YKD_MODE_SENDSTATE = 0,
 	YKD_MODE_ATTEMPT = 1
 };
 
+/**
+ * @brief The ykd_header struct
+ */
 struct ykd_header {
 	int id;
 };
 
+/**
+ * @brief The ykd_session struct
+ */
 struct ykd_session {
 	unsigned int member_list[YKD_PROCESSOR_COUNT_MAX];
 	int member_list_entries;
 	int session_id;
 };
 
+/**
+ * @brief The ykd_state struct
+ */
 struct ykd_state {
 	struct ykd_session last_primary;
 
@@ -104,6 +119,9 @@ struct ykd_state {
 	int session_id;
 };
 
+/**
+ * @brief The state_received struct
+ */
 struct state_received {
 	unsigned int nodeid;
 	int received;
@@ -146,12 +164,18 @@ hdb_handle_t schedwrk_state_send_callback_handle;
 
 static struct corosync_api_v1 *api;
 
+/**
+ *
+ */
 static void (*ykd_primary_callback_fn) (
 	const unsigned int *view_list,
 	size_t view_list_entries,
 	int primary_designated,
 	struct memb_ring_id *ring_id) = NULL;
 
+/**
+ * @brief ykd_state_init
+ */
 static void ykd_state_init (void)
 {
 	ykd_state.session_id = 0;
@@ -161,6 +185,11 @@ static void ykd_state_init (void)
 	ykd_state.last_primary.member_list_entries = 0;
 }
 
+/**
+ * @brief ykd_state_send_msg
+ * @param context
+ * @return
+ */
 static int ykd_state_send_msg (const void *context)
 {
 	struct iovec iovec[2];
@@ -180,6 +209,9 @@ static int ykd_state_send_msg (const void *context)
 	return (res);
 }
 
+/**
+ * @brief ykd_state_send
+ */
 static void ykd_state_send (void)
 {
 	api->schedwrk_create (
@@ -188,6 +220,11 @@ static void ykd_state_send (void)
                 NULL);
 }
 
+/**
+ * @brief ykd_attempt_send_msg
+ * @param context
+ * @return
+ */
 static int ykd_attempt_send_msg (const void *context)
 {
 	struct iovec iovec;
@@ -205,6 +242,9 @@ static int ykd_attempt_send_msg (const void *context)
 	return (res);
 }
 
+/**
+ * @brief ykd_attempt_send
+ */
 static void ykd_attempt_send (void)
 {
 	api->schedwrk_create (
@@ -213,6 +253,9 @@ static void ykd_attempt_send (void)
                 NULL);
 }
 
+/**
+ * @brief compute
+ */
 static void compute (void)
 {
 	int i;
@@ -251,6 +294,13 @@ static void compute (void)
 	}
 }
 
+/**
+ * @brief subquorum
+ * @param member_list
+ * @param member_list_entries
+ * @param session
+ * @return
+ */
 static int subquorum (
 	unsigned int *member_list,
 	int member_list_entries,
@@ -284,6 +334,10 @@ static int subquorum (
 	return (0);
 }
 
+/**
+ * @brief decide
+ * @return
+ */
 static int decide (void)
 {
 	int i;
@@ -304,6 +358,10 @@ static int decide (void)
 	return (1);
 }
 
+/**
+ * @brief ykd_session_endian_convert
+ * @param ykd_session
+ */
 static void ykd_session_endian_convert (struct ykd_session *ykd_session)
 {
 	int i;
@@ -317,6 +375,10 @@ static void ykd_session_endian_convert (struct ykd_session *ykd_session)
 	}
 }
 
+/**
+ * @brief ykd_state_endian_convert
+ * @param state
+ */
 static void ykd_state_endian_convert (struct ykd_state *state)
 {
 	int i;
@@ -335,6 +397,13 @@ static void ykd_state_endian_convert (struct ykd_state *state)
 	}
 }
 
+/**
+ * @brief ykd_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static void ykd_deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
@@ -453,7 +522,22 @@ static void ykd_deliver_fn (
 	}
 }
 
+/**
+ * @brief first_run
+ */
 int first_run = 1;
+
+/**
+ * @brief ykd_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void ykd_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -503,11 +587,20 @@ static void ykd_confchg_fn (
 	ykd_state_send ();
 }
 
+/**
+ *
+ */
 struct corosync_tpg_group ykd_group = {
 	.group		= "ykd",
 	.group_len	= 3
 };
 
+/**
+ * @brief ykd_init
+ * @param corosync_api
+ * @param set_primary
+ * @return
+ */
 char *ykd_init (
 	struct corosync_api_v1 *corosync_api,
 	quorum_set_quorate_fn_t set_primary)

--- a/exec/vsf_ykd.h
+++ b/exec/vsf_ykd.h
@@ -39,6 +39,12 @@
 #include <corosync/list.h>
 #include <corosync/coroapi.h>
 
+/**
+ * @brief ykd_init
+ * @param api
+ * @param set_primary
+ * @return
+ */
 char *ykd_init(struct corosync_api_v1 *api,
 	quorum_set_quorate_fn_t set_primary);
 

--- a/include/corosync/cfg.h
+++ b/include/corosync/cfg.h
@@ -60,15 +60,24 @@ typedef enum {
 	COROSYNC_CFG_SHUTDOWN_FLAG_IMMEDIATE = 2,
 } corosync_cfg_shutdown_flags_t;
 
+/**
+ * @brief enum corosync_cfg_shutdown_reply_flags_t
+ */
 typedef enum {
 	COROSYNC_CFG_SHUTDOWN_FLAG_NO = 0,
 	COROSYNC_CFG_SHUTDOWN_FLAG_YES = 1,
 } corosync_cfg_shutdown_reply_flags_t;
 
+/**
+ * @brief corosync_cfg_shutdown_callback_t callback
+ */
 typedef void (*corosync_cfg_shutdown_callback_t) (
 	corosync_cfg_handle_t cfg_handle,
 	corosync_cfg_shutdown_flags_t flags);
 
+/**
+ * @brief struct corosync_cfg_shutdown_callback_t
+ */
 typedef struct {
 	corosync_cfg_shutdown_callback_t corosync_cfg_shutdown_callback;
 } corosync_cfg_callbacks_t;

--- a/include/corosync/coroapi.h
+++ b/include/corosync/coroapi.h
@@ -159,6 +159,9 @@ typedef enum {
 #ifndef QUORUM_H_DEFINED
 typedef void (*quorum_callback_fn_t) (int quorate, void *context);
 
+/**
+ * @brief The quorum_callin_functions struct
+ */
 struct quorum_callin_functions {
 	int (*quorate) (void);
 	int (*register_callback) (quorum_callback_fn_t callback_fn, void *contexxt);
@@ -174,6 +177,9 @@ typedef void (*sync_callback_fn_t) (
 #endif /* QUORUM_H_DEFINED */
 
 
+/**
+ * @brief The corosync_api_v1 struct
+ */
 struct corosync_api_v1 {
 	/*
 	 * Time and timer APIs
@@ -414,20 +420,32 @@ struct corosync_api_v1 {
 
 #define SERVICES_COUNT_MAX 64
 
+/**
+ * @brief The corosync_lib_handler struct
+ */
 struct corosync_lib_handler {
 	void (*lib_handler_fn) (void *conn, const void *msg);
 	enum cs_lib_flow_control flow_control;
 };
 
+/**
+ * @brief The corosync_exec_handler struct
+ */
 struct corosync_exec_handler {
 	void (*exec_handler_fn) (const void *msg, unsigned int nodeid);
 	void (*exec_endian_convert_fn) (void *msg);
 };
 
+/**
+ * @brief The corosync_service_engine_iface_ver0 struct
+ */
 struct corosync_service_engine_iface_ver0 {
         struct corosync_service_engine *(*corosync_get_service_engine_ver0) (void);
 };
 
+/**
+ * @brief The corosync_service_engine struct
+ */
 struct corosync_service_engine {
 	const char *name;
 	unsigned short id;

--- a/include/corosync/corotypes.h
+++ b/include/corosync/corotypes.h
@@ -116,6 +116,11 @@ typedef enum {
 #define CS_TIME_US_IN_MSEC  1000ULL
 #define CS_TIME_NS_IN_MSEC  1000000ULL
 #define CS_TIME_NS_IN_USEC  1000ULL
+
+/**
+ * @brief cs_timestamp_get
+ * @return
+ */
 static inline uint64_t cs_timestamp_get(void)
 {
 	uint64_t result;

--- a/include/corosync/hdb.h
+++ b/include/corosync/hdb.h
@@ -59,20 +59,37 @@ typedef qb_handle_t hdb_handle_t;
 
 #define hdb_handle_database qb_hdb
 
+/**
+ * @brief hdb_database_lock
+ * @param mutex
+ */
 static inline void hdb_database_lock (pthread_mutex_t *mutex)
 {
 	pthread_mutex_lock (mutex);
 }
 
+/**
+ * @brief hdb_database_unlock
+ * @param mutex
+ */
 static inline void hdb_database_unlock (pthread_mutex_t *mutex)
 {
 	pthread_mutex_unlock (mutex);
 }
+
+/**
+ * @brief hdb_database_lock_init
+ * @param mutex
+ */
 static inline void hdb_database_lock_init (pthread_mutex_t *mutex)
 {
 	pthread_mutex_init (mutex, NULL);
 }
 
+/**
+ * @brief hdb_database_lock_destroy
+ * @param mutex
+ */
 static inline void hdb_database_lock_destroy (pthread_mutex_t *mutex)
 {
 	pthread_mutex_destroy (mutex);
@@ -80,19 +97,33 @@ static inline void hdb_database_lock_destroy (pthread_mutex_t *mutex)
 
 #define DECLARE_HDB_DATABASE QB_HDB_DECLARE
 
+/**
+ * @brief hdb_create
+ * @param handle_database
+ */
 static inline void hdb_create (
 	struct hdb_handle_database *handle_database)
 {
 	qb_hdb_create (handle_database);
 }
 
+/**
+ * @brief hdb_destroy
+ * @param handle_database
+ */
 static inline void hdb_destroy (
 	struct hdb_handle_database *handle_database)
 {
 	qb_hdb_destroy (handle_database);
 }
 
-
+/**
+ * @brief hdb_handle_create
+ * @param handle_database
+ * @param instance_size
+ * @param handle_id_out
+ * @return
+ */
 static inline int hdb_handle_create (
 	struct hdb_handle_database *handle_database,
 	int instance_size,
@@ -102,6 +133,13 @@ static inline int hdb_handle_create (
 		handle_id_out));
 }
 
+/**
+ * @brief hdb_handle_get
+ * @param handle_database
+ * @param handle_in
+ * @param instance
+ * @return
+ */
 static inline int hdb_handle_get (
 	struct hdb_handle_database *handle_database,
 	hdb_handle_t handle_in,
@@ -110,6 +148,13 @@ static inline int hdb_handle_get (
 	return (qb_hdb_handle_get (handle_database, handle_in, instance));
 }
 
+/**
+ * @brief hdb_handle_get_always
+ * @param handle_database
+ * @param handle_in
+ * @param instance
+ * @return
+ */
 static inline int hdb_handle_get_always (
 	struct hdb_handle_database *handle_database,
 	hdb_handle_t handle_in,
@@ -118,6 +163,12 @@ static inline int hdb_handle_get_always (
 	return (qb_hdb_handle_get_always (handle_database, handle_in, instance));
 }
 
+/**
+ * @brief hdb_handle_put
+ * @param handle_database
+ * @param handle_in
+ * @return
+ */
 static inline int hdb_handle_put (
 	struct hdb_handle_database *handle_database,
 	hdb_handle_t handle_in)
@@ -125,6 +176,12 @@ static inline int hdb_handle_put (
 	return (qb_hdb_handle_put (handle_database, handle_in));
 }
 
+/**
+ * @brief hdb_handle_destroy
+ * @param handle_database
+ * @param handle_in
+ * @return
+ */
 static inline int hdb_handle_destroy (
 	struct hdb_handle_database *handle_database,
 	hdb_handle_t handle_in)
@@ -132,6 +189,12 @@ static inline int hdb_handle_destroy (
 	return (qb_hdb_handle_destroy (handle_database, handle_in));
 }
 
+/**
+ * @brief hdb_handle_refcount_get
+ * @param handle_database
+ * @param handle_in
+ * @return
+ */
 static inline int hdb_handle_refcount_get (
 	struct hdb_handle_database *handle_database,
 	hdb_handle_t handle_in)
@@ -139,12 +202,23 @@ static inline int hdb_handle_refcount_get (
 	return (qb_hdb_handle_refcount_get (handle_database, handle_in));
 }
 
+/**
+ * @brief hdb_iterator_reset
+ * @param handle_database
+ */
 static inline void hdb_iterator_reset (
 	struct hdb_handle_database *handle_database)
 {
 	qb_hdb_iterator_reset (handle_database);
 }
 
+/**
+ * @brief hdb_iterator_next
+ * @param handle_database
+ * @param instance
+ * @param handle
+ * @return
+ */
 static inline int hdb_iterator_next (
 	struct hdb_handle_database *handle_database,
 	void **instance,
@@ -153,11 +227,21 @@ static inline int hdb_iterator_next (
 	return (qb_hdb_iterator_next (handle_database, instance, handle));
 }
 
+/**
+ * @brief hdb_base_convert
+ * @param handle
+ * @return
+ */
 static inline unsigned int hdb_base_convert (hdb_handle_t handle)
 {
 	return (qb_hdb_base_convert (handle));
 }
 
+/**
+ * @brief hdb_nocheck_convert
+ * @param handle
+ * @return
+ */
 static inline unsigned long long hdb_nocheck_convert (unsigned int handle)
 {
 	return (qb_hdb_nocheck_convert (handle));

--- a/include/corosync/ipc_cfg.h
+++ b/include/corosync/ipc_cfg.h
@@ -47,6 +47,9 @@
  */
 #define CFG_MAX_INTERFACES			16
 
+/**
+ * @brief The req_lib_cfg_types enum
+ */
 enum req_lib_cfg_types {
 	MESSAGE_REQ_CFG_RINGSTATUSGET = 0,
 	MESSAGE_REQ_CFG_RINGREENABLE = 1,
@@ -59,6 +62,9 @@ enum req_lib_cfg_types {
 	MESSAGE_REQ_CFG_CRYPTO_SET = 8
 };
 
+/**
+ * @brief The res_lib_cfg_types enum
+ */
 enum res_lib_cfg_types {
         MESSAGE_RES_CFG_RINGSTATUSGET = 0,
         MESSAGE_RES_CFG_RINGREENABLE = 1,
@@ -78,10 +84,16 @@ enum res_lib_cfg_types {
 	MESSAGE_RES_CFG_RELOAD_CONFIG = 15
 };
 
+/**
+ * @brief The req_lib_cfg_ringstatusget struct
+ */
 struct req_lib_cfg_ringstatusget {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cfg_ringstatusget struct
+ */
 struct res_lib_cfg_ringstatusget {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t interface_count __attribute__((aligned(8)));
@@ -89,52 +101,85 @@ struct res_lib_cfg_ringstatusget {
 	char interface_status[CFG_MAX_INTERFACES][CFG_INTERFACE_STATUS_MAX_LEN] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cfg_ringreenable struct
+ */
 struct req_lib_cfg_ringreenable {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cfg_ringreenable struct
+ */
 struct res_lib_cfg_ringreenable {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cfg_killnode struct
+ */
 struct req_lib_cfg_killnode {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	unsigned int nodeid __attribute__((aligned(8)));
 	cs_name_t reason __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cfg_killnode struct
+ */
 struct res_lib_cfg_killnode {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cfg_tryshutdown struct
+ */
 struct req_lib_cfg_tryshutdown {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	unsigned int flags;
 };
 
+/**
+ * @brief The res_lib_cfg_tryshutdown struct
+ */
 struct res_lib_cfg_tryshutdown {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cfg_replytoshutdown struct
+ */
 struct req_lib_cfg_replytoshutdown {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	unsigned int response;
 };
 
+/**
+ * @brief The res_lib_cfg_replytoshutdown struct
+ */
 struct res_lib_cfg_replytoshutdown {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cfg_testshutdown struct
+ */
 struct res_lib_cfg_testshutdown {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	unsigned int flags;
 };
 
+/**
+ * @brief The req_lib_cfg_get_node_addrs struct
+ */
 struct req_lib_cfg_get_node_addrs {
         struct qb_ipc_request_header header __attribute__((aligned(8)));
 	unsigned int nodeid;
 };
 
+/**
+ * @brief The res_lib_cfg_get_node_addrs struct
+ */
 struct res_lib_cfg_get_node_addrs {
         struct qb_ipc_response_header header __attribute__((aligned(8)));
 	unsigned int family;
@@ -143,23 +188,38 @@ struct res_lib_cfg_get_node_addrs {
 	char addrs[];
 };
 
+/**
+ * @brief The req_lib_cfg_local_get struct
+ */
 struct req_lib_cfg_local_get {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cfg_local_get struct
+ */
 struct res_lib_cfg_local_get {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t local_nodeid __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cfg_reload_config struct
+ */
 struct req_lib_cfg_reload_config {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cfg_reload_config struct
+ */
 struct res_lib_cfg_reload_config {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief corosync_administrative_target_t enum
+ */
 typedef enum {
 	AIS_AMF_ADMINISTRATIVETARGET_SERVICEUNIT = 0,
 	AIS_AMF_ADMINISTRATIVETARGET_SERVICEGROUP = 1,
@@ -167,12 +227,18 @@ typedef enum {
 	AIS_AMF_ADMINISTRATIVETARGET_NODE = 3
 } corosync_administrative_target_t;
 
+/**
+ * @brief corosync_administrative_state_t enum
+ */
 typedef enum {
 	AIS_AMF_ADMINISTRATIVESTATE_UNLOCKED = 0,
 	AIS_AMF_ADMINISTRATIVESTATE_LOCKED = 1,
 	AIS_AMF_ADMINISTRATIVESTATE_STOPPING = 2
 } corosync_administrative_state_t;
 
+/**
+ * @brief corosync_shutdown_flags_t enum
+ */
 typedef enum {
 	CFG_SHUTDOWN_FLAG_REQUEST = 0,
 	CFG_SHUTDOWN_FLAG_REGARDLESS = 1,

--- a/include/corosync/ipc_cmap.h
+++ b/include/corosync/ipc_cmap.h
@@ -39,6 +39,9 @@
 #include <corosync/corotypes.h>
 #include <corosync/mar_gen.h>
 
+/**
+ * @brief The req_cmap_types enum
+ */
 enum req_cmap_types {
 	MESSAGE_REQ_CMAP_SET = 0,
 	MESSAGE_REQ_CMAP_DELETE = 1,
@@ -51,6 +54,9 @@ enum req_cmap_types {
 	MESSAGE_REQ_CMAP_TRACK_DELETE = 8,
 };
 
+/**
+ * @brief The res_cmap_types enum
+ */
 enum res_cmap_types {
 	MESSAGE_RES_CMAP_SET = 0,
 	MESSAGE_RES_CMAP_DELETE = 1,
@@ -64,6 +70,9 @@ enum res_cmap_types {
 	MESSAGE_RES_CMAP_NOTIFY_CALLBACK = 9,
 };
 
+/**
+ * @brief The req_lib_cmap_set struct
+ */
 struct req_lib_cmap_set {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_name_t key_name __attribute__((aligned(8)));
@@ -72,25 +81,40 @@ struct req_lib_cmap_set {
 	mar_uint8_t value[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_set struct
+ */
 struct res_lib_cmap_set {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cmap_delete struct
+ */
 struct req_lib_cmap_delete {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_name_t key_name __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_delete struct
+ */
 struct res_lib_cmap_delete {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cmap_get struct
+ */
 struct req_lib_cmap_get {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_name_t key_name __attribute__((aligned(8)));
 	mar_size_t value_len __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_get struct
+ */
 struct res_lib_cmap_get {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_size_t value_len __attribute__((aligned(8)));
@@ -98,31 +122,49 @@ struct res_lib_cmap_get {
 	mar_uint8_t value[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cmap_adjust_int struct
+ */
 struct req_lib_cmap_adjust_int {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_name_t key_name __attribute__((aligned(8)));
 	mar_int32_t step __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_adjust_int struct
+ */
 struct res_lib_cmap_adjust_int {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cmap_iter_init struct
+ */
 struct req_lib_cmap_iter_init {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_name_t prefix __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_iter_init struct
+ */
 struct res_lib_cmap_iter_init {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint64_t iter_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cmap_iter_next struct
+ */
 struct req_lib_cmap_iter_next {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_uint64_t iter_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_iter_next struct
+ */
 struct res_lib_cmap_iter_next {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_name_t key_name __attribute__((aligned(8)));
@@ -130,15 +172,24 @@ struct res_lib_cmap_iter_next {
 	mar_uint8_t type __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cmap_iter_finalize struct
+ */
 struct req_lib_cmap_iter_finalize {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_uint64_t iter_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_iter_finalize struct
+ */
 struct res_lib_cmap_iter_finalize {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cmap_track_add struct
+ */
 struct req_lib_cmap_track_add {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_name_t key_name __attribute__((aligned(8)));
@@ -146,21 +197,33 @@ struct req_lib_cmap_track_add {
 	mar_uint64_t track_inst_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_track_add struct
+ */
 struct res_lib_cmap_track_add {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint64_t track_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cmap_track_delete struct
+ */
 struct req_lib_cmap_track_delete {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_uint64_t track_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_track_delete struct
+ */
 struct res_lib_cmap_track_delete {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint64_t track_inst_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cmap_notify_callback struct
+ */
 struct res_lib_cmap_notify_callback {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint64_t track_inst_handle __attribute__((aligned(8)));

--- a/include/corosync/ipc_cpg.h
+++ b/include/corosync/ipc_cpg.h
@@ -42,6 +42,9 @@
 
 #define CPG_ZC_PATH_LEN				128
 
+/**
+ * @brief The req_cpg_types enum
+ */
 enum req_cpg_types {
 	MESSAGE_REQ_CPG_JOIN = 0,
 	MESSAGE_REQ_CPG_LEAVE = 1,
@@ -58,6 +61,9 @@ enum req_cpg_types {
 	MESSAGE_REQ_CPG_PARTIAL_MCAST = 12,
 };
 
+/**
+ * @brief The res_cpg_types enum
+ */
 enum res_cpg_types {
 	MESSAGE_RES_CPG_JOIN = 0,
 	MESSAGE_RES_CPG_LEAVE = 1,
@@ -80,6 +86,9 @@ enum res_cpg_types {
 	MESSAGE_RES_CPG_PARTIAL_SEND = 18,
 };
 
+/**
+ * @brief The lib_cpg_confchg_reason enum
+ */
 enum lib_cpg_confchg_reason {
 	CONFCHG_CPG_REASON_JOIN = 1,
 	CONFCHG_CPG_REASON_LEAVE = 2,
@@ -88,22 +97,37 @@ enum lib_cpg_confchg_reason {
 	CONFCHG_CPG_REASON_PROCDOWN = 5
 };
 
+/**
+ * @brief The lib_cpg_partial_types enum
+ */
 enum lib_cpg_partial_types {
 	LIBCPG_PARTIAL_FIRST = 1,
 	LIBCPG_PARTIAL_CONTINUED = 2,
 	LIBCPG_PARTIAL_LAST = 3,
 };
 
+/**
+ * @brief mar_cpg_name_t struct
+ */
 typedef struct {
 	uint32_t length __attribute__((aligned(8)));
 	char value[CPG_MAX_NAME_LENGTH] __attribute__((aligned(8)));
 } mar_cpg_name_t;
 
+/**
+ * @brief swab_mar_cpg_name_t
+ * @param to_swab
+ */
 static inline void swab_mar_cpg_name_t (mar_cpg_name_t *to_swab)
 {
 	swab_mar_uint32_t (&to_swab->length);
 }
 
+/**
+ * @brief marshall_from_mar_cpg_name_t
+ * @param dest
+ * @param src
+ */
 static inline void marshall_from_mar_cpg_name_t (
 	struct cpg_name *dest,
 	const mar_cpg_name_t *src)
@@ -112,6 +136,11 @@ static inline void marshall_from_mar_cpg_name_t (
 	memcpy (&dest->value, &src->value, CPG_MAX_NAME_LENGTH);
 }
 
+/**
+ * @brief marshall_to_mar_cpg_name_t
+ * @param dest
+ * @param src
+ */
 static inline void marshall_to_mar_cpg_name_t (
 	mar_cpg_name_t *dest,
 	const struct cpg_name *src)
@@ -120,12 +149,20 @@ static inline void marshall_to_mar_cpg_name_t (
 	memcpy (&dest->value, &src->value, CPG_MAX_NAME_LENGTH);
 }
 
+/**
+ * @brief mar_cpg_address_t struct
+ */
 typedef struct {
         mar_uint32_t nodeid __attribute__((aligned(8)));
         mar_uint32_t pid __attribute__((aligned(8)));
         mar_uint32_t reason __attribute__((aligned(8)));
 } mar_cpg_address_t;
 
+/**
+ * @brief marshall_from_mar_cpg_address_t
+ * @param dest
+ * @param src
+ */
 static inline void marshall_from_mar_cpg_address_t (
 	struct cpg_address *dest,
 	const mar_cpg_address_t *src)
@@ -135,6 +172,11 @@ static inline void marshall_from_mar_cpg_address_t (
 	dest->reason = src->reason;
 }
 
+/**
+ * @brief marshall_to_mar_cpg_address_t
+ * @param dest
+ * @param src
+ */
 static inline void marshall_to_mar_cpg_address_t (
 	mar_cpg_address_t *dest,
 	const struct cpg_address *src)
@@ -144,6 +186,12 @@ static inline void marshall_to_mar_cpg_address_t (
 	dest->reason = src->reason;
 }
 
+/**
+ * @brief mar_name_compare
+ * @param g1
+ * @param g2
+ * @return
+ */
 static inline int mar_name_compare (
 		const mar_cpg_name_t *g1,
 		const mar_cpg_name_t *g2)
@@ -153,12 +201,20 @@ static inline int mar_name_compare (
 		g1->length - g2->length);
 }
 
+/**
+ * @brief mar_cpg_iteration_description_t struct
+ */
 typedef struct {
 	mar_cpg_name_t group;
 	mar_uint32_t nodeid;
 	mar_uint32_t pid;
 } mar_cpg_iteration_description_t;
 
+/**
+ * @brief marshall_from_mar_cpg_iteration_description_t
+ * @param dest
+ * @param src
+ */
 static inline void marshall_from_mar_cpg_iteration_description_t(
 	struct cpg_iteration_description_t *dest,
 	const mar_cpg_iteration_description_t *src)
@@ -168,11 +224,19 @@ static inline void marshall_from_mar_cpg_iteration_description_t(
 	marshall_from_mar_cpg_name_t (&dest->group, &src->group);
 };
 
+/**
+ * @brief mar_cpg_ring_id_t struct
+ */
 typedef struct {
         mar_uint32_t nodeid __attribute__((aligned(8)));
         mar_uint64_t seq __attribute__((aligned(8)));
 } mar_cpg_ring_id_t;
 
+/**
+ * @brief marshall_from_mar_cpg_ring_id_t
+ * @param dest
+ * @param src
+ */
 static inline void marshall_from_mar_cpg_ring_id_t (
 	struct cpg_ring_id *dest,
 	const mar_cpg_ring_id_t *src)
@@ -181,6 +245,9 @@ static inline void marshall_from_mar_cpg_ring_id_t (
 	dest->seq = src->seq;
 }
 
+/**
+ * @brief The req_lib_cpg_join struct
+ */
 struct req_lib_cpg_join {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -188,31 +255,52 @@ struct req_lib_cpg_join {
 	mar_uint32_t flags __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_join struct
+ */
 struct res_lib_cpg_join {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cpg_finalize struct
+ */
 struct req_lib_cpg_finalize {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_finalize struct
+ */
 struct res_lib_cpg_finalize {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cpg_local_get struct
+ */
 struct req_lib_cpg_local_get {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_local_get struct
+ */
 struct res_lib_cpg_local_get {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t local_nodeid __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_partial_send struct
+ */
 struct res_lib_cpg_partial_send {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cpg_mcast struct
+ */
 struct req_lib_cpg_mcast {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t guarantee __attribute__((aligned(8)));
@@ -220,6 +308,9 @@ struct req_lib_cpg_mcast {
 	mar_uint8_t message[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cpg_partial_mcast struct
+ */
 struct req_lib_cpg_partial_mcast {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t guarantee __attribute__((aligned(8)));
@@ -229,6 +320,9 @@ struct req_lib_cpg_partial_mcast {
 	mar_uint8_t message[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_mcast struct
+ */
 struct res_lib_cpg_mcast {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
@@ -245,6 +339,9 @@ struct res_lib_cpg_deliver_callback {
 	mar_uint8_t message[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_partial_deliver_callback struct
+ */
 struct res_lib_cpg_partial_deliver_callback {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -256,22 +353,34 @@ struct res_lib_cpg_partial_deliver_callback {
 	mar_uint8_t message[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_flowcontrol_callback struct
+ */
 struct res_lib_cpg_flowcontrol_callback {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t flow_control_state __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cpg_membership_get struct
+ */
 struct req_lib_cpg_membership_get {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_membership_get struct
+ */
 struct res_lib_cpg_membership_get {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t member_count __attribute__((aligned(8)));
 	mar_cpg_address_t member_list[PROCESSOR_COUNT_MAX];
 };
 
+/**
+ * @brief The res_lib_cpg_confchg_callback struct
+ */
 struct res_lib_cpg_confchg_callback {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -283,6 +392,9 @@ struct res_lib_cpg_confchg_callback {
 //	struct cpg_address joined_list[];
 };
 
+/**
+ * @brief The res_lib_cpg_totem_confchg_callback struct
+ */
 struct res_lib_cpg_totem_confchg_callback {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_cpg_ring_id_t ring_id __attribute__((aligned(8)));
@@ -290,63 +402,99 @@ struct res_lib_cpg_totem_confchg_callback {
 	mar_uint32_t member_list[];
 };
 
+/**
+ * @brief The req_lib_cpg_leave struct
+ */
 struct req_lib_cpg_leave {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
 	mar_uint32_t pid __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_leave struct
+ */
 struct res_lib_cpg_leave {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cpg_iterationinitialize struct
+ */
 struct req_lib_cpg_iterationinitialize {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
 	mar_uint32_t iteration_type __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_iterationinitialize struct
+ */
 struct res_lib_cpg_iterationinitialize {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	hdb_handle_t iteration_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cpg_iterationnext struct
+ */
 struct req_lib_cpg_iterationnext {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	hdb_handle_t iteration_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_iterationnext struct
+ */
 struct res_lib_cpg_iterationnext {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_cpg_iteration_description_t description __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_cpg_iterationfinalize struct
+ */
 struct req_lib_cpg_iterationfinalize {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	hdb_handle_t iteration_handle __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_cpg_iterationfinalize struct
+ */
 struct res_lib_cpg_iterationfinalize {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief mar_req_coroipcc_zc_alloc_t struct
+ */
 typedef struct {
         struct qb_ipc_request_header header __attribute__((aligned(8)));
         size_t map_size __attribute__((aligned(8)));
         char path_to_file[CPG_ZC_PATH_LEN] __attribute__((aligned(8)));
 } mar_req_coroipcc_zc_alloc_t __attribute__((aligned(8)));
 
+/**
+ * @brief mar_req_coroipcc_zc_free_t struct
+ */
 typedef struct {
         struct qb_ipc_request_header header __attribute__((aligned(8)));
         size_t map_size __attribute__((aligned(8)));
 	uint64_t server_address __attribute__((aligned(8)));
 } mar_req_coroipcc_zc_free_t __attribute__((aligned(8)));
 
+/**
+ * @brief mar_req_coroipcc_zc_execute_t struct
+ */
 typedef struct {
         struct qb_ipc_request_header header __attribute__((aligned(8)));
 	uint64_t server_address __attribute__((aligned(8)));
 } mar_req_coroipcc_zc_execute_t __attribute__((aligned(8)));
 
+/**
+ * @brief coroipcs_zc_header struct
+ */
 struct coroipcs_zc_header {
 	int map_size;
 	uint64_t server_address;

--- a/include/corosync/ipc_quorum.h
+++ b/include/corosync/ipc_quorum.h
@@ -37,6 +37,9 @@
 #include <corosync/corotypes.h>
 #include <corosync/mar_gen.h>
 
+/**
+ * @brief The req_quorum_types enum
+ */
 enum req_quorum_types {
 	MESSAGE_REQ_QUORUM_GETQUORATE = 0,
 	MESSAGE_REQ_QUORUM_TRACKSTART,
@@ -44,6 +47,9 @@ enum req_quorum_types {
 	MESSAGE_REQ_QUORUM_GETTYPE
 };
 
+/**
+ * @brief The res_quorum_types enum
+ */
 enum res_quorum_types {
 	MESSAGE_RES_QUORUM_GETQUORATE = 0,
 	MESSAGE_RES_QUORUM_TRACKSTART,
@@ -52,17 +58,25 @@ enum res_quorum_types {
 	MESSAGE_RES_QUORUM_GETTYPE
 };
 
+/**
+ * @brief The req_lib_quorum_trackstart struct
+ */
 struct req_lib_quorum_trackstart {
         struct qb_ipc_request_header header __attribute__((aligned(8)));
 	unsigned int track_flags;
 };
 
-
+/**
+ * @brief The res_lib_quorum_getquorate struct
+ */
 struct res_lib_quorum_getquorate {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t quorate;
 };
 
+/**
+ * @brief The res_lib_quorum_notification struct
+ */
 struct res_lib_quorum_notification {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_int32_t quorate __attribute__((aligned(8)));
@@ -71,6 +85,9 @@ struct res_lib_quorum_notification {
 	mar_uint32_t view_list[];
 };
 
+/**
+ * @brief The res_lib_quorum_gettype struct
+ */
 struct res_lib_quorum_gettype {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t quorum_type;

--- a/include/corosync/ipc_votequorum.h
+++ b/include/corosync/ipc_votequorum.h
@@ -40,6 +40,9 @@
 #define VOTEQUORUM_QDEVICE_MAX_NAME_LEN      255
 #define VOTEQUORUM_QDEVICE_DEFAULT_TIMEOUT 10000
 
+/**
+ * @brief The req_votequorum_types enum
+ */
 enum req_votequorum_types {
 	MESSAGE_REQ_VOTEQUORUM_GETINFO = 0,
 	MESSAGE_REQ_VOTEQUORUM_SETEXPECTED,
@@ -53,6 +56,9 @@ enum req_votequorum_types {
 	MESSAGE_REQ_VOTEQUORUM_QDEVICE_MASTER_WINS
 };
 
+/**
+ * @brief The res_votequorum_types enum
+ */
 enum res_votequorum_types {
 	MESSAGE_RES_VOTEQUORUM_STATUS = 0,
 	MESSAGE_RES_VOTEQUORUM_GETINFO,
@@ -61,27 +67,42 @@ enum res_votequorum_types {
 	MESSAGE_RES_VOTEQUORUM_EXPECTEDVOTES_NOTIFICATION
 };
 
+/**
+ * @brief The mar_votequorum_ring_id struct
+ */
 struct mar_votequorum_ring_id {
 	mar_uint32_t nodeid;
 	mar_uint64_t seq;
 };
 
+/**
+ * @brief The req_lib_votequorum_qdevice_register struct
+ */
 struct req_lib_votequorum_qdevice_register {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	char name[VOTEQUORUM_QDEVICE_MAX_NAME_LEN];
 };
 
+/**
+ * @brief The req_lib_votequorum_qdevice_unregister struct
+ */
 struct req_lib_votequorum_qdevice_unregister {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	char name[VOTEQUORUM_QDEVICE_MAX_NAME_LEN];
 };
 
+/**
+ * @brief The req_lib_votequorum_qdevice_update struct
+ */
 struct req_lib_votequorum_qdevice_update {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	char oldname[VOTEQUORUM_QDEVICE_MAX_NAME_LEN];
 	char newname[VOTEQUORUM_QDEVICE_MAX_NAME_LEN];
 };
 
+/**
+ * @brief The req_lib_votequorum_qdevice_poll struct
+ */
 struct req_lib_votequorum_qdevice_poll {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	char name[VOTEQUORUM_QDEVICE_MAX_NAME_LEN];
@@ -89,38 +110,59 @@ struct req_lib_votequorum_qdevice_poll {
 	struct mar_votequorum_ring_id ring_id __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_votequorum_qdevice_master_wins struct
+ */
 struct req_lib_votequorum_qdevice_master_wins {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	char name[VOTEQUORUM_QDEVICE_MAX_NAME_LEN];
 	unsigned int allow;
 };
 
+/**
+ * @brief The req_lib_votequorum_setvotes struct
+ */
 struct req_lib_votequorum_setvotes {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	unsigned int votes;
 	int nodeid;
 };
 
+/**
+ * @brief The req_lib_votequorum_setexpected struct
+ */
 struct req_lib_votequorum_setexpected {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	unsigned int expected_votes;
 };
 
+/**
+ * @brief The req_lib_votequorum_trackstart struct
+ */
 struct req_lib_votequorum_trackstart {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	uint64_t context;
 	unsigned int track_flags;
 };
 
+/**
+ * @brief The req_lib_votequorum_general struct
+ */
 struct req_lib_votequorum_general {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_lib_votequorum_getinfo struct
+ */
 struct req_lib_votequorum_getinfo {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	int nodeid;
 };
 
+/**
+ * @brief The res_lib_votequorum_status struct
+ */
 struct res_lib_votequorum_status {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 };
@@ -140,6 +182,9 @@ struct res_lib_votequorum_status {
 #define VOTEQUORUM_NODESTATE_DEAD       2
 #define VOTEQUORUM_NODESTATE_LEAVING    3
 
+/**
+ * @brief The res_lib_votequorum_getinfo struct
+ */
 struct res_lib_votequorum_getinfo {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	unsigned int nodeid;
@@ -154,11 +199,17 @@ struct res_lib_votequorum_getinfo {
 	char qdevice_name[VOTEQUORUM_QDEVICE_MAX_NAME_LEN];
 };
 
+/**
+ * @brief The votequorum_node struct
+ */
 struct votequorum_node {
 	mar_uint32_t nodeid;
 	mar_uint32_t state;
 };
 
+/**
+ * @brief The res_lib_votequorum_notification struct
+ */
 struct res_lib_votequorum_notification {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint32_t quorate __attribute__((aligned(8)));
@@ -168,12 +219,20 @@ struct res_lib_votequorum_notification {
 	struct votequorum_node node_list[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_votequorum_expectedvotes_notification struct
+ */
 struct res_lib_votequorum_expectedvotes_notification {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint64_t context __attribute__((aligned(8)));
 	mar_uint32_t expected_votes __attribute__((aligned(8)));
 };
 
+/**
+ * @brief marshall_from_mar_votequorum_ring_id
+ * @param dest
+ * @param src
+ */
 static inline void marshall_from_mar_votequorum_ring_id (
 	votequorum_ring_id_t *dest,
 	const struct mar_votequorum_ring_id *src)
@@ -182,6 +241,11 @@ static inline void marshall_from_mar_votequorum_ring_id (
 	dest->seq = src->seq;
 };
 
+/**
+ * @brief marshall_to_mar_votequorum_ring_id
+ * @param dest
+ * @param src
+ */
 static inline void marshall_to_mar_votequorum_ring_id (
 	struct mar_votequorum_ring_id *dest,
 	const votequorum_ring_id_t *src)

--- a/include/corosync/logsys.h
+++ b/include/corosync/logsys.h
@@ -194,6 +194,9 @@ static void logsys_system_init (void)					\
 #define LOGSYS_DECLARE_SECTION
 #endif
 
+/**
+ *
+ */
 #define LOGSYS_DECLARE_SUBSYS(subsys)					\
 __attribute__ ((constructor))						\
 static void logsys_subsys_init (void)					\
@@ -208,6 +211,9 @@ static void logsys_subsys_init (void)					\
 	}								\
 }
 
+/**
+ *
+ */
 #define LOGSYS_PERROR(err_num, level, fmt, args...) do {						\
 		char _error_str[LOGSYS_MAX_PERROR_MSG_LEN];						\
 		const char *_error_ptr = qb_strerror_r(err_num, _error_str, sizeof(_error_str));	\

--- a/include/corosync/mar_gen.h
+++ b/include/corosync/mar_gen.h
@@ -53,46 +53,83 @@ typedef uint16_t mar_uint16_t;
 typedef uint32_t mar_uint32_t;
 typedef uint64_t mar_uint64_t;
 
+/**
+ * @brief swab_mar_int8_t
+ * @param to_swab
+ */
 static inline void swab_mar_int8_t (mar_int8_t *to_swab)
 {
 	return;
 }
 
+/**
+ * @brief swab_mar_int16_t
+ * @param to_swab
+ */
 static inline void swab_mar_int16_t (mar_int16_t *to_swab)
 {
 	*to_swab = swab16 (*to_swab);
 }
 
+/**
+ * @brief swab_mar_int32_t
+ * @param to_swab
+ */
 static inline void swab_mar_int32_t (mar_int32_t *to_swab)
 {
 	*to_swab = swab32 (*to_swab);
 }
 
+/**
+ * @brief swab_mar_int64_t
+ * @param to_swab
+ */
 static inline void swab_mar_int64_t (mar_int64_t *to_swab)
 {
 	*to_swab = swab64 (*to_swab);
 }
 
+/**
+ * @brief swab_mar_uint8_t
+ * @param to_swab
+ */
 static inline void swab_mar_uint8_t (mar_uint8_t *to_swab)
 {
 	return;
 }
 
+/**
+ * @brief swab_mar_uint16_t
+ * @param to_swab
+ */
 static inline void swab_mar_uint16_t (mar_uint16_t *to_swab)
 {
 	*to_swab = swab16 (*to_swab);
 }
 
+/**
+ * @brief swab_mar_uint32_t
+ * @param to_swab
+ */
 static inline void swab_mar_uint32_t (mar_uint32_t *to_swab)
 {
 	*to_swab = swab32 (*to_swab);
 }
 
+/**
+ * @brief swab_mar_uint64_t
+ * @param to_swab
+ */
 static inline void swab_mar_uint64_t (mar_uint64_t *to_swab)
 {
 	*to_swab = swab64 (*to_swab);
 }
 
+/**
+ * @brief swabbin
+ * @param data
+ * @param len
+ */
 static inline void swabbin(char *data, size_t len)
 {
 	int i;
@@ -105,25 +142,47 @@ static inline void swabbin(char *data, size_t len)
 	}
 }
 
+/**
+ * @brief swabflt
+ * @param flt
+ */
 static inline void swabflt(float *flt)
 {
 	swabbin((char *)flt, sizeof(*flt));
 }
 
+/**
+ * @brief swabdbl
+ * @param dbl
+ */
 static inline void swabdbl(double *dbl)
 {
 	swabbin((char *)dbl, sizeof(*dbl));
 }
 
+/**
+ * @brief mar_name_t struct
+ */
 typedef struct {
 	mar_uint16_t length __attribute__((aligned(8)));
 	mar_uint8_t value[CS_MAX_NAME_LENGTH] __attribute__((aligned(8)));
 } mar_name_t;
 
+/**
+ * @brief get_mar_name_t
+ * @param name
+ * @return
+ */
 static inline const char *get_mar_name_t (const mar_name_t *name) {
         return ((const char *)name->value);
 }
 
+/**
+ * @brief mar_name_match
+ * @param name1
+ * @param name2
+ * @return
+ */
 static inline int mar_name_match(const mar_name_t *name1, const mar_name_t *name2)
 {
         if (name1->length == name2->length) {
@@ -134,12 +193,20 @@ static inline int mar_name_match(const mar_name_t *name1, const mar_name_t *name
         return 0;
 }
 
-
+/**
+ * @brief swab_mar_name_t
+ * @param to_swab
+ */
 static inline void swab_mar_name_t (mar_name_t *to_swab)
 {
 	swab_mar_uint16_t (&to_swab->length);
 }
 
+/**
+ * @brief marshall_from_mar_name_t
+ * @param dest
+ * @param src
+ */
 static inline void marshall_from_mar_name_t (
 	cs_name_t *dest,
 	const mar_name_t *src)
@@ -148,6 +215,11 @@ static inline void marshall_from_mar_name_t (
 	memcpy (dest->value, src->value, CS_MAX_NAME_LENGTH);
 }
 
+/**
+ * @brief marshall_to_mar_name_t
+ * @param dest
+ * @param src
+ */
 static inline void marshall_to_mar_name_t (
 	mar_name_t *dest,
 	const cs_name_t *src)
@@ -156,13 +228,23 @@ static inline void marshall_to_mar_name_t (
 	memcpy (dest->value, src->value, CS_MAX_NAME_LENGTH);
 }
 
+/**
+ * @brief mar_bool_t enum
+ */
 typedef enum {
 	MAR_FALSE = 0,
 	MAR_TRUE = 1
 } mar_bool_t;
 
+/**
+ * @brief mar_time_t
+ */
 typedef mar_uint64_t mar_time_t;
 
+/**
+ * @brief swab_mar_time_t
+ * @param to_swab
+ */
 static inline void swab_mar_time_t (mar_time_t *to_swab)
 {
 	swab_mar_uint64_t (to_swab);
@@ -184,20 +266,38 @@ static inline void swab_mar_time_t (mar_time_t *to_swab)
 #define MAR_TRACK_CHANGES 0x02
 #define MAR_TRACK_CHANGES_ONLY 0x04
 
+/**
+ * @brief mar_invocation_t
+ */
 typedef mar_uint64_t mar_invocation_t;
 
+/**
+ * @brief swab_mar_invocation_t
+ * @param to_swab
+ */
 static inline void swab_mar_invocation_t (mar_invocation_t *to_swab)
 {
 	swab_mar_uint64_t (to_swab);
 }
 
+/**
+ * @brief mar_size_t
+ */
 typedef mar_uint64_t mar_size_t;
 
+/**
+ * @brief swab_mar_size_t
+ * @param to_swab
+ */
 static inline void swab_mar_size_t (mar_size_t *to_swab)
 {
 	swab_mar_uint64_t (to_swab);
 }
 
+/**
+ * @brief swab_coroipc_request_header_t
+ * @param to_swab
+ */
 static inline void swab_coroipc_request_header_t (struct qb_ipc_request_header *to_swab)
 {
 	swab_mar_int32_t (&to_swab->size);

--- a/include/corosync/quorum.h
+++ b/include/corosync/quorum.h
@@ -42,6 +42,9 @@ extern "C" {
 
 typedef uint64_t quorum_handle_t;
 
+/**
+ * @brief quorum_notification_fn_t callback
+ */
 typedef void (*quorum_notification_fn_t) (
 	quorum_handle_t handle,
 	uint32_t quorate,
@@ -50,6 +53,9 @@ typedef void (*quorum_notification_fn_t) (
 	uint32_t *view_list
 	);
 
+/**
+ * @brief quorum_callbacks_t struct
+ */
 typedef struct {
 	quorum_notification_fn_t quorum_notify_fn;
 } quorum_callbacks_t;

--- a/include/corosync/sam.h
+++ b/include/corosync/sam.h
@@ -40,6 +40,9 @@
 extern "C" {
 #endif
 
+/**
+ * @brief sam_recovery_policy_t enum
+ */
 typedef enum {
 	SAM_RECOVERY_POLICY_QUIT = 1,
 	SAM_RECOVERY_POLICY_RESTART = 2,

--- a/include/corosync/sq.h
+++ b/include/corosync/sq.h
@@ -37,6 +37,9 @@
 #include <errno.h>
 #include <string.h>
 
+/**
+ * @brief The sq struct
+ */
 struct sq {
 	unsigned int head;
 	unsigned int size;
@@ -65,6 +68,12 @@ struct sq {
  */
 #define ADJUST_ROLLOVER_VALUE 0x10000
 
+/**
+ * @brief sq_lt_compare
+ * @param a
+ * @param b
+ * @return
+ */
 static inline int sq_lt_compare (unsigned int a, unsigned int b) {
 	if ((a > ADJUST_ROLLOVER_POINT) || (b > ADJUST_ROLLOVER_POINT)) {
 		if ((a - ADJUST_ROLLOVER_VALUE) < (b - ADJUST_ROLLOVER_VALUE)) {
@@ -78,6 +87,12 @@ static inline int sq_lt_compare (unsigned int a, unsigned int b) {
 	return (0);
 }
 
+/**
+ * @brief sq_lte_compare
+ * @param a
+ * @param b
+ * @return
+ */
 static inline int sq_lte_compare (unsigned int a, unsigned int b) {
 	if ((a > ADJUST_ROLLOVER_POINT) || (b > ADJUST_ROLLOVER_POINT)) {
 		if ((a - ADJUST_ROLLOVER_VALUE) <= (b - ADJUST_ROLLOVER_VALUE)) {
@@ -91,6 +106,14 @@ static inline int sq_lte_compare (unsigned int a, unsigned int b) {
 	return (0);
 }
 
+/**
+ * @brief sq_init
+ * @param sq
+ * @param item_count
+ * @param size_per_item
+ * @param head_seqid
+ * @return
+ */
 static inline int sq_init (
 	struct sq *sq,
 	int item_count,
@@ -123,6 +146,11 @@ static inline int sq_init (
 	return (0);
 }
 
+/**
+ * @brief sq_reinit
+ * @param sq
+ * @param head_seqid
+ */
 static inline void sq_reinit (struct sq *sq, unsigned int head_seqid)
 {
 	sq->head = 0;
@@ -134,6 +162,11 @@ static inline void sq_reinit (struct sq *sq, unsigned int head_seqid)
 	memset (sq->items_miss_count, 0, sq->item_count * sizeof (unsigned int));
 }
 
+/**
+ * @brief sq_assert
+ * @param sq
+ * @param pos
+ */
 static inline void sq_assert (const struct sq *sq, unsigned int pos)
 {
 	unsigned int i;
@@ -144,6 +177,12 @@ static inline void sq_assert (const struct sq *sq, unsigned int pos)
 		assert (sq->items_inuse[i] == 0);
 	}
 }
+
+/**
+ * @brief sq_copy
+ * @param sq_dest
+ * @param sq_src
+ */
 static inline void sq_copy (struct sq *sq_dest, const struct sq *sq_src)
 {
 	sq_assert (sq_src, 20);
@@ -161,12 +200,23 @@ static inline void sq_copy (struct sq *sq_dest, const struct sq *sq_src)
 		sq_src->item_count * sizeof (unsigned int));
 }
 
+/**
+ * @brief sq_free
+ * @param sq
+ */
 static inline void sq_free (struct sq *sq) {
 	free (sq->items);
 	free (sq->items_inuse);
 	free (sq->items_miss_count);
 }
 
+/**
+ * @brief sq_item_add
+ * @param sq
+ * @param item
+ * @param seqid
+ * @return
+ */
 static inline void *sq_item_add (
 	struct sq *sq,
 	void *item,
@@ -194,6 +244,12 @@ static inline void *sq_item_add (
 	return (sq_item);
 }
 
+/**
+ * @brief sq_item_inuse
+ * @param sq
+ * @param seq_id
+ * @return
+ */
 static inline unsigned int sq_item_inuse (
 	const struct sq *sq,
 	unsigned int seq_id) {
@@ -216,6 +272,12 @@ static inline unsigned int sq_item_inuse (
 	return (sq->items_inuse[sq_position] != 0);
 }
 
+/**
+ * @brief sq_item_miss_count
+ * @param sq
+ * @param seq_id
+ * @return
+ */
 static inline unsigned int sq_item_miss_count (
 	const struct sq *sq,
 	unsigned int seq_id)
@@ -227,12 +289,23 @@ static inline unsigned int sq_item_miss_count (
 	return (sq->items_miss_count[sq_position]);
 }
 
+/**
+ * @brief sq_size_get
+ * @param sq
+ * @return
+ */
 static inline unsigned int sq_size_get (
 	const struct sq *sq)
 {
 	return sq->size;
 }
 
+/**
+ * @brief sq_in_range
+ * @param sq
+ * @param seq_id
+ * @return
+ */
 static inline unsigned int sq_in_range (
 	const struct sq *sq,
 	unsigned int seq_id)
@@ -262,6 +335,13 @@ static inline unsigned int sq_in_range (
 
 }
 
+/**
+ * @brief sq_item_get
+ * @param sq
+ * @param seq_id
+ * @param sq_item_out
+ * @return
+ */
 static inline unsigned int sq_item_get (
 	const struct sq *sq,
 	unsigned int seq_id,
@@ -293,6 +373,11 @@ static inline unsigned int sq_item_get (
 	return (0);
 }
 
+/**
+ * @brief sq_items_release
+ * @param sq
+ * @param seqid
+ */
 static inline void sq_items_release (struct sq *sq, unsigned int seqid)
 {
 	unsigned int oldhead;

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -90,9 +90,19 @@ struct totem_logging_configuration {
 	int log_subsys_id;
 };
 
+/**
+ *
+ */
 enum { TOTEM_PRIVATE_KEY_LEN = 128 };
+
+/**
+ *
+ */
 enum { TOTEM_RRP_MODE_BYTES = 64 };
 
+/**
+ * @brief totem_transport_t enum
+ */
 typedef enum {
 	TOTEM_TRANSPORT_UDP = 0,
 	TOTEM_TRANSPORT_UDPU = 1,
@@ -100,11 +110,17 @@ typedef enum {
 } totem_transport_t;
 
 #define MEMB_RING_ID
+/**
+ * @brief The memb_ring_id struct
+ */
 struct memb_ring_id {
 	struct totem_ip_address rep;
 	unsigned long long seq;
 } __attribute__((packed));
 
+/**
+ * @brief The totem_config struct
+ */
 struct totem_config {
 	int version;
 
@@ -198,32 +214,50 @@ struct totem_config {
 };
 
 #define TOTEM_CONFIGURATION_TYPE
+/**
+ * @brief The totem_configuration_type enum
+ */
 enum totem_configuration_type {
 	TOTEM_CONFIGURATION_REGULAR,
 	TOTEM_CONFIGURATION_TRANSITIONAL
 };
 
 #define TOTEM_CALLBACK_TOKEN_TYPE
+/**
+ * @brief The totem_callback_token_type enum
+ */
 enum totem_callback_token_type {
 	TOTEM_CALLBACK_TOKEN_RECEIVED = 1,
 	TOTEM_CALLBACK_TOKEN_SENT = 2
 };
 
+/**
+ * @brief The totem_event_type enum
+ */
 enum totem_event_type {
 	TOTEM_EVENT_DELIVERY_CONGESTED,
 	TOTEM_EVENT_NEW_MSG,
 };
 
+/**
+ * @brief totem_stats_header_t struct
+ */
 typedef struct {
 	int is_dirty;
 	time_t last_updated;
 } totem_stats_header_t;
 
+/**
+ * @brief totemnet_stats_t struct
+ */
 typedef struct {
 	totem_stats_header_t hdr;
 	uint32_t iface_changes;
 } totemnet_stats_t;
 
+/**
+ * @brief totemrrp_stats_t struct
+ */
 typedef struct {
 	totem_stats_header_t hdr;
 	totemnet_stats_t *net;
@@ -232,13 +266,18 @@ typedef struct {
 	uint32_t interface_count;
 } totemrrp_stats_t;
 
-
+/**
+ * @brief totemsrp_token_stats_t struct
+ */
 typedef struct {
 	uint32_t rx;
 	uint32_t tx;
 	int backlog_calc;
 } totemsrp_token_stats_t;
 
+/**
+ * @brief totemsrp_stats_t struct
+ */
 typedef struct {
 	totem_stats_header_t hdr;
 	totemrrp_stats_t *rrp;
@@ -272,17 +311,22 @@ typedef struct {
 	int latest_token;
 #define TOTEM_TOKEN_STATS_MAX 100
 	totemsrp_token_stats_t token[TOTEM_TOKEN_STATS_MAX];
-
 } totemsrp_stats_t;
 
  
- #define TOTEM_CONFIGURATION_TYPE
+#define TOTEM_CONFIGURATION_TYPE
 
+/**
+ * @brief totemmrp_stats_t struct
+ */
 typedef struct {
 	totem_stats_header_t hdr;
 	totemsrp_stats_t *srp;
 } totemmrp_stats_t;
 
+/**
+ * @brief totempg_stats_t struct
+ */
 typedef struct {
 	totem_stats_header_t hdr;
 	totemmrp_stats_t *mrp;

--- a/include/corosync/totem/totemip.h
+++ b/include/corosync/totem/totemip.h
@@ -60,6 +60,9 @@ void totemip_nosigpipe(int s);
 
 /* These are the things that get passed around */
 #define TOTEM_IP_ADDRESS
+/**
+ * @brief The totem_ip_address struct
+ */
 struct totem_ip_address
 {
 	unsigned int   nodeid;
@@ -67,6 +70,9 @@ struct totem_ip_address
 	unsigned char  addr[TOTEMIP_ADDRLEN];
 } __attribute__((packed));
 
+/**
+ * @brief The totem_ip_if_address struct
+ */
 struct totem_ip_if_address
 {
 	struct totem_ip_address ip_addr;
@@ -104,11 +110,20 @@ extern int totemip_getifaddrs(struct list_head *addrs);
 
 extern void totemip_freeifaddrs(struct list_head *addrs);
 
-/* These two simulate a zero in_addr by clearing the family field */
+/**
+ * @brief totemip_zero_set These two simulate a zero in_addr by clearing the family field
+ * @param addr
+ */
 static inline void totemip_zero_set(struct totem_ip_address *addr)
 {
 	addr->family = 0;
 }
+
+/**
+ * @brief totemip_zero_check These two simulate a zero in_addr by clearing the family field */
+ * @param addr
+ * @return
+ */
 static inline int totemip_zero_check(const struct totem_ip_address *addr)
 {
 	return (addr->family == 0);

--- a/include/corosync/totem/totempg.h
+++ b/include/corosync/totem/totempg.h
@@ -52,6 +52,9 @@ extern "C" {
 #include "totem.h"
 #include <qb/qbloop.h>
 
+/**
+ * @brief The totempg_group struct
+ */
 struct totempg_group {
 	const void *group;
 	size_t group_len;
@@ -170,6 +173,9 @@ extern int totempg_member_remove (
 	const struct totem_ip_address *member,
 	int ring_no);
 
+/**
+ * @brief The totem_q_level enum
+ */
 enum totem_q_level {
 	TOTEM_Q_LEVEL_LOW,
 	TOTEM_Q_LEVEL_GOOD,
@@ -179,6 +185,9 @@ enum totem_q_level {
 
 void totempg_check_q_level(void *instance);
 
+/**
+ * @brief totem_queue_level_changed_fn
+ */
 typedef void (*totem_queue_level_changed_fn) (enum totem_q_level level);
 extern void totempg_queue_level_register_callback (totem_queue_level_changed_fn);
 

--- a/include/corosync/votequorum.h
+++ b/include/corosync/votequorum.h
@@ -66,6 +66,9 @@ typedef uint64_t votequorum_handle_t;
 
 /** @} */
 
+/**
+ * @brief The votequorum_info struct
+ */
 struct votequorum_info {
 	unsigned int node_id;
 	unsigned int node_state;
@@ -79,16 +82,25 @@ struct votequorum_info {
 	char qdevice_name[VOTEQUORUM_QDEVICE_MAX_NAME_LEN];
 };
 
+/**
+ * @brief votequorum_node_t struct
+ */
 typedef struct {
 	uint32_t nodeid;
 	uint32_t state;
 } votequorum_node_t;
 
+/**
+ * @brief votequorum_ring_id_t struct
+ */
 typedef struct {
 	uint32_t nodeid;
 	uint64_t seq;
 } votequorum_ring_id_t;
 
+/**
+ * @brief votequorum_notification_fn_t callback
+ */
 typedef void (*votequorum_notification_fn_t) (
 	votequorum_handle_t handle,
 	uint64_t context,
@@ -97,11 +109,17 @@ typedef void (*votequorum_notification_fn_t) (
 	uint32_t node_list_entries,
 	votequorum_node_t node_list[]);
 
+/**
+ * @brief votequorum_expectedvotes_notification_fn_t callback
+ */
 typedef void (*votequorum_expectedvotes_notification_fn_t) (
 	votequorum_handle_t handle,
 	uint64_t context,
 	uint32_t expected_votes);
 
+/**
+ * @brief votequorum_callbacks_t struct
+ */
 typedef struct {
 	votequorum_notification_fn_t votequorum_notify_fn;
 	votequorum_expectedvotes_notification_fn_t votequorum_expectedvotes_notify_fn;
@@ -168,8 +186,13 @@ cs_error_t votequorum_setvotes (
 cs_error_t votequorum_trackstart (
 	votequorum_handle_t handle,
 	uint64_t context,
-	unsigned int flags );
+        unsigned int flags);
 
+/**
+ * @brief votequorum_trackstop
+ * @param handle
+ * @return
+ */
 cs_error_t votequorum_trackstop (
 	votequorum_handle_t handle);
 
@@ -180,6 +203,12 @@ cs_error_t votequorum_context_get (
 	votequorum_handle_t handle,
 	void **context);
 
+/**
+ * @brief votequorum_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t votequorum_context_set (
 	votequorum_handle_t handle,
 	void *context);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -62,6 +62,9 @@
 /*
  * Data structure for instance data
  */
+/**
+ * @brief The cfg_inst struct
+ */
 struct cfg_inst {
 	qb_ipcc_connection_t *c;
 	corosync_cfg_callbacks_t callbacks;
@@ -81,6 +84,12 @@ DECLARE_HDB_DATABASE (cfg_hdb, cfg_inst_free);
  * Implementation
  */
 
+/**
+ * @brief corosync_cfg_initialize
+ * @param cfg_handle
+ * @param cfg_callbacks
+ * @return
+ */
 cs_error_t
 corosync_cfg_initialize (
 	corosync_cfg_handle_t *cfg_handle,
@@ -122,6 +131,12 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_fd_get
+ * @param cfg_handle
+ * @param selection_fd
+ * @return
+ */
 cs_error_t
 corosync_cfg_fd_get (
 	corosync_cfg_handle_t cfg_handle,
@@ -141,6 +156,12 @@ corosync_cfg_fd_get (
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_dispatch
+ * @param cfg_handle
+ * @param dispatch_flags
+ * @return
+ */
 cs_error_t
 corosync_cfg_dispatch (
 	corosync_cfg_handle_t cfg_handle,
@@ -244,12 +265,21 @@ error_nounlock:
 	return (error);
 }
 
+/**
+ * @brief cfg_inst_free
+ * @param inst
+ */
 static void cfg_inst_free (void *inst)
 {
 	struct cfg_inst *cfg_inst = (struct cfg_inst *)inst;
 	qb_ipcc_disconnect(cfg_inst->c);
 }
 
+/**
+ * @brief corosync_cfg_finalize
+ * @param cfg_handle
+ * @return
+ */
 cs_error_t
 corosync_cfg_finalize (
 	corosync_cfg_handle_t cfg_handle)
@@ -279,6 +309,14 @@ corosync_cfg_finalize (
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_ring_status_get
+ * @param cfg_handle
+ * @param interface_names
+ * @param status
+ * @param interface_count
+ * @return
+ */
 cs_error_t
 corosync_cfg_ring_status_get (
 	corosync_cfg_handle_t cfg_handle,
@@ -363,6 +401,11 @@ no_error:
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_ring_reenable
+ * @param cfg_handle
+ * @return
+ */
 cs_error_t
 corosync_cfg_ring_reenable (
 	corosync_cfg_handle_t cfg_handle)
@@ -395,6 +438,13 @@ corosync_cfg_ring_reenable (
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_kill_node
+ * @param cfg_handle
+ * @param nodeid
+ * @param reason
+ * @return
+ */
 cs_error_t
 corosync_cfg_kill_node (
 	corosync_cfg_handle_t cfg_handle,
@@ -438,6 +488,12 @@ corosync_cfg_kill_node (
         return (error == CS_OK ? res_lib_cfg_killnode.header.error : error);
 }
 
+/**
+ * @brief corosync_cfg_try_shutdown
+ * @param cfg_handle
+ * @param flags
+ * @return
+ */
 cs_error_t
 corosync_cfg_try_shutdown (
 	corosync_cfg_handle_t cfg_handle,
@@ -473,6 +529,12 @@ corosync_cfg_try_shutdown (
         return (error == CS_OK ? res_lib_cfg_tryshutdown.header.error : error);
 }
 
+/**
+ * @brief corosync_cfg_replyto_shutdown
+ * @param cfg_handle
+ * @param response
+ * @return
+ */
 cs_error_t
 corosync_cfg_replyto_shutdown (
 	corosync_cfg_handle_t cfg_handle,
@@ -506,6 +568,15 @@ corosync_cfg_replyto_shutdown (
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_get_node_addrs
+ * @param cfg_handle
+ * @param nodeid
+ * @param max_addrs
+ * @param num_addrs
+ * @param addrs
+ * @return
+ */
 cs_error_t corosync_cfg_get_node_addrs (
 	corosync_cfg_handle_t cfg_handle,
 	int nodeid,
@@ -579,6 +650,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_local_get
+ * @param handle
+ * @param local_nodeid
+ * @return
+ */
 cs_error_t corosync_cfg_local_get (
 	corosync_cfg_handle_t handle,
 	unsigned int *local_nodeid)
@@ -621,6 +698,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_reload_config
+ * @param handle
+ * @return
+ */
 cs_error_t corosync_cfg_reload_config (
 	corosync_cfg_handle_t handle)
 {

--- a/lib/cmap.c
+++ b/lib/cmap.c
@@ -54,12 +54,18 @@
 #include "util.h"
 #include <stdio.h>
 
+/**
+ * @brief The cmap_inst struct
+ */
 struct cmap_inst {
 	int finalize;
 	qb_ipcc_connection_t *c;
 	const void *context;
 };
 
+/**
+ * @brief The cmap_track_inst struct
+ */
 struct cmap_track_inst {
 	void *user_data;
 	cmap_notify_fn_t notify_fn;
@@ -75,6 +81,16 @@ DECLARE_HDB_DATABASE(cmap_track_handle_t_db,NULL);
 /*
  * Function prototypes
  */
+
+/**
+ * @brief cmap_get_int
+ * @param handle
+ * @param key_name
+ * @param value
+ * @param value_size
+ * @param type
+ * @return
+ */
 static cs_error_t cmap_get_int(
 	cmap_handle_t handle,
 	const char *key_name,
@@ -86,6 +102,11 @@ static cs_error_t cmap_adjust_int(cmap_handle_t handle, const char *key_name, in
 
 /*
  * Function implementations
+ */
+/**
+ * @brief cmap_initialize
+ * @param handle
+ * @return
  */
 cs_error_t cmap_initialize (cmap_handle_t *handle)
 {
@@ -122,12 +143,21 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief cmap_inst_free
+ * @param inst
+ */
 static void cmap_inst_free (void *inst)
 {
 	struct cmap_inst *cmap_inst = (struct cmap_inst *)inst;
 	qb_ipcc_disconnect(cmap_inst->c);
 }
 
+/**
+ * @brief cmap_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t cmap_finalize(cmap_handle_t handle)
 {
 	struct cmap_inst *cmap_inst;
@@ -167,6 +197,12 @@ cs_error_t cmap_finalize(cmap_handle_t handle)
 	return (CS_OK);
 }
 
+/**
+ * @brief cmap_fd_get
+ * @param handle
+ * @param fd
+ * @return
+ */
 cs_error_t cmap_fd_get(cmap_handle_t handle, int *fd)
 {
 	cs_error_t error;
@@ -184,6 +220,12 @@ cs_error_t cmap_fd_get(cmap_handle_t handle, int *fd)
 	return (error);
 }
 
+/**
+ * @brief cmap_dispatch
+ * @param handle
+ * @param dispatch_types
+ * @return
+ */
 cs_error_t cmap_dispatch (
 	cmap_handle_t handle,
         cs_dispatch_flags_t dispatch_types)
@@ -307,6 +349,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief cmap_context_get
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t cmap_context_get (
 	cmap_handle_t handle,
 	const void **context)
@@ -326,6 +374,12 @@ cs_error_t cmap_context_get (
 	return (CS_OK);
 }
 
+/**
+ * @brief cmap_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t cmap_context_set (
 	cmap_handle_t handle,
 	const void *context)
@@ -345,6 +399,15 @@ cs_error_t cmap_context_set (
 	return (CS_OK);
 }
 
+/**
+ * @brief cmap_set
+ * @param handle
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t cmap_set (
 	cmap_handle_t handle,
 	const char *key_name,
@@ -402,56 +465,133 @@ cs_error_t cmap_set (
 	return (error);
 }
 
+/**
+ * @brief cmap_set_int8
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_int8(cmap_handle_t handle, const char *key_name, int8_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_INT8));
 }
 
+/**
+ * @brief cmap_set_uint8
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_uint8(cmap_handle_t handle, const char *key_name, uint8_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_UINT8));
 }
 
+/**
+ * @brief cmap_set_int16
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_int16(cmap_handle_t handle, const char *key_name, int16_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_INT16));
 }
 
+/**
+ * @brief cmap_set_uint16
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_uint16(cmap_handle_t handle, const char *key_name, uint16_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_UINT16));
 }
 
+/**
+ * @brief cmap_set_int32
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_int32(cmap_handle_t handle, const char *key_name, int32_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_INT32));
 }
 
+/**
+ * @brief cmap_set_uint32
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_uint32(cmap_handle_t handle, const char *key_name, uint32_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_UINT32));
 }
 
+/**
+ * @brief cmap_set_int64
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_int64(cmap_handle_t handle, const char *key_name, int64_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_INT64));
 }
 
+/**
+ * @brief cmap_set_uint64
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_uint64(cmap_handle_t handle, const char *key_name, uint64_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_UINT64));
 }
 
+/**
+ * @brief cmap_set_float
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_float(cmap_handle_t handle, const char *key_name, float value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_FLOAT));
 }
 
+/**
+ * @brief cmap_set_double
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_double(cmap_handle_t handle, const char *key_name, double value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_DOUBLE));
 }
 
+/**
+ * @brief cmap_set_string
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_string(cmap_handle_t handle, const char *key_name, const char *value)
 {
 
@@ -462,6 +602,12 @@ cs_error_t cmap_set_string(cmap_handle_t handle, const char *key_name, const cha
 	return (cmap_set(handle, key_name, value, strlen(value), CMAP_VALUETYPE_STRING));
 }
 
+/**
+ * @brief cmap_delete
+ * @param handle
+ * @param key_name
+ * @return
+ */
 cs_error_t cmap_delete(cmap_handle_t handle, const char *key_name)
 {
 	cs_error_t error;
@@ -508,6 +654,15 @@ cs_error_t cmap_delete(cmap_handle_t handle, const char *key_name)
 	return (error);
 }
 
+/**
+ * @brief cmap_get
+ * @param handle
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t cmap_get(
 		cmap_handle_t handle,
 		const char *key_name,
@@ -593,6 +748,15 @@ cs_error_t cmap_get(
 	return (error);
 }
 
+/**
+ * @brief cmap_get_int
+ * @param handle
+ * @param key_name
+ * @param value
+ * @param value_size
+ * @param type
+ * @return
+ */
 static cs_error_t cmap_get_int(
 	cmap_handle_t handle,
 	const char *key_name,
@@ -622,66 +786,143 @@ static cs_error_t cmap_get_int(
 	return (CS_OK);
 }
 
+/**
+ * @brief cmap_get_int8
+ * @param handle
+ * @param key_name
+ * @param i8
+ * @return
+ */
 cs_error_t cmap_get_int8(cmap_handle_t handle, const char *key_name, int8_t *i8)
 {
 
 	return (cmap_get_int(handle, key_name, i8, sizeof(*i8), CMAP_VALUETYPE_INT8));
 }
 
+/**
+ * @brief cmap_get_uint8
+ * @param handle
+ * @param key_name
+ * @param u8
+ * @return
+ */
 cs_error_t cmap_get_uint8(cmap_handle_t handle, const char *key_name, uint8_t *u8)
 {
 
 	return (cmap_get_int(handle, key_name, u8, sizeof(*u8), CMAP_VALUETYPE_UINT8));
 }
 
+/**
+ * @brief cmap_get_int16
+ * @param handle
+ * @param key_name
+ * @param i16
+ * @return
+ */
 cs_error_t cmap_get_int16(cmap_handle_t handle, const char *key_name, int16_t *i16)
 {
 
 	return (cmap_get_int(handle, key_name, i16, sizeof(*i16), CMAP_VALUETYPE_INT16));
 }
 
+/**
+ * @brief cmap_get_uint16
+ * @param handle
+ * @param key_name
+ * @param u16
+ * @return
+ */
 cs_error_t cmap_get_uint16(cmap_handle_t handle, const char *key_name, uint16_t *u16)
 {
 
 	return (cmap_get_int(handle, key_name, u16, sizeof(*u16), CMAP_VALUETYPE_UINT16));
 }
 
+/**
+ * @brief cmap_get_int32
+ * @param handle
+ * @param key_name
+ * @param i32
+ * @return
+ */
 cs_error_t cmap_get_int32(cmap_handle_t handle, const char *key_name, int32_t *i32)
 {
 
 	return (cmap_get_int(handle, key_name, i32, sizeof(*i32), CMAP_VALUETYPE_INT32));
 }
 
+/**
+ * @brief cmap_get_uint32
+ * @param handle
+ * @param key_name
+ * @param u32
+ * @return
+ */
 cs_error_t cmap_get_uint32(cmap_handle_t handle, const char *key_name, uint32_t *u32)
 {
 
 	return (cmap_get_int(handle, key_name, u32, sizeof(*u32), CMAP_VALUETYPE_UINT32));
 }
 
+/**
+ * @brief cmap_get_int64
+ * @param handle
+ * @param key_name
+ * @param i64
+ * @return
+ */
 cs_error_t cmap_get_int64(cmap_handle_t handle, const char *key_name, int64_t *i64)
 {
 
 	return (cmap_get_int(handle, key_name, i64, sizeof(*i64), CMAP_VALUETYPE_INT64));
 }
 
+/**
+ * @brief cmap_get_uint64
+ * @param handle
+ * @param key_name
+ * @param u64
+ * @return
+ */
 cs_error_t cmap_get_uint64(cmap_handle_t handle, const char *key_name, uint64_t *u64)
 {
 
 	return (cmap_get_int(handle, key_name, u64, sizeof(*u64), CMAP_VALUETYPE_UINT64));
 }
 
+/**
+ * @brief cmap_get_float
+ * @param handle
+ * @param key_name
+ * @param flt
+ * @return
+ */
 cs_error_t cmap_get_float(cmap_handle_t handle, const char *key_name, float *flt)
 {
 
 	return (cmap_get_int(handle, key_name, flt, sizeof(*flt), CMAP_VALUETYPE_FLOAT));
 }
 
+/**
+ * @brief cmap_get_double
+ * @param handle
+ * @param key_name
+ * @param dbl
+ * @return
+ */
 cs_error_t cmap_get_double(cmap_handle_t handle, const char *key_name, double *dbl)
 {
 
 	return (cmap_get_int(handle, key_name, dbl, sizeof(*dbl), CMAP_VALUETYPE_DOUBLE));
 }
 
+/**
+ * @brief cmap_get_string
+ * @param handle
+ * @param key_name
+ * @param str
+ * @return
+ */
 cs_error_t cmap_get_string(cmap_handle_t handle, const char *key_name, char **str)
 {
 	cs_error_t res;
@@ -718,6 +959,13 @@ return_error:
 	return (res);
 }
 
+/**
+ * @brief cmap_adjust_int
+ * @param handle
+ * @param key_name
+ * @param step
+ * @return
+ */
 static cs_error_t cmap_adjust_int(cmap_handle_t handle, const char *key_name, int32_t step)
 {
 	cs_error_t error;
@@ -766,18 +1014,37 @@ static cs_error_t cmap_adjust_int(cmap_handle_t handle, const char *key_name, in
 	return (error);
 }
 
+/**
+ * @brief cmap_inc
+ * @param handle
+ * @param key_name
+ * @return
+ */
 cs_error_t cmap_inc(cmap_handle_t handle, const char *key_name)
 {
 
 	return (cmap_adjust_int(handle, key_name, 1));
 }
 
+/**
+ * @brief cmap_dec
+ * @param handle
+ * @param key_name
+ * @return
+ */
 cs_error_t cmap_dec(cmap_handle_t handle, const char *key_name)
 {
 
 	return (cmap_adjust_int(handle, key_name, -1));
 }
 
+/**
+ * @brief cmap_iter_init
+ * @param handle
+ * @param prefix
+ * @param cmap_iter_handle
+ * @return
+ */
 cs_error_t cmap_iter_init(
 		cmap_handle_t handle,
 		const char *prefix,
@@ -833,6 +1100,15 @@ cs_error_t cmap_iter_init(
 	return (error);
 }
 
+/**
+ * @brief cmap_iter_next
+ * @param handle
+ * @param iter_handle
+ * @param key_name
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t cmap_iter_next(
 		cmap_handle_t handle,
 		cmap_iter_handle_t iter_handle,
@@ -891,6 +1167,12 @@ cs_error_t cmap_iter_next(
 	return (error);
 }
 
+/**
+ * @brief cmap_iter_finalize
+ * @param handle
+ * @param iter_handle
+ * @return
+ */
 cs_error_t cmap_iter_finalize(
 		cmap_handle_t handle,
 		cmap_iter_handle_t iter_handle)
@@ -930,6 +1212,16 @@ cs_error_t cmap_iter_finalize(
 	return (error);
 }
 
+/**
+ * @brief cmap_track_add
+ * @param handle
+ * @param key_name
+ * @param track_type
+ * @param notify_fn
+ * @param user_data
+ * @param cmap_track_handle
+ * @return
+ */
 cs_error_t cmap_track_add(
 	cmap_handle_t handle,
 	const char *key_name,
@@ -1021,6 +1313,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief cmap_track_delete
+ * @param handle
+ * @param track_handle
+ * @return
+ */
 cs_error_t cmap_track_delete(
 		cmap_handle_t handle,
 		cmap_track_handle_t track_handle)

--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -80,6 +80,9 @@
  */
 #define CPG_MEMORY_MAP_UMASK		077
 
+/**
+ * @brief The cpg_inst struct
+ */
 struct cpg_inst {
 	qb_ipcc_connection_t *c;
 	int finalize;
@@ -102,6 +105,9 @@ static void cpg_inst_free (void *inst);
 
 DECLARE_HDB_DATABASE(cpg_handle_t_db, cpg_inst_free);
 
+/**
+ * @brief The cpg_iteration_instance_t struct
+ */
 struct cpg_iteration_instance_t {
 	cpg_iteration_handle_t cpg_iteration_handle;
 	qb_ipcc_connection_t *conn;
@@ -116,6 +122,15 @@ DECLARE_HDB_DATABASE(cpg_iteration_handle_t_db,NULL);
  * Internal (not visible by API) functions
  */
 
+/**
+ * @brief coroipcc_msg_send_reply_receive
+ * @param c
+ * @param iov
+ * @param iov_len
+ * @param res_msg
+ * @param res_len
+ * @return
+ */
 static cs_error_t
 coroipcc_msg_send_reply_receive (
 	qb_ipcc_connection_t *c,
@@ -128,18 +143,31 @@ coroipcc_msg_send_reply_receive (
 				CS_IPC_TIMEOUT_MS));
 }
 
+/**
+ * @brief cpg_iteration_instance_finalize
+ * @param cpg_iteration_instance
+ */
 static void cpg_iteration_instance_finalize (struct cpg_iteration_instance_t *cpg_iteration_instance)
 {
 	list_del (&cpg_iteration_instance->list);
 	hdb_handle_destroy (&cpg_iteration_handle_t_db, cpg_iteration_instance->cpg_iteration_handle);
 }
 
+/**
+ * @brief cpg_inst_free
+ * @param inst
+ */
 static void cpg_inst_free (void *inst)
 {
 	struct cpg_inst *cpg_inst = (struct cpg_inst *)inst;
 	qb_ipcc_disconnect(cpg_inst->c);
 }
 
+/**
+ * @brief cpg_inst_finalize
+ * @param cpg_inst
+ * @param handle
+ */
 static void cpg_inst_finalize (struct cpg_inst *cpg_inst, hdb_handle_t handle)
 {
 	struct list_head *iter, *iter_next;
@@ -165,6 +193,12 @@ static void cpg_inst_finalize (struct cpg_inst *cpg_inst, hdb_handle_t handle)
  * @{
  */
 
+/**
+ * @brief cpg_initialize
+ * @param handle
+ * @param callbacks
+ * @return
+ */
 cs_error_t cpg_initialize (
 	cpg_handle_t *handle,
 	cpg_callbacks_t *callbacks)
@@ -181,6 +215,14 @@ cs_error_t cpg_initialize (
 	return (cpg_model_initialize (handle, CPG_MODEL_V1, (cpg_model_data_t *)&model_v1_data, NULL));
 }
 
+/**
+ * @brief cpg_model_initialize
+ * @param handle
+ * @param model
+ * @param model_data
+ * @param context
+ * @return
+ */
 cs_error_t cpg_model_initialize (
 	cpg_handle_t *handle,
 	cpg_model_t model,
@@ -243,6 +285,11 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief cpg_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t cpg_finalize (
 	cpg_handle_t handle)
 {
@@ -288,6 +335,12 @@ cs_error_t cpg_finalize (
 	return (error);
 }
 
+/**
+ * @brief cpg_fd_get
+ * @param handle
+ * @param fd
+ * @return
+ */
 cs_error_t cpg_fd_get (
 	cpg_handle_t handle,
 	int *fd)
@@ -307,6 +360,12 @@ cs_error_t cpg_fd_get (
 	return (error);
 }
 
+/**
+ * @brief cpg_max_atomic_msgsize_get
+ * @param handle
+ * @param size
+ * @return
+ */
 cs_error_t cpg_max_atomic_msgsize_get (
 	cpg_handle_t handle,
 	uint32_t *size)
@@ -326,6 +385,12 @@ cs_error_t cpg_max_atomic_msgsize_get (
 	return (error);
 }
 
+/**
+ * @brief cpg_context_get
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t cpg_context_get (
 	cpg_handle_t handle,
 	void **context)
@@ -345,6 +410,12 @@ cs_error_t cpg_context_get (
 	return (CS_OK);
 }
 
+/**
+ * @brief cpg_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t cpg_context_set (
 	cpg_handle_t handle,
 	void *context)
@@ -364,6 +435,12 @@ cs_error_t cpg_context_set (
 	return (CS_OK);
 }
 
+/**
+ * @brief cpg_dispatch
+ * @param handle
+ * @param dispatch_types
+ * @return
+ */
 cs_error_t cpg_dispatch (
 	cpg_handle_t handle,
 	cs_dispatch_flags_t dispatch_types)
@@ -586,6 +663,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief cpg_join
+ * @param handle
+ * @param group
+ * @return
+ */
 cs_error_t cpg_join (
     cpg_handle_t handle,
     const struct cpg_name *group)
@@ -640,6 +723,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_leave
+ * @param handle
+ * @param group
+ * @return
+ */
 cs_error_t cpg_leave (
     cpg_handle_t handle,
     const struct cpg_name *group)
@@ -685,6 +774,14 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_membership_get
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @return
+ */
 cs_error_t cpg_membership_get (
 	cpg_handle_t handle,
 	struct cpg_name *group_name,
@@ -748,6 +845,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_local_get
+ * @param handle
+ * @param local_nodeid
+ * @return
+ */
 cs_error_t cpg_local_get (
 	cpg_handle_t handle,
 	unsigned int *local_nodeid)
@@ -786,6 +889,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_flow_control_state_get
+ * @param handle
+ * @param flow_control_state
+ * @return
+ */
 cs_error_t cpg_flow_control_state_get (
 	cpg_handle_t handle,
 	cpg_flow_control_state_t *flow_control_state)
@@ -805,6 +914,14 @@ cs_error_t cpg_flow_control_state_get (
 	return (error);
 }
 
+/**
+ * @brief memory_map
+ * @param path
+ * @param file
+ * @param buf
+ * @param bytes
+ * @return
+ */
 static int
 memory_map (char *path, const char *file, void **buf, size_t bytes)
 {
@@ -884,6 +1001,13 @@ error_close_unlink:
 	return -1;
 }
 
+/**
+ * @brief cpg_zcb_alloc
+ * @param handle
+ * @param size
+ * @param buffer
+ * @return
+ */
 cs_error_t cpg_zcb_alloc (
 	cpg_handle_t handle,
 	size_t size,
@@ -941,6 +1065,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_zcb_free
+ * @param handle
+ * @param buffer
+ * @return
+ */
 cs_error_t cpg_zcb_free (
 	cpg_handle_t handle,
 	void *buffer)
@@ -990,6 +1120,14 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_zcb_mcast_joined
+ * @param handle
+ * @param guarantee
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 cs_error_t cpg_zcb_mcast_joined (
 	cpg_handle_t handle,
 	cpg_guarantee_t guarantee,
@@ -1050,6 +1188,15 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief send_fragments
+ * @param cpg_inst
+ * @param guarantee
+ * @param msg_len
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 static cs_error_t send_fragments (
 	struct cpg_inst *cpg_inst,
 	cpg_guarantee_t guarantee,
@@ -1132,6 +1279,14 @@ error_exit:
 }
 
 
+/**
+ * @brief cpg_mcast_joined
+ * @param handle
+ * @param guarantee
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 cs_error_t cpg_mcast_joined (
 	cpg_handle_t handle,
 	cpg_guarantee_t guarantee,
@@ -1180,6 +1335,14 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_iteration_initialize
+ * @param handle
+ * @param iteration_type
+ * @param group
+ * @param cpg_iteration_handle
+ * @return
+ */
 cs_error_t cpg_iteration_initialize(
 	cpg_handle_t handle,
 	cpg_iteration_type_t iteration_type,
@@ -1273,6 +1436,12 @@ error_put_cpg_db:
 	return (error);
 }
 
+/**
+ * @brief cpg_iteration_next
+ * @param handle
+ * @param description
+ * @return
+ */
 cs_error_t cpg_iteration_next(
 	cpg_iteration_handle_t handle,
 	struct cpg_iteration_description_t *description)
@@ -1323,6 +1492,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_iteration_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t cpg_iteration_finalize (
 	cpg_iteration_handle_t handle)
 {

--- a/lib/quorum.c
+++ b/lib/quorum.c
@@ -55,6 +55,9 @@
 
 #include "util.h"
 
+/**
+ * @brief The quorum_inst struct
+ */
 struct quorum_inst {
 	qb_ipcc_connection_t *c;
 	int finalize;
@@ -66,6 +69,13 @@ static void quorum_inst_free (void *inst);
 
 DECLARE_HDB_DATABASE(quorum_handle_t_db, quorum_inst_free);
 
+/**
+ * @brief quorum_initialize
+ * @param handle
+ * @param callbacks
+ * @param quorum_type
+ * @return
+ */
 cs_error_t quorum_initialize (
 	quorum_handle_t *handle,
 	quorum_callbacks_t *callbacks,
@@ -133,12 +143,21 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief quorum_inst_free
+ * @param inst
+ */
 static void quorum_inst_free (void *inst)
 {
 	struct quorum_inst *quorum_inst = (struct quorum_inst *)inst;
 	qb_ipcc_disconnect(quorum_inst->c);
 }
 
+/**
+ * @brief quorum_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t quorum_finalize (
 	quorum_handle_t handle)
 {
@@ -167,6 +186,12 @@ cs_error_t quorum_finalize (
 	return (CS_OK);
 }
 
+/**
+ * @brief quorum_getquorate
+ * @param handle
+ * @param quorate
+ * @return
+ */
 cs_error_t quorum_getquorate (
 	quorum_handle_t handle,
 	int *quorate)
@@ -209,6 +234,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief quorum_fd_get
+ * @param handle
+ * @param fd
+ * @return
+ */
 cs_error_t quorum_fd_get (
 	quorum_handle_t handle,
 	int *fd)
@@ -229,6 +260,12 @@ cs_error_t quorum_fd_get (
 }
 
 
+/**
+ * @brief quorum_context_get
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t quorum_context_get (
 	quorum_handle_t handle,
 	const void **context)
@@ -248,6 +285,12 @@ cs_error_t quorum_context_get (
 	return (CS_OK);
 }
 
+/**
+ * @brief quorum_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t quorum_context_set (
 	quorum_handle_t handle,
 	const void *context)
@@ -267,7 +310,12 @@ cs_error_t quorum_context_set (
 	return (CS_OK);
 }
 
-
+/**
+ * @brief quorum_trackstart
+ * @param handle
+ * @param flags
+ * @return
+ */
 cs_error_t quorum_trackstart (
 	quorum_handle_t handle,
 	unsigned int flags )
@@ -309,6 +357,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief quorum_trackstop
+ * @param handle
+ * @return
+ */
 cs_error_t quorum_trackstop (
 	quorum_handle_t handle)
 {
@@ -348,6 +401,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief quorum_dispatch
+ * @param handle
+ * @param dispatch_types
+ * @return
+ */
 cs_error_t quorum_dispatch (
 	quorum_handle_t handle,
 	cs_dispatch_flags_t dispatch_types)

--- a/lib/sam.c
+++ b/lib/sam.c
@@ -71,6 +71,9 @@
 #define SAM_RP_MASK_C(pol)	(pol & (~SAM_RECOVERY_POLICY_CMAP))
 #define SAM_RP_MASK(pol)	(pol & (~(SAM_RECOVERY_POLICY_QUORUM | SAM_RECOVERY_POLICY_CMAP)))
 
+/**
+ * @brief The sam_internal_status_t enum
+ */
 enum sam_internal_status_t {
 	SAM_INTERNAL_STATUS_NOT_INITIALIZED = 0,
 	SAM_INTERNAL_STATUS_INITIALIZED,
@@ -79,6 +82,9 @@ enum sam_internal_status_t {
 	SAM_INTERNAL_STATUS_FINALIZED
 };
 
+/**
+ * @brief The sam_command_t enum
+ */
 enum sam_command_t {
 	SAM_COMMAND_START,
 	SAM_COMMAND_STOP,
@@ -88,11 +94,17 @@ enum sam_command_t {
 	SAM_COMMAND_MARK_FAILED,
 };
 
+/**
+ * @brief The sam_reply_t enum
+ */
 enum sam_reply_t {
 	SAM_REPLY_OK,
 	SAM_REPLY_ERROR,
 };
 
+/**
+ * @brief The sam_parent_action_t enum
+ */
 enum sam_parent_action_t {
 	SAM_PARENT_ACTION_ERROR,
 	SAM_PARENT_ACTION_RECOVERY,
@@ -100,6 +112,9 @@ enum sam_parent_action_t {
 	SAM_PARENT_ACTION_CONTINUE
 };
 
+/**
+ * @brief The sam_cmap_key_t enum
+ */
 enum sam_cmap_key_t {
 	SAM_CMAP_KEY_RECOVERY,
 	SAM_CMAP_KEY_HC_PERIOD,
@@ -107,6 +122,9 @@ enum sam_cmap_key_t {
 	SAM_CMAP_KEY_STATE,
 };
 
+/**
+ *
+ */
 static struct {
 	int time_interval;
 	sam_recovery_policy_t recovery_policy;
@@ -139,6 +157,12 @@ static struct {
 
 extern const char *__progname;
 
+/**
+ * @brief sam_cmap_update_key
+ * @param key
+ * @param value
+ * @return
+ */
 static cs_error_t sam_cmap_update_key (enum sam_cmap_key_t key, const char *value)
 {
 	cs_error_t err;
@@ -191,6 +215,10 @@ exit_error:
 	return (err);
 }
 
+/**
+ * @brief sam_cmap_destroy_pid_path
+ * @return
+ */
 static cs_error_t sam_cmap_destroy_pid_path (void)
 {
 	cmap_iter_handle_t iter;
@@ -212,6 +240,10 @@ error_exit:
 	return (err);
 }
 
+/**
+ * @brief sam_cmap_register
+ * @return
+ */
 static cs_error_t sam_cmap_register (void)
 {
 	cs_error_t err;
@@ -241,6 +273,14 @@ destroy_finalize_error:
 	return (err);
 }
 
+/**
+ * @brief quorum_notification_fn
+ * @param handle
+ * @param quorate
+ * @param ring_id
+ * @param view_list_entries
+ * @param view_list
+ */
 static void quorum_notification_fn (
         quorum_handle_t handle,
         uint32_t quorate,
@@ -251,6 +291,12 @@ static void quorum_notification_fn (
 	sam_internal_data.quorate = quorate;
 }
 
+/**
+ * @brief sam_initialize
+ * @param time_interval
+ * @param recovery_policy
+ * @return
+ */
 cs_error_t sam_initialize (
 	int time_interval,
 	sam_recovery_policy_t recovery_policy)
@@ -319,6 +365,13 @@ exit_error:
 /*
  * Wrapper on top of write(2) function. It handles EAGAIN and EINTR states and sends whole buffer if possible.
  */
+/**
+ * @brief sam_safe_write
+ * @param d
+ * @param buf
+ * @param nbyte
+ * @return
+ */
 static size_t sam_safe_write (
 	int d,
 	const void *buf,
@@ -347,6 +400,13 @@ static size_t sam_safe_write (
 /*
  * Wrapper on top of read(2) function. It handles EAGAIN and EINTR states and reads whole buffer if possible.
  */
+/**
+ * @brief sam_safe_read
+ * @param d
+ * @param buf
+ * @param nbyte
+ * @return
+ */
 static size_t sam_safe_read (
 	int d,
 	void *buf,
@@ -373,6 +433,11 @@ static size_t sam_safe_read (
 	return (bytes_read);
 }
 
+/**
+ * @brief sam_read_reply
+ * @param child_fd_in
+ * @return
+ */
 static cs_error_t sam_read_reply (
 	int child_fd_in)
 {
@@ -407,6 +472,11 @@ static cs_error_t sam_read_reply (
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_data_getsize
+ * @param size
+ * @return
+ */
 cs_error_t sam_data_getsize (size_t *size)
 {
 	if (size == NULL) {
@@ -429,6 +499,12 @@ cs_error_t sam_data_getsize (size_t *size)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_data_restore
+ * @param data
+ * @param size
+ * @return
+ */
 cs_error_t sam_data_restore (
 	void *data,
 	size_t size)
@@ -474,6 +550,12 @@ error_unlock:
 	return (err);
 }
 
+/**
+ * @brief sam_data_store
+ * @param data
+ * @param size
+ * @return
+ */
 cs_error_t sam_data_store (
 	const void *data,
 	size_t size)
@@ -563,6 +645,10 @@ error_unlock:
 	return (err);
 }
 
+/**
+ * @brief sam_start
+ * @return
+ */
 cs_error_t sam_start (void)
 {
 	char command;
@@ -611,6 +697,10 @@ cs_error_t sam_start (void)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_stop
+ * @return
+ */
 cs_error_t sam_stop (void)
 {
 	char command;
@@ -656,6 +746,10 @@ cs_error_t sam_stop (void)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_hc_send
+ * @return
+ */
 cs_error_t sam_hc_send (void)
 {
 	char command;
@@ -672,6 +766,10 @@ cs_error_t sam_hc_send (void)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_finalize
+ * @return
+ */
 cs_error_t sam_finalize (void)
 {
 	cs_error_t error;
@@ -696,6 +794,10 @@ exit_error:
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_mark_failed
+ * @return
+ */
 cs_error_t sam_mark_failed (void)
 {
 	char command;
@@ -717,6 +819,11 @@ cs_error_t sam_mark_failed (void)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_warn_signal_set
+ * @param warn_signal
+ * @return
+ */
 cs_error_t sam_warn_signal_set (int warn_signal)
 {
 	char command;
@@ -771,6 +878,13 @@ error_unlock:
 	return (err);
 }
 
+/**
+ * @brief sam_parent_reply_send
+ * @param err
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @return
+ */
 static cs_error_t sam_parent_reply_send (
 	cs_error_t err,
 	int parent_fd_in,
@@ -802,6 +916,12 @@ error_reply:
 }
 
 
+/**
+ * @brief sam_parent_warn_signal_set
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @return
+ */
 static cs_error_t sam_parent_warn_signal_set (
 	int parent_fd_in,
 	int parent_fd_out)
@@ -828,6 +948,12 @@ error_reply:
 	return (sam_parent_reply_send (err, parent_fd_in, parent_fd_out));
 }
 
+/**
+ * @brief sam_parent_wait_for_quorum
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @return
+ */
 static cs_error_t sam_parent_wait_for_quorum (
 	int parent_fd_in,
 	int parent_fd_out)
@@ -906,6 +1032,13 @@ error_reply:
 	return (sam_parent_reply_send (err, parent_fd_in, parent_fd_out));
 }
 
+/**
+ * @brief sam_parent_cmap_state_set
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @param state
+ * @return
+ */
 static cs_error_t sam_parent_cmap_state_set (
 	int parent_fd_in,
 	int parent_fd_out,
@@ -930,6 +1063,12 @@ error_reply:
 	return (sam_parent_reply_send (err, parent_fd_in, parent_fd_out));
 }
 
+/**
+ * @brief sam_parent_kill_child
+ * @param action
+ * @param child_pid
+ * @return
+ */
 static cs_error_t sam_parent_kill_child (
 	int *action,
 	pid_t child_pid)
@@ -955,6 +1094,12 @@ static cs_error_t sam_parent_kill_child (
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_parent_mark_child_failed
+ * @param action
+ * @param child_pid
+ * @return
+ */
 static cs_error_t sam_parent_mark_child_failed (
 	int *action,
 	pid_t child_pid)
@@ -971,6 +1116,12 @@ static cs_error_t sam_parent_mark_child_failed (
 	return (sam_parent_kill_child (action, child_pid));
 }
 
+/**
+ * @brief sam_parent_data_store
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @return
+ */
 static cs_error_t sam_parent_data_store (
 	int parent_fd_in,
 	int parent_fd_out)
@@ -1015,6 +1166,13 @@ error_reply:
 	return (sam_parent_reply_send (err, parent_fd_in, parent_fd_out));
 }
 
+/**
+ * @brief sam_parent_handler
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @param child_pid
+ * @return
+ */
 static enum sam_parent_action_t sam_parent_handler (
 	int parent_fd_in,
 	int parent_fd_out,
@@ -1179,6 +1337,11 @@ action_exit:
 	return action;
 }
 
+/**
+ * @brief sam_register
+ * @param instance_id
+ * @return
+ */
 cs_error_t sam_register (
 	unsigned int *instance_id)
 {
@@ -1320,6 +1483,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief hc_callback_thread
+ * @param unused_param
+ * @return
+ */
 static void *hc_callback_thread (void *unused_param)
 {
 	int poll_error;
@@ -1382,6 +1550,11 @@ static void *hc_callback_thread (void *unused_param)
 	return (unused_param);
 }
 
+/**
+ * @brief sam_hc_callback_register
+ * @param cb
+ * @return
+ */
 cs_error_t sam_hc_callback_register (sam_hc_callback_t cb)
 {
 	cs_error_t error = CS_OK;

--- a/lib/util.h
+++ b/lib/util.h
@@ -39,6 +39,11 @@
 
 #include <corosync/corotypes.h>
 
+/**
+ * @brief hdb_error_to_cs
+ * @param res
+ * @return
+ */
 cs_error_t hdb_error_to_cs (int res);
 
 #ifdef HAVE_SMALL_MEMORY_FOOTPRINT

--- a/lib/votequorum.c
+++ b/lib/votequorum.c
@@ -58,6 +58,9 @@
 
 #include "util.h"
 
+/**
+ * @brief The votequorum_inst struct
+ */
 struct votequorum_inst {
 	qb_ipcc_connection_t *c;
 	int finalize;
@@ -69,6 +72,12 @@ static void votequorum_inst_free (void *inst);
 
 DECLARE_HDB_DATABASE(votequorum_handle_t_db, votequorum_inst_free);
 
+/**
+ * @brief votequorum_initialize
+ * @param handle
+ * @param callbacks
+ * @return
+ */
 cs_error_t votequorum_initialize (
 	votequorum_handle_t *handle,
 	votequorum_callbacks_t *callbacks)
@@ -110,12 +119,21 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief votequorum_inst_free
+ * @param inst
+ */
 static void votequorum_inst_free (void *inst)
 {
 	struct votequorum_inst *vq_inst = (struct votequorum_inst *)inst;
 	qb_ipcc_disconnect(vq_inst->c);
 }
 
+/**
+ * @brief votequorum_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t votequorum_finalize (
 	votequorum_handle_t handle)
 {
@@ -145,6 +163,13 @@ cs_error_t votequorum_finalize (
 }
 
 
+/**
+ * @brief votequorum_getinfo
+ * @param handle
+ * @param nodeid
+ * @param info
+ * @return
+ */
 cs_error_t votequorum_getinfo (
 	votequorum_handle_t handle,
 	unsigned int nodeid,
@@ -199,6 +224,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_setexpected
+ * @param handle
+ * @param expected_votes
+ * @return
+ */
 cs_error_t votequorum_setexpected (
 	votequorum_handle_t handle,
 	unsigned int expected_votes)
@@ -241,6 +272,13 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_setvotes
+ * @param handle
+ * @param nodeid
+ * @param votes
+ * @return
+ */
 cs_error_t votequorum_setvotes (
 	votequorum_handle_t handle,
 	unsigned int nodeid,
@@ -284,6 +322,13 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_trackstart
+ * @param handle
+ * @param context
+ * @param flags
+ * @return
+ */
 cs_error_t votequorum_trackstart (
 	votequorum_handle_t handle,
 	uint64_t context,
@@ -327,6 +372,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_trackstop
+ * @param handle
+ * @return
+ */
 cs_error_t votequorum_trackstop (
 	votequorum_handle_t handle)
 {
@@ -367,6 +417,12 @@ error_exit:
 }
 
 
+/**
+ * @brief votequorum_context_get
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t votequorum_context_get (
 	votequorum_handle_t handle,
 	void **context)
@@ -386,6 +442,12 @@ cs_error_t votequorum_context_get (
 	return (CS_OK);
 }
 
+/**
+ * @brief votequorum_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t votequorum_context_set (
 	votequorum_handle_t handle,
 	void *context)
@@ -406,6 +468,12 @@ cs_error_t votequorum_context_set (
 }
 
 
+/**
+ * @brief votequorum_fd_get
+ * @param handle
+ * @param fd
+ * @return
+ */
 cs_error_t votequorum_fd_get (
         votequorum_handle_t handle,
         int *fd)
@@ -425,6 +493,12 @@ cs_error_t votequorum_fd_get (
 	return (error);
 }
 
+/**
+ * @brief votequorum_dispatch
+ * @param handle
+ * @param dispatch_types
+ * @return
+ */
 cs_error_t votequorum_dispatch (
 	votequorum_handle_t handle,
 	cs_dispatch_flags_t dispatch_types)
@@ -557,6 +631,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_register
+ * @param handle
+ * @param name
+ * @return
+ */
 cs_error_t votequorum_qdevice_register (
 	votequorum_handle_t handle,
 	const char *name)
@@ -604,6 +684,14 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_poll
+ * @param handle
+ * @param name
+ * @param cast_vote
+ * @param ring_id
+ * @return
+ */
 cs_error_t votequorum_qdevice_poll (
 	votequorum_handle_t handle,
 	const char *name,
@@ -654,6 +742,13 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_master_wins
+ * @param handle
+ * @param name
+ * @param allow
+ * @return
+ */
 cs_error_t votequorum_qdevice_master_wins (
 	votequorum_handle_t handle,
 	const char *name,
@@ -702,6 +797,13 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_update
+ * @param handle
+ * @param oldname
+ * @param newname
+ * @return
+ */
 cs_error_t votequorum_qdevice_update (
 	votequorum_handle_t handle,
 	const char *oldname,
@@ -752,6 +854,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_unregister
+ * @param handle
+ * @param name
+ * @return
+ */
 cs_error_t votequorum_qdevice_unregister (
 	votequorum_handle_t handle,
 	const char *name)

--- a/test/cpgbench.c
+++ b/test/cpgbench.c
@@ -58,8 +58,14 @@
 #include <corosync/corotypes.h>
 #include <corosync/cpg.h>
 
+/**
+ * @brief handle
+ */
 static cpg_handle_t handle;
 
+/**
+ * @brief thread
+ */
 static pthread_t thread;
 
 #ifndef timersub
@@ -74,8 +80,22 @@ static pthread_t thread;
 	} while (0)
 #endif /* timersub */
 
+/**
+ * @brief alarm_notice
+ */
 static int alarm_notice;
 
+/**
+ * @brief cpg_bm_confchg_fn
+ * @param handle_in
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_bm_confchg_fn (
 	cpg_handle_t handle_in,
 	const struct cpg_name *group_name,
@@ -85,8 +105,20 @@ static void cpg_bm_confchg_fn (
 {
 }
 
+/**
+ * @brief write_count
+ */
 static unsigned int write_count;
 
+/**
+ * @brief cpg_bm_deliver_fn
+ * @param handle_in
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void cpg_bm_deliver_fn (
         cpg_handle_t handle_in,
         const struct cpg_name *group_name,
@@ -98,14 +130,26 @@ static void cpg_bm_deliver_fn (
 	write_count++;
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	.cpg_deliver_fn 	= cpg_bm_deliver_fn,
 	.cpg_confchg_fn		= cpg_bm_confchg_fn
 };
 
 #define ONE_MEG 1048576
+
+/**
+ * @brief data
+ */
 static char data[ONE_MEG];
 
+/**
+ * @brief cpg_benchmark
+ * @param handle_in
+ * @param write_size
+ */
 static void cpg_benchmark (
 	cpg_handle_t handle_in,
 	int write_size)
@@ -138,22 +182,38 @@ static void cpg_benchmark (
 		((float)write_count) * ((float)write_size) /  ((tv_elapsed.tv_sec + (tv_elapsed.tv_usec / 1000000.0)) * 1000000.0));
 }
 
+/**
+ * @brief sigalrm_handler
+ * @param num
+ */
 static void sigalrm_handler (int num)
 {
 	alarm_notice = 1;
 }
 
+/**
+ *
+ */
 static struct cpg_name group_name = {
 	.value = "cpg_bm",
 	.length = 6
 };
 
+/**
+ * @brief dispatch_thread
+ * @param arg
+ * @return
+ */
 static void* dispatch_thread (void *arg)
 {
 	cpg_dispatch (handle, CS_DISPATCH_BLOCKING);
 	return NULL;
 }
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void) {
 	unsigned int size;
 	int i;

--- a/test/cpgbenchzc.c
+++ b/test/cpgbenchzc.c
@@ -67,8 +67,22 @@
     } while (0)
 #endif
 
+/**
+ * @brief alarm_notice
+ */
 static int alarm_notice;
 
+/**
+ * @brief cpg_bm_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_bm_confchg_fn (
 	cpg_handle_t handle,
 	const struct cpg_name *group_name,
@@ -78,8 +92,20 @@ static void cpg_bm_confchg_fn (
 {
 }
 
+/**
+ * @brief write_count
+ */
 static unsigned int write_count;
 
+/**
+ * @brief cpg_bm_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void cpg_bm_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -91,6 +117,9 @@ static void cpg_bm_deliver_fn (
 	write_count++;
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	.cpg_deliver_fn 	= cpg_bm_deliver_fn,
 	.cpg_confchg_fn		= cpg_bm_confchg_fn
@@ -99,6 +128,11 @@ static cpg_callbacks_t callbacks = {
 
 void *data;
 
+/**
+ * @brief cpg_benchmark
+ * @param handle
+ * @param write_size
+ */
 static void cpg_benchmark (
 	cpg_handle_t handle,
 	int write_size)
@@ -144,16 +178,27 @@ retry:
 		((float)write_count) * ((float)write_size) /  ((tv_elapsed.tv_sec + (tv_elapsed.tv_usec / 1000000.0)) * 1000000.0));
 }
 
+/**
+ * @brief sigalrm_handler
+ * @param num
+ */
 static void sigalrm_handler (int num)
 {
 	alarm_notice = 1;
 }
 
+/**
+ *
+ */
 static struct cpg_name group_name = {
 	.value = "cpg_bm",
 	.length = 6
 };
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void) {
 	cpg_handle_t handle;
 	unsigned int size;

--- a/test/cpgbound.c
+++ b/test/cpgbound.c
@@ -45,6 +45,15 @@
 #include <corosync/corotypes.h>
 #include <corosync/cpg.h>
 
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -55,6 +64,17 @@ static void cpg_deliver_fn (
 {
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -64,18 +84,32 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ *
+ */
 static struct cpg_name group_name = {
         .value = "cpg_bm",
         .length = 6
 };
 
 
+/**
+ * @brief buffer
+ */
 static unsigned char buffer[2000000];
+
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	cpg_handle_t handle;

--- a/test/cpghum.c
+++ b/test/cpghum.c
@@ -92,6 +92,17 @@ static unsigned int packets_recvd=0;
 static unsigned int send_retries=0;
 static unsigned int send_fails=0;
 
+/**
+ * @brief cpg_bm_confchg_fn
+ * @param handle_in
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_bm_confchg_fn (
 	cpg_handle_t handle_in,
 	const struct cpg_name *group_name,
@@ -106,6 +117,15 @@ static unsigned int g_recv_length;
 static unsigned int g_write_size;
 static int g_recv_counter = 0;
 
+/**
+ * @brief cpg_bm_deliver_fn
+ * @param handle_in
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void cpg_bm_deliver_fn (
 	cpg_handle_t handle_in,
 	const struct cpg_name *group_name,
@@ -158,21 +178,37 @@ static void cpg_bm_deliver_fn (
 
 }
 
+/**
+ *
+ */
 static cpg_model_v1_data_t model1_data = {
 	.cpg_deliver_fn		= cpg_bm_deliver_fn,
 	.cpg_confchg_fn		= cpg_bm_confchg_fn,
 };
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	.cpg_deliver_fn		= cpg_bm_deliver_fn,
 	.cpg_confchg_fn		= cpg_bm_confchg_fn
 };
 
+/**
+ *
+ */
 static struct cpg_name group_name = {
 	.value = "cpghum",
 	.length = 7
 };
 
+/**
+ * @brief cpg_test
+ * @param handle_in
+ * @param write_size
+ * @param delay_time
+ * @param print_time
+ */
 static void cpg_test (
 	cpg_handle_t handle_in,
 	int write_size,
@@ -227,22 +263,39 @@ static void cpg_test (
 
 }
 
+/**
+ * @brief sigalrm_handler
+ * @param num
+ */
 static void sigalrm_handler (int num)
 {
 	alarm_notice = 1;
 }
 
+/**
+ * @brief sigint_handler
+ * @param num
+ */
 static void sigint_handler (int num)
 {
 	stopped = 1;
 }
 
+/**
+ * @brief dispatch_thread
+ * @param arg
+ * @return
+ */
 static void* dispatch_thread (void *arg)
 {
 	cpg_dispatch (handle, CS_DISPATCH_BLOCKING);
 	return NULL;
 }
 
+/**
+ * @brief usage
+ * @param cmd
+ */
 static void usage(char *cmd)
 {
 	fprintf(stderr, "%s [OPTIONS]\n", cmd);
@@ -276,6 +329,12 @@ static void usage(char *cmd)
 	fprintf(stderr, "\n");
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	int i;
 	unsigned int res;

--- a/test/cpgverify.c
+++ b/test/cpgverify.c
@@ -49,15 +49,30 @@
 #include <nss.h>
 #include <pk11pub.h>
 
+/**
+ * @brief The my_msg struct
+ */
 struct my_msg {
 	unsigned int msg_size;
 	unsigned char sha1[20];
 	unsigned char buffer[0];
 };
 
+/**
+ * @brief deliveries
+ */
 static int deliveries = 0;
 PK11Context* sha1_context;
 
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -87,6 +102,17 @@ printf ("\n");
 	deliveries++;
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -96,17 +122,26 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ *
+ */
 static struct cpg_name group_name = {
         .value = "cpg_bm",
         .length = 6
 };
 
 
+/**
+ * @brief buffer
+ */
 static unsigned char buffer[200000];
 int main (int argc, char *argv[])
 {

--- a/test/stress_cpgcontext.c
+++ b/test/stress_cpgcontext.c
@@ -45,12 +45,24 @@
 #include <corosync/cpg.h>
 #include <signal.h>
 
+/**
+ * @brief The my_msg struct
+ */
 struct my_msg {
 	unsigned int msg_size;
 	unsigned char sha1[20];
 	unsigned char buffer[0];
 };
 
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -61,6 +73,17 @@ static void cpg_deliver_fn (
 {
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -75,6 +98,10 @@ static cpg_callbacks_t callbacks = {
 	cpg_confchg_fn
 };
 
+/**
+ * @brief sigintr_handler
+ * @param num
+ */
 static void sigintr_handler (int num)
 {
 	exit (1);
@@ -84,6 +111,10 @@ static void sigintr_handler (int num)
 
 #define INSTANCES 100
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	cpg_handle_t handle[INSTANCES];

--- a/test/stress_cpgfdget.c
+++ b/test/stress_cpgfdget.c
@@ -45,12 +45,24 @@
 #include <corosync/cpg.h>
 #include <signal.h>
 
+/**
+ * @brief The my_msg struct
+ */
 struct my_msg {
 	unsigned int msg_size;
 	unsigned char sha1[20];
 	unsigned char buffer[0];
 };
 
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -61,6 +73,17 @@ static void cpg_deliver_fn (
 {
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -70,11 +93,18 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ * @brief sigintr_handler
+ * @param num
+ */
 static void sigintr_handler (int num)
 {
 	exit (1);
@@ -83,6 +113,10 @@ static void sigintr_handler (int num)
 
 #define ITERATIONS (1000*2000)
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	cpg_handle_t handle;

--- a/test/stress_cpgzc.c
+++ b/test/stress_cpgzc.c
@@ -46,6 +46,9 @@
 #include <signal.h>
 #include <assert.h>
 
+/**
+ * @brief The my_msg struct
+ */
 struct my_msg {
 	unsigned int msg_size;
 	unsigned char sha1[20];
@@ -53,6 +56,16 @@ struct my_msg {
 };
 
 static int deliveries = 0;
+
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -64,6 +77,17 @@ static void cpg_deliver_fn (
 	deliveries++;
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -73,11 +97,18 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ * @brief sigintr_handler
+ * @param num
+ */
 static void sigintr_handler (int num)
 {
 	exit (1);
@@ -86,6 +117,11 @@ static void sigintr_handler (int num)
 #define ITERATIONS 100
 #define ALLOCATIONS 2000
 #define MAX_SIZE 100000
+
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	cs_error_t res;

--- a/test/testcpg.c
+++ b/test/testcpg.c
@@ -71,6 +71,10 @@ static uint32_t nodeidStart = 0;
 
 static void print_localnodeid(cpg_handle_t handle);
 
+/**
+ * @brief print_cpgname
+ * @param name
+ */
 static void print_cpgname (const struct cpg_name *name)
 {
 	unsigned int i;
@@ -80,6 +84,12 @@ static void print_cpgname (const struct cpg_name *name)
 	}
 }
 
+/**
+ * @brief node_pid_format
+ * @param nodeid
+ * @param pid
+ * @return
+ */
 static char * node_pid_format(unsigned int nodeid, unsigned int pid) {
 	static char buffer[100];
 	if (show_ip) {
@@ -97,6 +107,9 @@ static char * node_pid_format(unsigned int nodeid, unsigned int pid) {
 	return buffer;
 }
 
+/**
+ * @brief print_time
+ */
 static void
 print_time(void)
 {
@@ -128,7 +141,15 @@ print_time(void)
 	printf("%s\n", buf);
 }
 
-
+/**
+ * @brief DeliverCallback
+ * @param handle
+ * @param groupName
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void DeliverCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -143,6 +164,17 @@ static void DeliverCallback (
 		       (const char *)msg);
 }
 
+/**
+ * @brief ConfchgCallback
+ * @param handle
+ * @param groupName
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void ConfchgCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -209,6 +241,13 @@ static void ConfchgCallback (
 	}
 }
 
+/**
+ * @brief TotemConfchgCallback
+ * @param handle
+ * @param ring_id
+ * @param member_list_entries
+ * @param member_list
+ */
 static void TotemConfchgCallback (
 	cpg_handle_t handle,
         struct cpg_ring_id ring_id,
@@ -230,6 +269,9 @@ static void TotemConfchgCallback (
 	printf ("\n");
 }
 
+/**
+ *
+ */
 static cpg_model_v1_data_t model_data = {
 	.cpg_deliver_fn =            DeliverCallback,
 	.cpg_confchg_fn =            ConfchgCallback,
@@ -237,6 +279,9 @@ static cpg_model_v1_data_t model_data = {
 	.flags =                     CPG_MODEL_V1_DELIVER_INITIAL_TOTEM_CONF,
 };
 
+/**
+ * @brief group_name
+ */
 static struct cpg_name group_name;
 
 #define retrybackoff(counter) {    \
@@ -269,6 +314,10 @@ static struct cpg_name group_name;
 	}                                     \
 } while (counter < max)
 
+/**
+ * @brief print_localnodeid
+ * @param handle
+ */
 static void print_localnodeid(cpg_handle_t handle)
 {
 	char addrStr[128];
@@ -293,6 +342,12 @@ static void print_localnodeid(cpg_handle_t handle)
 	}
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	cpg_handle_t handle;
 	fd_set read_fds;

--- a/test/testcpg2.c
+++ b/test/testcpg2.c
@@ -44,6 +44,15 @@
 #include <corosync/corotypes.h>
 #include <corosync/cpg.h>
 
+/**
+ * @brief deliver
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void deliver(
 	cpg_handle_t handle,
 	const struct cpg_name *group_name,
@@ -55,6 +64,17 @@ static void deliver(
     printf("self delivered nodeid: %x\n", nodeid);
 }
 
+/**
+ * @brief confch
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void confch(
 	cpg_handle_t handle,
 	const struct cpg_name *group_name,
@@ -65,6 +85,12 @@ static void confch(
 	printf("confchg nodeid %x\n", member_list[0].nodeid);
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char** argv) {
 	cpg_handle_t handle=0;
 	cpg_callbacks_t cb={&deliver,&confch};

--- a/test/testcpgzc.c
+++ b/test/testcpgzc.c
@@ -55,6 +55,10 @@
 static int quit = 0;
 static int show_ip = 0;
 
+/**
+ * @brief print_cpgname
+ * @param name
+ */
 static void print_cpgname (const struct cpg_name *name)
 {
 	int i;
@@ -64,6 +68,15 @@ static void print_cpgname (const struct cpg_name *name)
 	}
 }
 
+/**
+ * @brief DeliverCallback
+ * @param handle
+ * @param groupName
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void DeliverCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -86,6 +99,17 @@ static void DeliverCallback (
 	}
 }
 
+/**
+ * @brief ConfchgCallback
+ * @param handle
+ * @param groupName
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void ConfchgCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -156,6 +180,12 @@ static cpg_callbacks_t callbacks = {
 
 static struct cpg_name group_name;
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	cpg_handle_t handle;
 	fd_set read_fds;

--- a/test/testparse.c
+++ b/test/testparse.c
@@ -40,6 +40,10 @@
 #include "../exec/parse.h"
 #include "../exec/print.h"
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 #ifdef CODE_COVERAGE_COMPILE_OUT

--- a/test/testquorum.c
+++ b/test/testquorum.c
@@ -10,6 +10,14 @@
 
 static quorum_handle_t g_handle;
 
+/**
+ * @brief quorum_notification_fn
+ * @param handle
+ * @param quorate
+ * @param ring_id
+ * @param view_list_entries
+ * @param view_list
+ */
 static void quorum_notification_fn(
 	quorum_handle_t handle,
 	uint32_t quorate,
@@ -31,6 +39,12 @@ static void quorum_notification_fn(
 }
 
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	int quorate;

--- a/test/testsam.c
+++ b/test/testsam.c
@@ -67,6 +67,11 @@ static int test6_sig_delivered = 0;
  * twice. One should succeed, second should fail. After this, we will call every function
  * (none should succeed).
  */
+
+/**
+ * @brief test1
+ * @return
+ */
 static int test1 (void)
 {
 	cs_error_t error;
@@ -176,6 +181,10 @@ static int test1 (void)
 }
 
 
+/**
+ * @brief test2_signal
+ * @param sig
+ */
 static void test2_signal (int sig) {
 	printf ("%s\n", __FUNCTION__);
 
@@ -184,6 +193,10 @@ static void test2_signal (int sig) {
 
 /*
  * This tests recovery policy quit and callback.
+ */
+/**
+ * @brief test2
+ * @return
  */
 static int test2 (void) {
 	cs_error_t error;
@@ -241,6 +254,10 @@ static int test2 (void) {
  * Smoke test. Better to turn off coredump ;) This has no time limit, just restart process
  * when it dies.
  */
+/**
+ * @brief test3
+ * @return
+ */
 static int test3 (void) {
 	cs_error_t error;
 	unsigned int instance_id;
@@ -277,6 +294,10 @@ static int test3 (void) {
 
 /*
  * Test sam_data_store, sam_data_restore and sam_data_getsize
+ */
+/**
+ * @brief test4
+ * @return
  */
 static int test4 (void)
 {
@@ -524,6 +545,10 @@ static int test4 (void)
 	return (0);
 }
 
+/**
+ * @brief test5_hc_cb
+ * @return
+ */
 static int test5_hc_cb (void)
 {
 	cs_error_t res;
@@ -538,8 +563,13 @@ static int test5_hc_cb (void)
 
 	return 0;
 }
+
 /*
  * Test event driven healtchecking.
+ */
+/**
+ * @brief test5
+ * @return
  */
 static int test5 (void)
 {
@@ -601,6 +631,10 @@ static int test5 (void)
 	return 1;
 }
 
+/**
+ * @brief test6_signal
+ * @param sig
+ */
 static void test6_signal (int sig) {
 	cs_error_t error;
 
@@ -614,6 +648,10 @@ static void test6_signal (int sig) {
 
 /*
  * Test warn signal set.
+ */
+/**
+ * @brief test6
+ * @return
  */
 static int test6 (void) {
 	cs_error_t error;
@@ -748,6 +786,10 @@ static void *test7_thread (void *arg)
 /*
  * Test quorum
  */
+/**
+ * @brief test7
+ * @return
+ */
 static int test7 (void) {
 	cmap_handle_t cmap_handle;
 	cs_error_t err;
@@ -855,6 +897,13 @@ static int test7 (void) {
 
 /*
  * Test cmap integration + quit policy
+ */
+/**
+ * @brief test8
+ * @param pid
+ * @param old_pid
+ * @param test_n
+ * @return
  */
 static int test8 (pid_t pid, pid_t old_pid, int test_n) {
 	cmap_handle_t cmap_handle;
@@ -1102,6 +1151,13 @@ static int test8 (pid_t pid, pid_t old_pid, int test_n) {
 /*
  * Test cmap integration + restart policy
  */
+/**
+ * @brief test9
+ * @param pid
+ * @param old_pid
+ * @param test_n
+ * @return
+ */
 static int test9 (pid_t pid, pid_t old_pid, int test_n) {
 	cs_error_t err;
 	cmap_handle_t cmap_handle;
@@ -1234,6 +1290,12 @@ static int test9 (pid_t pid, pid_t old_pid, int test_n) {
 	return (2);
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	pid_t pid, old_pid;

--- a/test/testtimer.c
+++ b/test/testtimer.c
@@ -41,11 +41,19 @@
 
 #include "../exec/timer.h"
 
+/**
+ * @brief timer_function
+ * @param data
+ */
 void timer_function (void *data)
 {
 	printf ("timer %p\n", data);
 }
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	int msec;

--- a/test/testvotequorum1.c
+++ b/test/testvotequorum1.c
@@ -46,6 +46,11 @@
 
 static votequorum_handle_t g_handle;
 
+/**
+ * @brief node_state
+ * @param state
+ * @return
+ */
 static const char *node_state(int state)
 {
 	switch (state) {
@@ -65,6 +70,12 @@ static const char *node_state(int state)
 }
 
 
+/**
+ * @brief votequorum_expectedvotes_notification_fn
+ * @param handle
+ * @param context
+ * @param expected_votes
+ */
 static void votequorum_expectedvotes_notification_fn(
 	votequorum_handle_t handle,
 	uint64_t context,
@@ -76,6 +87,15 @@ static void votequorum_expectedvotes_notification_fn(
 }
 
 
+/**
+ * @brief votequorum_notification_fn
+ * @param handle
+ * @param context
+ * @param quorate
+ * @param ring_id
+ * @param node_list_entries
+ * @param node_list
+ */
 static void votequorum_notification_fn(
 	votequorum_handle_t handle,
 	uint64_t context,
@@ -99,6 +119,12 @@ static void votequorum_notification_fn(
 }
 
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	struct votequorum_info info;

--- a/test/testvotequorum2.c
+++ b/test/testvotequorum2.c
@@ -50,6 +50,11 @@ static votequorum_ring_id_t last_received_ring_id;
 static votequorum_ring_id_t ring_id_to_send;
 static int no_sent_old_ringid = 0;
 
+/**
+ * @brief print_info
+ * @param ok_to_fail
+ * @return
+ */
 static int print_info(int ok_to_fail)
 {
 	struct votequorum_info info;
@@ -76,6 +81,15 @@ static int print_info(int ok_to_fail)
 	return 0;
 }
 
+/**
+ * @brief votequorum_notification_fn
+ * @param vq_handle
+ * @param context
+ * @param quorate
+ * @param ring_id
+ * @param node_list_entries
+ * @param node_list
+ */
 static void votequorum_notification_fn(
 	votequorum_handle_t vq_handle,
 	uint64_t context,
@@ -93,6 +107,10 @@ static void votequorum_notification_fn(
 	no_sent_old_ringid = 0;
 }
 
+/**
+ * @brief usage
+ * @param command
+ */
 static void usage(const char *command)
 {
   printf("%s [-F <num>] [-p <num>] [-t <time>] [-n <name>] [-c] [-m]\n", command);
@@ -106,6 +124,12 @@ static void usage(const char *command)
         printf("      -1        Print status once and exit\n");
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	int ret = 0;

--- a/test/testzcgc.c
+++ b/test/testzcgc.c
@@ -52,6 +52,10 @@
 static int quit = 0;
 static int show_ip = 0;
 
+/**
+ * @brief print_cpgname
+ * @param name
+ */
 static void print_cpgname (const struct cpg_name *name)
 {
 	int i;
@@ -61,6 +65,15 @@ static void print_cpgname (const struct cpg_name *name)
 	}
 }
 
+/**
+ * @brief DeliverCallback
+ * @param handle
+ * @param groupName
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void DeliverCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -83,6 +96,17 @@ static void DeliverCallback (
 	}
 }
 
+/**
+ * @brief ConfchgCallback
+ * @param handle
+ * @param groupName
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void ConfchgCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -146,6 +170,9 @@ static void ConfchgCallback (
 	}
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	.cpg_deliver_fn =            DeliverCallback,
 	.cpg_confchg_fn =            ConfchgCallback,
@@ -153,6 +180,12 @@ static cpg_callbacks_t callbacks = {
 
 static struct cpg_name group_name;
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	cpg_handle_t handle;
 	int result;

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -65,6 +65,11 @@
 		} while (counter < max);			\
 	} while (0)
 
+/**
+ * @brief ringstatusget_do
+ * @param interface_name
+ * @return
+ */
 static int ringstatusget_do (char *interface_name)
 {
 	cs_error_t result;
@@ -117,6 +122,9 @@ static int ringstatusget_do (char *interface_name)
 	return rc;
 }
 
+/**
+ * @brief ringreenable_do
+ */
 static void ringreenable_do (void)
 {
 	cs_error_t result;
@@ -137,6 +145,10 @@ static void ringreenable_do (void)
 	(void)corosync_cfg_finalize (handle);
 }
 
+/**
+ * @brief reload_config_do
+ * @return
+ */
 static int reload_config_do (void)
 {
 	cs_error_t result;
@@ -166,6 +178,9 @@ static int reload_config_do (void)
 	return (rc);
 }
 
+/**
+ * @brief shutdown_do
+ */
 static void shutdown_do(void)
 {
 	cs_error_t result;
@@ -189,6 +204,10 @@ static void shutdown_do(void)
 	(void)corosync_cfg_finalize (handle);
 }
 
+/**
+ * @brief showaddrs_do
+ * @param nodeid
+ */
 static void showaddrs_do(int nodeid)
 {
 	cs_error_t result;
@@ -231,7 +250,10 @@ static void showaddrs_do(int nodeid)
 	(void)corosync_cfg_finalize (handle);
 }
 
-
+/**
+ * @brief killnode_do
+ * @param nodeid
+ */
 static void killnode_do(unsigned int nodeid)
 {
 	cs_error_t result;
@@ -250,7 +272,9 @@ static void killnode_do(unsigned int nodeid)
 	(void)corosync_cfg_finalize (handle);
 }
 
-
+/**
+ * @brief usage_do
+ */
 static void usage_do (void)
 {
 	printf ("corosync-cfgtool [-i <interface ip>] -s] [-r] [-H] [service_name] [-k] [nodeid] [-a] [nodeid]\n\n");
@@ -265,6 +289,12 @@ static void usage_do (void)
 	printf ("\t-H\tShutdown corosync cleanly on this node.\n");
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	const char *options = "i:srRk:a:hH";
 	int opt;

--- a/tools/corosync-cmapctl.c
+++ b/tools/corosync-cmapctl.c
@@ -48,6 +48,9 @@
 
 #define MAX_TRY_AGAIN 10
 
+/**
+ * @brief The user_action enum
+ */
 enum user_action {
 	ACTION_GET,
 	ACTION_SET,
@@ -59,6 +62,9 @@ enum user_action {
 	ACTION_LOAD,
 };
 
+/**
+ * @brief The name_to_type_item struct
+ */
 struct name_to_type_item {
 	const char *name;
 	cmap_value_types_t type;
@@ -80,6 +86,11 @@ struct name_to_type_item name_to_type[] = {
 
 int show_binary = 0;
 
+/**
+ * @brief convert_name_to_type
+ * @param name
+ * @return
+ */
 static int convert_name_to_type(const char *name)
 {
 	int i;
@@ -93,6 +104,10 @@ static int convert_name_to_type(const char *name)
 	return (-1);
 }
 
+/**
+ * @brief print_help
+ * @return
+ */
 static int print_help(void)
 {
 	printf("\n");
@@ -141,6 +156,11 @@ static int print_help(void)
 	return (0);
 }
 
+/**
+ * @brief print_binary_key
+ * @param value
+ * @param value_len
+ */
 static void print_binary_key (char *value, size_t value_len)
 {
 	size_t i;
@@ -160,6 +180,14 @@ static void print_binary_key (char *value, size_t value_len)
 	}
 }
 
+/**
+ * @brief print_key
+ * @param handle
+ * @param key_name
+ * @param value_len
+ * @param value
+ * @param type
+ */
 static void print_key(cmap_handle_t handle,
 		const char *key_name,
 		size_t value_len,
@@ -361,6 +389,11 @@ static void print_key(cmap_handle_t handle,
 	printf("\n");
 }
 
+/**
+ * @brief print_iter
+ * @param handle
+ * @param prefix
+ */
 static void print_iter(cmap_handle_t handle, const char *prefix)
 {
 	cmap_iter_handle_t iter_handle;
@@ -381,6 +414,11 @@ static void print_iter(cmap_handle_t handle, const char *prefix)
 	cmap_iter_finalize(handle, iter_handle);
 }
 
+/**
+ * @brief delete_with_prefix
+ * @param handle
+ * @param prefix
+ */
 static void delete_with_prefix(cmap_handle_t handle, const char *prefix)
 {
 	cmap_iter_handle_t iter_handle;
@@ -405,6 +443,16 @@ static void delete_with_prefix(cmap_handle_t handle, const char *prefix)
 	cmap_iter_finalize(handle, iter_handle);
 }
 
+/**
+ * @brief cmap_notify_fn
+ * @param cmap_handle
+ * @param cmap_track_handle
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void cmap_notify_fn(
 	cmap_handle_t cmap_handle,
 	cmap_track_handle_t cmap_track_handle,
@@ -434,6 +482,12 @@ static void cmap_notify_fn(
 
 }
 
+/**
+ * @brief add_track
+ * @param handle
+ * @param key_name
+ * @param prefix
+ */
 static void add_track(cmap_handle_t handle, const char *key_name, int prefix)
 {
 	cmap_track_handle_t track_handle;
@@ -452,6 +506,10 @@ static void add_track(cmap_handle_t handle, const char *key_name, int prefix)
 	}
 }
 
+/**
+ * @brief track_changes
+ * @param handle
+ */
 static void track_changes(cmap_handle_t handle)
 {
 	struct pollfd pfd[2];
@@ -497,6 +555,13 @@ static void track_changes(cmap_handle_t handle)
 	} while (poll_res > 0 && !quit);
 }
 
+/**
+ * @brief set_key_bin
+ * @param handle
+ * @param key_name
+ * @param fname
+ * @return
+ */
 static cs_error_t set_key_bin(cmap_handle_t handle, const char *key_name, const char *fname)
 {
 	FILE *f;
@@ -541,6 +606,13 @@ static cs_error_t set_key_bin(cmap_handle_t handle, const char *key_name, const 
 	return (err);
 }
 
+/**
+ * @brief set_key
+ * @param handle
+ * @param key_name
+ * @param key_type_s
+ * @param key_value_s
+ */
 static void set_key(cmap_handle_t handle, const char *key_name, const char *key_type_s, const char *key_value_s)
 {
 	int64_t i64;
@@ -665,7 +737,11 @@ static void set_key(cmap_handle_t handle, const char *key_name, const char *key_
 	}
 }
 
-
+/**
+ * @brief read_in_config_file
+ * @param handle
+ * @param filename
+ */
 static void read_in_config_file(cmap_handle_t handle, char * filename)
 {
 	int ignore;
@@ -735,6 +811,12 @@ static void read_in_config_file(cmap_handle_t handle, char * filename)
 	fclose (fh);
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	enum user_action action;

--- a/tools/corosync-cpgtool.c
+++ b/tools/corosync-cpgtool.c
@@ -56,11 +56,19 @@
 static corosync_cfg_handle_t cfg_handle;
 static cpg_handle_t cpg_handle;
 
+/**
+ * @brief operation_t enum
+ */
 typedef enum {
 	OPER_NAMES_ONLY = 1,
 	OPER_FULL_OUTPUT = 2,
 } operation_t;
 
+/**
+ * @brief fprint_addrs
+ * @param f
+ * @param nodeid
+ */
 static void fprint_addrs(FILE *f, int nodeid)
 {
 	int numaddrs;
@@ -89,6 +97,12 @@ static void fprint_addrs(FILE *f, int nodeid)
 	}
 }
 
+/**
+ * @brief fprint_group
+ * @param f
+ * @param escape
+ * @param group
+ */
 static void fprint_group (FILE *f, int escape, const struct cpg_name *group) {
 	int i;
 	char c;
@@ -107,6 +121,12 @@ static void fprint_group (FILE *f, int escape, const struct cpg_name *group) {
 	}
 }
 
+/**
+ * @brief display_groups
+ * @param delimiter
+ * @param escape
+ * @return
+ */
 static int display_groups (char delimiter, int escape)
 {
 	cs_error_t res;
@@ -133,6 +153,12 @@ static int display_groups (char delimiter, int escape)
 	return 1;
 }
 
+/**
+ * @brief group_name_compare
+ * @param g1
+ * @param g2
+ * @return
+ */
 static inline int group_name_compare (
 	const struct cpg_name *g1,
 	const struct cpg_name *g2)
@@ -142,6 +168,12 @@ static inline int group_name_compare (
 		g1->length - g2->length);
 }
 
+/**
+ * @brief display_groups_with_members
+ * @param delimiter
+ * @param escape
+ * @return
+ */
 static int display_groups_with_members (char delimiter, int escape) {
 	cs_error_t res;
 	cpg_iteration_handle_t iter_handle;
@@ -192,6 +224,10 @@ static int display_groups_with_members (char delimiter, int escape) {
 	return 1;
 }
 
+/**
+ * @brief usage_do
+ * @param prog_name
+ */
 static void usage_do (const char *prog_name)
 {
 	printf ("%s [-d delimiter] [-e] [-n] [-h]\n\n", prog_name);
@@ -204,6 +240,12 @@ static void usage_do (const char *prog_name)
 }
 
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	const char *options = "hd:ne";
 	int opt;

--- a/tools/corosync-keygen.c
+++ b/tools/corosync-keygen.c
@@ -59,6 +59,12 @@ static const char usage[] =
 	"            application is used from a script.\n";
 
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[])
 {
 	int authkey_fd;

--- a/tools/corosync-notifyd.c
+++ b/tools/corosync-notifyd.c
@@ -65,6 +65,9 @@
 /*
  * generic declarations
  */
+/**
+ * @brief unnamed enum
+ */
 enum {
 	CS_NTF_LOG,
 	CS_NTF_STDOUT,
@@ -82,6 +85,9 @@ typedef void (*node_quorum_fn_t)(char *nodename, uint32_t nodeid, const char *st
 typedef void (*application_connection_fn_t)(char *nodename, uint32_t nodeid, char *app_name, const char *state);
 typedef void (*rrp_faulty_fn_t)(char *nodename, uint32_t nodeid, uint32_t iface_no, const char *state);
 
+/**
+ * @brief The notify_callbacks struct
+ */
 struct notify_callbacks {
 	node_membership_fn_t node_membership_fn;
 	node_quorum_fn_t node_quorum_fn;
@@ -126,6 +132,9 @@ static void _cs_dbus_init(void);
 #include <net-snmp/library/snmp_client.h>
 #include <net-snmp/library/snmp_debug.h>
 
+/**
+ * @brief The snmp_node_status enum
+ */
 enum snmp_node_status {
        SNMP_NODE_STATUS_UNKNOWN = 0,
        SNMP_NODE_STATUS_JOINED = 1,
@@ -162,11 +171,17 @@ static char *snmp_manager = NULL;
 
 #define CMAP_MAX_RETRIES 10
 
-/*
- * cmap
+/**
+ * @brief cmap_handle
  */
 static cmap_handle_t cmap_handle;
 
+/**
+ * @brief _cs_ip_to_hostname
+ * @param ip
+ * @param name_out
+ * @return
+ */
 static int32_t _cs_ip_to_hostname(char* ip, char* name_out)
 {
 	struct sockaddr_in sa;
@@ -192,6 +207,16 @@ static int32_t _cs_ip_to_hostname(char* ip, char* name_out)
 	return 0;
 }
 
+/**
+ * @brief _cs_cmap_members_key_changed
+ * @param cmap_handle_c
+ * @param cmap_track_handle
+ * @param event
+ * @param key_name
+ * @param new_value
+ * @param old_value
+ * @param user_data
+ */
 static void _cs_cmap_members_key_changed (
 	cmap_handle_t cmap_handle_c,
 	cmap_track_handle_t cmap_track_handle,
@@ -246,6 +271,16 @@ static void _cs_cmap_members_key_changed (
 	free(ip_str);
 }
 
+/**
+ * @brief _cs_cmap_connections_key_changed
+ * @param cmap_handle_c
+ * @param cmap_track_handle
+ * @param event
+ * @param key_name
+ * @param new_value
+ * @param old_value
+ * @param user_data
+ */
 static void _cs_cmap_connections_key_changed (
 	cmap_handle_t cmap_handle_c,
 	cmap_track_handle_t cmap_track_handle,
@@ -280,6 +315,16 @@ static void _cs_cmap_connections_key_changed (
 	}
 }
 
+/**
+ * @brief _cs_cmap_rrp_faulty_key_changed
+ * @param cmap_handle_c
+ * @param cmap_track_handle
+ * @param event
+ * @param key_name
+ * @param new_value
+ * @param old_value
+ * @param user_data
+ */
 static void _cs_cmap_rrp_faulty_key_changed (
 	cmap_handle_t cmap_handle_c,
 	cmap_track_handle_t cmap_track_handle,
@@ -322,6 +367,13 @@ static void _cs_cmap_rrp_faulty_key_changed (
 	}
 }
 
+/**
+ * @brief _cs_cmap_dispatch
+ * @param fd
+ * @param revents
+ * @param data
+ * @return
+ */
 static int
 _cs_cmap_dispatch(int fd, int revents, void *data)
 {
@@ -340,6 +392,14 @@ _cs_cmap_dispatch(int fd, int revents, void *data)
 	return 0;
 }
 
+/**
+ * @brief _cs_quorum_notification
+ * @param handle
+ * @param quorate
+ * @param ring_seq
+ * @param view_list_entries
+ * @param view_list
+ */
 static void _cs_quorum_notification(quorum_handle_t handle,
 	uint32_t quorate, uint64_t ring_seq,
 	uint32_t view_list_entries, uint32_t *view_list)
@@ -356,6 +416,13 @@ static void _cs_quorum_notification(quorum_handle_t handle,
 	}
 }
 
+/**
+ * @brief _cs_quorum_dispatch
+ * @param fd
+ * @param revents
+ * @param data
+ * @return
+ */
 static int
 _cs_quorum_dispatch(int fd, int revents, void *data)
 {
@@ -372,6 +439,9 @@ _cs_quorum_dispatch(int fd, int revents, void *data)
 	return 0;
 }
 
+/**
+ * @brief _cs_quorum_init
+ */
 static void
 _cs_quorum_init(void)
 {
@@ -399,6 +469,9 @@ _cs_quorum_init(void)
 	}
 }
 
+/**
+ * @brief _cs_quorum_finalize
+ */
 static void
 _cs_quorum_finalize(void)
 {
@@ -407,8 +480,8 @@ _cs_quorum_finalize(void)
 
 
 #ifdef HAVE_DBUS
-/*
- * dbus notifications
+/**
+ * @brief _cs_dbus_auto_flush dbus notifications
  */
 static void
 _cs_dbus_auto_flush(void)
@@ -425,6 +498,9 @@ _cs_dbus_auto_flush(void)
 	dbus_connection_unref(db);
 }
 
+/**
+ * @brief _cs_dbus_release
+ */
 static void
 _cs_dbus_release(void)
 {
@@ -440,6 +516,12 @@ _cs_dbus_release(void)
 	db = NULL;
 }
 
+/**
+ * @brief _cs_dbus_node_quorum_event
+ * @param nodename
+ * @param nodeid
+ * @param state
+ */
 static void
 _cs_dbus_node_quorum_event(char *nodename, uint32_t nodeid, const char *state)
 {
@@ -489,6 +571,13 @@ out_free:
 	return;
 }
 
+/**
+ * @brief _cs_dbus_node_membership_event
+ * @param nodename
+ * @param nodeid
+ * @param state
+ * @param ip
+ */
 static void
 _cs_dbus_node_membership_event(char *nodename, uint32_t nodeid, char *state, char* ip)
 {
@@ -539,6 +628,13 @@ out_free:
 	return;
 }
 
+/**
+ * @brief _cs_dbus_application_connection_event
+ * @param nodename
+ * @param nodeid
+ * @param app_name
+ * @param state
+ */
 static void
 _cs_dbus_application_connection_event(char *nodename, uint32_t nodeid, char *app_name, const char *state)
 {
@@ -589,6 +685,13 @@ out_free:
 	return;
 }
 
+/**
+ * @brief _cs_dbus_rrp_faulty_event
+ * @param nodename
+ * @param nodeid
+ * @param iface_no
+ * @param state
+ */
 static void
 _cs_dbus_rrp_faulty_event(char *nodename, uint32_t nodeid, uint32_t iface_no, const char *state)
 {
@@ -639,6 +742,9 @@ out_free:
 	return;
 }
 
+/**
+ * @brief _cs_dbus_init
+ */
 static void
 _cs_dbus_init(void)
 {
@@ -675,6 +781,11 @@ _cs_dbus_init(void)
 #endif /* HAVE_DBUS */
 
 #ifdef ENABLE_SNMP
+/**
+ * @brief snmp_init
+ * @param target
+ * @return
+ */
 static netsnmp_session *snmp_init (const char *target)
 {
 	static netsnmp_session *session = NULL;
@@ -710,6 +821,14 @@ static netsnmp_session *snmp_init (const char *target)
 	return (session);
 }
 
+/**
+ * @brief add_field
+ * @param trap_pdu
+ * @param asn_type
+ * @param prefix
+ * @param value
+ * @param value_size
+ */
 static inline void add_field (
 	netsnmp_pdu *trap_pdu,
 	u_char asn_type,
@@ -724,6 +843,13 @@ static inline void add_field (
 	}
 }
 
+/**
+ * @brief _cs_snmp_node_membership_event
+ * @param nodename
+ * @param nodeid
+ * @param state
+ * @param ip
+ */
 static void
 _cs_snmp_node_membership_event(char *nodename, uint32_t nodeid, char *state, char* ip)
 {
@@ -766,6 +892,12 @@ _cs_snmp_node_membership_event(char *nodename, uint32_t nodeid, char *state, cha
 	}
 }
 
+/**
+ * @brief _cs_snmp_node_quorum_event
+ * @param nodename
+ * @param nodeid
+ * @param state
+ */
 static void
 _cs_snmp_node_quorum_event(char *nodename, uint32_t nodeid,
 			   const char *state)
@@ -808,6 +940,13 @@ _cs_snmp_node_quorum_event(char *nodename, uint32_t nodeid,
 	}
 }
 
+/**
+ * @brief _cs_snmp_rrp_faulty_event
+ * @param nodename
+ * @param nodeid
+ * @param iface_no
+ * @param state
+ */
 static void
 _cs_snmp_rrp_faulty_event(char *nodename, uint32_t nodeid,
 		uint32_t iface_no, const char *state)
@@ -851,6 +990,9 @@ _cs_snmp_rrp_faulty_event(char *nodename, uint32_t nodeid,
 	}
 }
 
+/**
+ * @brief _cs_snmp_init
+ */
 static void
 _cs_snmp_init(void)
 {
@@ -870,12 +1012,25 @@ _cs_snmp_init(void)
 
 #endif /* ENABLE_SNMP */
 
+/**
+ * @brief _cs_syslog_node_membership_event
+ * @param nodename
+ * @param nodeid
+ * @param state
+ * @param ip
+ */
 static void
 _cs_syslog_node_membership_event(char *nodename, uint32_t nodeid, char *state, char* ip)
 {
 	qb_log(LOG_NOTICE, "%s[%d] ip:%s %s", nodename, nodeid, ip, state);
 }
 
+/**
+ * @brief _cs_syslog_node_quorum_event
+ * @param nodename
+ * @param nodeid
+ * @param state
+ */
 static void
 _cs_syslog_node_quorum_event(char *nodename, uint32_t nodeid, const char *state)
 {
@@ -886,6 +1041,13 @@ _cs_syslog_node_quorum_event(char *nodename, uint32_t nodeid, const char *state)
 	}
 }
 
+/**
+ * @brief _cs_syslog_application_connection_event
+ * @param nodename
+ * @param nodeid
+ * @param app_name
+ * @param state
+ */
 static void
 _cs_syslog_application_connection_event(char *nodename, uint32_t nodeid, char* app_name, const char *state)
 {
@@ -896,12 +1058,26 @@ _cs_syslog_application_connection_event(char *nodename, uint32_t nodeid, char* a
 	}
 }
 
+/**
+ * @brief _cs_syslog_rrp_faulty_event
+ * @param nodename
+ * @param nodeid
+ * @param iface_no
+ * @param state
+ */
 static void
 _cs_syslog_rrp_faulty_event(char *nodename, uint32_t nodeid, uint32_t iface_no, const char *state)
 {
 	qb_log(LOG_NOTICE, "%s[%d] interface %u is now %s", nodename, nodeid, iface_no, state);
 }
 
+/**
+ * @brief _cs_node_membership_event
+ * @param nodename
+ * @param nodeid
+ * @param state
+ * @param ip
+ */
 static void
 _cs_node_membership_event(char *nodename, uint32_t nodeid, char *state, char* ip)
 {
@@ -914,6 +1090,11 @@ _cs_node_membership_event(char *nodename, uint32_t nodeid, char *state, char* ip
 	}
 }
 
+/**
+ * @brief _cs_local_node_info_get
+ * @param nodename
+ * @param nodeid
+ */
 static void
 _cs_local_node_info_get(char **nodename, uint32_t *nodeid)
 {
@@ -941,6 +1122,10 @@ _cs_local_node_info_get(char **nodename, uint32_t *nodeid)
 	*nodename = local_nodename;
 }
 
+/**
+ * @brief _cs_node_quorum_event
+ * @param state
+ */
 static void
 _cs_node_quorum_event(const char *state)
 {
@@ -957,6 +1142,11 @@ _cs_node_quorum_event(const char *state)
 	}
 }
 
+/**
+ * @brief _cs_application_connection_event
+ * @param app_name
+ * @param state
+ */
 static void
 _cs_application_connection_event(char *app_name, const char *state)
 {
@@ -973,6 +1163,11 @@ _cs_application_connection_event(char *app_name, const char *state)
 	}
 }
 
+/**
+ * @brief _cs_rrp_faulty_event
+ * @param iface_no
+ * @param state
+ */
 static void
 _cs_rrp_faulty_event(uint32_t iface_no, const char *state)
 {
@@ -989,6 +1184,12 @@ _cs_rrp_faulty_event(uint32_t iface_no, const char *state)
 	}
 }
 
+/**
+ * @brief sig_exit_handler
+ * @param num
+ * @param data
+ * @return
+ */
 static int32_t
 sig_exit_handler(int32_t num, void *data)
 {
@@ -996,6 +1197,9 @@ sig_exit_handler(int32_t num, void *data)
 	return 0;
 }
 
+/**
+ * @brief _cs_cmap_init
+ */
 static void
 _cs_cmap_init(void)
 {
@@ -1046,12 +1250,18 @@ _cs_cmap_init(void)
 	}
 }
 
+/**
+ * @brief _cs_cmap_finalize
+ */
 static void
 _cs_cmap_finalize(void)
 {
 	cmap_finalize (cmap_handle);
 }
 
+/**
+ * @brief _cs_check_config
+ */
 static void
 _cs_check_config(void)
 {
@@ -1085,6 +1295,9 @@ _cs_check_config(void)
 	}
 }
 
+/**
+ * @brief _cs_usage
+ */
 static void
 _cs_usage(void)
 {
@@ -1098,6 +1311,12 @@ _cs_usage(void)
 		"        -h     : Print this help\n\n");
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int
 main(int argc, char *argv[])
 {

--- a/tools/corosync-quorumtool.c
+++ b/tools/corosync-quorumtool.c
@@ -49,16 +49,25 @@
 #include <corosync/quorum.h>
 #include <corosync/votequorum.h>
 
+/**
+ * @brief nodeid_format_t enum
+ */
 typedef enum {
 	NODEID_FORMAT_DECIMAL,
 	NODEID_FORMAT_HEX
 } nodeid_format_t;
 
+/**
+ * @brief name_format_t enum
+ */
 typedef enum {
 	ADDRESS_FORMAT_NAME,
 	ADDRESS_FORMAT_IP
 } name_format_t;
 
+/**
+ * @brief command_t enum
+ */
 typedef enum {
 	CMD_UNKNOWN,
 	CMD_SHOWNODES,
@@ -69,6 +78,9 @@ typedef enum {
 	CMD_UNREGISTER_QDEVICE
 } command_t;
 
+/**
+ * @brief sorttype_t enum
+ */
 typedef enum {
 	SORT_ADDR,
 	SORT_NODEID,
@@ -140,6 +152,10 @@ static corosync_cfg_callbacks_t c_callbacks = {
  */
 static int machine_parsable = 0;
 
+/**
+ * @brief show_usage
+ * @param name
+ */
 static void show_usage(const char *name)
 {
 	printf("usage: \n");
@@ -165,6 +181,12 @@ static void show_usage(const char *name)
 	printf("\n");
 }
 
+/**
+ * @brief get_quorum_type
+ * @param quorum_type
+ * @param quorum_type_len
+ * @return
+ */
 static int get_quorum_type(char *quorum_type, size_t quorum_type_len)
 {
 	int err;
@@ -194,9 +216,10 @@ out:
 	return err;
 }
 
-/*
- * Returns 1 if 'votequorum' is active. The called then knows that
+/**
+ * @brief using_votequorum Returns 1 if 'votequorum' is active. The called then knows that
  * votequorum calls should work and can provide extra information
+ * @return
  */
 static int using_votequorum(void)
 {
@@ -218,6 +241,12 @@ static int using_votequorum(void)
 	return using_voteq;
 }
 
+/**
+ * @brief set_votes
+ * @param nodeid
+ * @param votes
+ * @return
+ */
 static int set_votes(uint32_t nodeid, int votes)
 {
 	int err;
@@ -230,6 +259,11 @@ static int set_votes(uint32_t nodeid, int votes)
 	return err==CS_OK?0:err;
 }
 
+/**
+ * @brief set_expected
+ * @param expected_votes
+ * @return
+ */
 static int set_expected(int expected_votes)
 {
 	int err;
@@ -241,10 +275,11 @@ static int set_expected(int expected_votes)
 	return err==CS_OK?0:err;
 }
 
-/*
- *  node name by nodelist
+/**
+ * @brief node_name_by_nodelist
+ * @param nodeid
+ * @return
  */
-
 static const char *node_name_by_nodelist(uint32_t nodeid)
 {
 	cmap_iter_handle_t iter;
@@ -295,9 +330,13 @@ static const char *node_name_by_nodelist(uint32_t nodeid)
 	return ret_buf;
 }
 
-/*
- * This resolves the first address assigned to a node
+/**
+ * @brief node_name This resolves the first address assigned to a node
  * and returns the name or IP address. Use cfgtool if you need more information.
+ *
+ * @param nodeid
+ * @param name_format
+ * @return
  */
 static const char *node_name(uint32_t nodeid, name_format_t name_format)
 {
@@ -343,6 +382,14 @@ static const char *node_name(uint32_t nodeid, name_format_t name_format)
 	return "";
 }
 
+/**
+ * @brief quorum_notification_fn
+ * @param handle
+ * @param quorate
+ * @param ring_id
+ * @param view_list_entries
+ * @param view_list
+ */
 static void quorum_notification_fn(
 	quorum_handle_t handle,
 	uint32_t quorate,
@@ -369,6 +416,10 @@ static void quorum_notification_fn(
 	}
 }
 
+/**
+ * @brief print_string_padded
+ * @param buf
+ */
 static void print_string_padded(const char *buf)
 {
 	int len, delta;
@@ -382,6 +433,10 @@ static void print_string_padded(const char *buf)
 	printf("%s ", buf);
 }
 
+/**
+ * @brief print_uint32_padded
+ * @param value
+ */
 static void print_uint32_padded(uint32_t value)
 {
 	char buf[12];
@@ -390,7 +445,12 @@ static void print_uint32_padded(uint32_t value)
 	print_string_padded(buf);
 }
 
-/* for qsort */
+/**
+ * @brief compare_nodeids binary function for qsort
+ * @param one
+ * @param two
+ * @return
+ */
 static int compare_nodeids(const void *one, const void *two)
 {
       const view_list_entry_t *info1 = one;
@@ -405,6 +465,12 @@ static int compare_nodeids(const void *one, const void *two)
       return -1;
 }
 
+/**
+ * @brief compare_nodenames
+ * @param one
+ * @param two
+ * @return
+ */
 static int compare_nodenames(const void *one, const void *two)
 {
       const view_list_entry_t *info1 = one;
@@ -413,6 +479,12 @@ static int compare_nodenames(const void *one, const void *two)
       return strcmp(info1->name, info2->name);
 }
 
+/**
+ * @brief display_nodes_data
+ * @param nodeid_format
+ * @param name_format
+ * @param sort_type
+ */
 static void display_nodes_data(nodeid_format_t nodeid_format, name_format_t name_format, sorttype_t sort_type)
 {
 	int i, display_qdevice = 0;
@@ -512,6 +584,15 @@ static void display_nodes_data(nodeid_format_t nodeid_format, name_format_t name
 
 }
 
+/**
+ * @brief display_quorum_data
+ * @param is_quorate
+ * @param nodeid_format
+ * @param name_format
+ * @param sort_type
+ * @param loop
+ * @return
+ */
 static int display_quorum_data(int is_quorate,
 			       nodeid_format_t nodeid_format, name_format_t name_format, sorttype_t sort_type,
 			       int loop)
@@ -571,10 +652,14 @@ static int display_quorum_data(int is_quorate,
 	return err;
 }
 
-/*
- * return  1 if quorate
- *         0 if not quorate
- *        -1 on error
+/**
+ * @brief show_status
+ * @param nodeid_format
+ * @param name_format
+ * @param sort_type
+ * @return  1 if quorate
+ *          0 if not quorate
+ *         -1 on error
  */
 static int show_status(nodeid_format_t nodeid_format, name_format_t name_format, sorttype_t sort_type)
 {
@@ -618,6 +703,13 @@ quorum_err:
 	return is_quorate;
 }
 
+/**
+ * @brief monitor_status
+ * @param nodeid_format
+ * @param name_format
+ * @param sort_type
+ * @return
+ */
 static int monitor_status(nodeid_format_t nodeid_format, name_format_t name_format, sorttype_t sort_type) {
 	int err;
 	int loop = 0;
@@ -652,6 +744,13 @@ quorum_err:
 	return -1;
 }
 
+/**
+ * @brief show_nodes
+ * @param nodeid_format
+ * @param name_format
+ * @param sort_type
+ * @return
+ */
 static int show_nodes(nodeid_format_t nodeid_format, name_format_t name_format, sorttype_t sort_type)
 {
 	int err;
@@ -679,6 +778,10 @@ err_exit:
 	return result;
 }
 
+/**
+ * @brief unregister_qdevice
+ * @return
+ */
 static int unregister_qdevice(void)
 {
 	int err;
@@ -702,11 +805,11 @@ static int unregister_qdevice(void)
 	return 0;
 }
 
-/*
- * return -1 on error
+/**
+ * @brief init_all
+ * @return -1 on error
  *         0 if OK
  */
-
 static int init_all(void) {
 	cmap_handle = 0;
 	q_handle = 0;
@@ -751,6 +854,9 @@ out:
 	return -1;
 }
 
+/**
+ * @brief close_all
+ */
 static void close_all(void) {
 	if (cmap_handle) {
 		cmap_finalize(cmap_handle);
@@ -766,6 +872,12 @@ static void close_all(void) {
 	}
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	const char *options = "VHslpmfe:v:hin:o:";
 	char *endptr;


### PR DESCRIPTION
This pull request adds doxygen documentation stubs to most (but not all) functions, enums, structs, and typedefs.

Most of the stubs have no content. The Corosync codebase is far to complex for me to be able to confidently add documentation to everything at this time.

Instead, this pull request adds blank documentation stubs to everything to allow other developers to add meaningful comments to functions as they're making other changes.

It's my hope that Corosync can some day have 100% documentation coverage.