### PR TITLE
Move _overview manpages to section 7

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -219,7 +219,7 @@ fi
 %endif
 %dir %{_localstatedir}/lib/corosync
 %dir %{_localstatedir}/log/cluster
-%{_mandir}/man8/corosync_overview.8*
+%{_mandir}/man8/corosync_overview.7*
 %{_mandir}/man8/corosync.8*
 %{_mandir}/man8/corosync-blackbox.8*
 %{_mandir}/man8/corosync-cmapctl.8*
@@ -324,12 +324,12 @@ The Corosync Cluster Engine APIs.
 %{_mandir}/man3/quorum_*3*
 %{_mandir}/man3/votequorum_*3*
 %{_mandir}/man3/sam_*3*
-%{_mandir}/man8/cpg_overview.8*
-%{_mandir}/man8/votequorum_overview.8*
-%{_mandir}/man8/sam_overview.8*
+%{_mandir}/man8/cpg_overview.3*
+%{_mandir}/man8/votequorum_overview.3*
+%{_mandir}/man8/sam_overview.3*
 %{_mandir}/man3/cmap_*3*
-%{_mandir}/man8/cmap_overview.8*
-%{_mandir}/man8/quorum_overview.8*
+%{_mandir}/man8/cmap_overview.3*
+%{_mandir}/man8/quorum_overview.3*
 
 %changelog
 * @date@ Autotools generated version <nobody@nowhere.org> - @version@-1-@numcomm@.@alphatag@.@dirty@

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -130,12 +130,12 @@ dist_man_MANS 		= corosync.conf.5 \
 			  corosync-cpgtool.8 \
 			  corosync-notifyd.8 \
 			  corosync-quorumtool.8 \
-			  corosync_overview.8 \
-			  cpg_overview.8 \
-			  quorum_overview.8 \
-			  votequorum_overview.8 \
-			  sam_overview.8 \
-			  cmap_overview.8 \
+			  corosync_overview.7 \
+			  cpg_overview.3 \
+			  quorum_overview.3 \
+			  votequorum_overview.3 \
+			  sam_overview.3 \
+			  cmap_overview.3 \
 			  cmap_keys.8
 
 if INSTALL_XMLCONF

--- a/man/cmap_context_get.3.in
+++ b/man/cmap_context_get.3.in
@@ -55,4 +55,4 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 
 .SH "SEE ALSO"
 .BR cmap_context_set (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_context_set.3.in
+++ b/man/cmap_context_set.3.in
@@ -57,4 +57,4 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 
 .SH "SEE ALSO"
 .BR cmap_context_get (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_dec.3.in
+++ b/man/cmap_dec.3.in
@@ -89,4 +89,4 @@ CS_ERR_ACCESS error.
 .BR cmap_get (3),
 .BR cmap_set (3),
 .BR cmap_initialize (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_delete.3.in
+++ b/man/cmap_delete.3.in
@@ -67,4 +67,4 @@ read-only directly in corosync and deleting such key will result in CS_ERR_ACCES
 .SH "SEE ALSO"
 .BR cmap_initialize (3),
 .BR cmap_set (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_dispatch.3.in
+++ b/man/cmap_dispatch.3.in
@@ -88,4 +88,4 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH "SEE ALSO"
 .BR cmap_track_add (3),
 .BR cmap_track_delete (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_fd_get.3.in
+++ b/man/cmap_fd_get.3.in
@@ -64,4 +64,4 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 
 .SH "SEE ALSO"
 .BR cmap_dispatch (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_finalize.3.in
+++ b/man/cmap_finalize.3.in
@@ -58,4 +58,4 @@ CS_ERR_BAD_HANDLE error is returned when handle is invalid.
 .SH "SEE ALSO"
 .BR cmap_initialize (3),
 .BR cmap_dispatch (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_get.3.in
+++ b/man/cmap_get.3.in
@@ -150,4 +150,4 @@ CS_ERR_INVALID_PARAM is returned if type stored in cmap doesn't match with type 
 .SH "SEE ALSO"
 .BR cmap_set (3),
 .BR cmap_initialize (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_inc.3.in
+++ b/man/cmap_inc.3.in
@@ -89,4 +89,4 @@ CS_ERR_ACCESS error.
 .BR cmap_get (3),
 .BR cmap_set (3),
 .BR cmap_initialize (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_initialize.3.in
+++ b/man/cmap_initialize.3.in
@@ -60,4 +60,4 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 
 .SH "SEE ALSO"
 .BR cmap_finalize (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_iter_finalize.3.in
+++ b/man/cmap_iter_finalize.3.in
@@ -69,4 +69,4 @@ is invalid.
 .SH "SEE ALSO"
 .BR cmap_iter_init (3),
 .BR cmap_initialize (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_iter_init.3.in
+++ b/man/cmap_iter_init.3.in
@@ -77,4 +77,4 @@ CS_ERR_NO_SECTIONS is returned.
 .BR cmap_iter_next (3),
 .BR cmap_iter_finalize (3),
 .BR cmap_initialize (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_iter_next.3.in
+++ b/man/cmap_iter_next.3.in
@@ -79,4 +79,4 @@ error code is returned.
 .BR cmap_iter_finalize (3),
 .BR cmap_initialize (3),
 .BR cmap_get (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_keys.8
+++ b/man/cmap_keys.8
@@ -363,6 +363,6 @@ Removal of a UDPU node is a very similar, slightly reversed action, so
 * Change the configuration file on all nodes.
 
 .SH "SEE ALSO"
-.BR corosync_overview (8),
+.BR corosync_overview (7),
 .BR corosync.conf (5),
 .BR corosync-cmapctl (8)

--- a/man/cmap_overview.3
+++ b/man/cmap_overview.3
@@ -31,7 +31,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH "CMAP_OVERVIEW" 8 "03/02/2012" "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH "CMAP_OVERVIEW" 3 "03/02/2012" "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 
 .SH NAME
 .P

--- a/man/cmap_set.3.in
+++ b/man/cmap_set.3.in
@@ -124,4 +124,4 @@ be tagged read-only directly in corosync and seting such key will result in CS_E
 .SH "SEE ALSO"
 .BR cmap_get (3),
 .BR cmap_initialize (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_track_add.3.in
+++ b/man/cmap_track_add.3.in
@@ -161,4 +161,4 @@ notify_fn is NULL or track_type is invalid value.
 .BR cmap_initialize (3),
 .BR cmap_get (3),
 .BR cmap_dispatch (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/cmap_track_delete.3.in
+++ b/man/cmap_track_delete.3.in
@@ -67,4 +67,4 @@ is invalid.
 .SH "SEE ALSO"
 .BR cmap_track_add (3),
 .BR cmap_initialize (3),
-.BR cmap_overview (8)
+.BR cmap_overview (3)

--- a/man/corosync-cfgtool.8
+++ b/man/corosync-cfgtool.8
@@ -74,7 +74,7 @@ Tell all instances of corosync in this cluster to reload corosync.conf
 .B -H
 Shutdown corosync cleanly on this node.
 .SH "SEE ALSO"
-.BR corosync_overview (8),
+.BR corosync_overview (7),
 .SH "AUTHOR"
 Angus Salkeld
 .PP 

--- a/man/corosync-cmapctl.8
+++ b/man/corosync-cmapctl.8
@@ -81,5 +81,5 @@ corosync\-cmapctl [\-b] \fB\-t\fR key_name
 corosync\-cmapctl [\-b] \fB\-T\fR key_prefix
 
 .SH "SEE ALSO"
-.BR cmap_overview (8),
+.BR cmap_overview (3),
 .BR cmap_keys (8)

--- a/man/corosync-cpgtool.8
+++ b/man/corosync-cpgtool.8
@@ -79,7 +79,7 @@ $ corosync-cpgtool -n
 .br
 example-group
 .SH SEE ALSO
-.BR corosync_overview (8),
+.BR corosync_overview (7),
 .SH AUTHOR
 Angus Salkeld
 .PP

--- a/man/corosync-keygen.8
+++ b/man/corosync-keygen.8
@@ -91,7 +91,7 @@ Corosync Cluster Engine Authentication key generator.
 Writing corosync key to /tmp/authkey.
 .br
 .SH SEE ALSO
-.BR corosync_overview (8),
+.BR corosync_overview (7),
 .BR corosync.conf (5),
 .SH AUTHOR
 Angus Salkeld

--- a/man/corosync-quorumtool.8
+++ b/man/corosync-quorumtool.8
@@ -80,8 +80,8 @@ show version and exit
 .PP
 * Starred items only work if votequorum is the quorum provider for corosync
 .SH SEE ALSO
-.BR corosync_overview (8),
-.BR votequorum_overview (8),
+.BR corosync_overview (7),
+.BR votequorum_overview (3),
 .SH AUTHOR
 Angus Salkeld
 .PP

--- a/man/corosync.8
+++ b/man/corosync.8
@@ -56,13 +56,13 @@ Test configuration and then exit.
 .B -v
 Display version and SVN revision of Corosync and exit.
 .SH SEE ALSO
-.BR corosync_overview (8),
+.BR corosync_overview (7),
 .BR corosync.conf (5),
-.BR cpg_overview (8),
-.BR votequorum_overview (8),
-.BR sam_overview (8),
-.BR cmap_overview (8),
-.BR quorum_overview (8)
+.BR cpg_overview (3),
+.BR votequorum_overview (3),
+.BR sam_overview (3),
+.BR cmap_overview (3),
+.BR quorum_overview (3)
 .SH AUTHOR
 Angus Salkeld
 .PP

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -686,7 +686,7 @@ ring buffer file in /dev/shm.
 The corosync executive configuration file.
 
 .SH "SEE ALSO"
-.BR corosync_overview (8),
+.BR corosync_overview (7),
 .BR votequorum (5),
 .BR logrotate (8)
 .PP

--- a/man/corosync.xml.5
+++ b/man/corosync.xml.5
@@ -66,7 +66,7 @@ For example, see /etc/corosync/corosync.xml.example
 XML version of the corosync executive configuration file.
 
 .SH "SEE ALSO"
-.BR corosync_overview (8),
+.BR corosync_overview (7),
 .BR corosync.conf (5),
 .BR corosync-xmlproc (8)
 .PP

--- a/man/corosync_overview.7
+++ b/man/corosync_overview.7
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC_OVERVIEW 8 2012-02-13 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH COROSYNC_OVERVIEW 7 2012-02-13 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 corosync_overview \- Corosync overview
 .SH OVERVIEW
@@ -190,6 +190,6 @@ None that are known.
 .SH "SEE ALSO"
 .BR corosync.conf (5),
 .BR corosync-keygen (8),
-.BR cpg_overview (8),
-.BR sam_overview (8)
+.BR cpg_overview (3),
+.BR sam_overview (3)
 .PP

--- a/man/cpg_context_get.3.in
+++ b/man/cpg_context_get.3.in
@@ -49,7 +49,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_context_set.3.in
+++ b/man/cpg_context_set.3.in
@@ -51,7 +51,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_dispatch.3.in
+++ b/man/cpg_dispatch.3.in
@@ -93,7 +93,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_fd_get.3.in
+++ b/man/cpg_fd_get.3.in
@@ -56,7 +56,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_finalize.3.in
+++ b/man/cpg_finalize.3.in
@@ -52,7 +52,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_initialize.3.in
+++ b/man/cpg_initialize.3.in
@@ -155,7 +155,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_iteration_finalize.3.in
+++ b/man/cpg_iteration_finalize.3.in
@@ -64,4 +64,4 @@ is invalid.
 
 .SH "SEE ALSO"
 .BR cpg_iteration_initialize (3),
-.BR cpg_overview (8)
+.BR cpg_overview (3)

--- a/man/cpg_iteration_initialize.3.in
+++ b/man/cpg_iteration_initialize.3.in
@@ -93,4 +93,4 @@ be returned, if \fIhandle\fR is not valid handle.
 .BR cpg_iteration_next (3),
 .BR cpg_iteration_finalize (3),
 .BR cpg_initialize (3),
-.BR cpg_overview (8)
+.BR cpg_overview (3)

--- a/man/cpg_iteration_next.3.in
+++ b/man/cpg_iteration_next.3.in
@@ -82,4 +82,4 @@ error code is returned.
 
 .SH "SEE ALSO"
 .BR cpg_iteration_initialize (3),
-.BR cpg_overview (8)
+.BR cpg_overview (3)

--- a/man/cpg_join.3.in
+++ b/man/cpg_join.3.in
@@ -93,7 +93,7 @@ handle is already joined to a group.
 .SH ERRORS
 Not all errors are documented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_leave.3.in
+++ b/man/cpg_leave.3.in
@@ -58,7 +58,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_local_get.3.in
+++ b/man/cpg_local_get.3.in
@@ -53,7 +53,7 @@ will return the 32 bit node id.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_mcast_joined.3.in
+++ b/man/cpg_mcast_joined.3.in
@@ -122,7 +122,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_membership_get.3.in
+++ b/man/cpg_membership_get.3.in
@@ -62,7 +62,7 @@ member_list after return from the function.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_model_initialize.3.in
+++ b/man/cpg_model_initialize.3.in
@@ -211,7 +211,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_overview.3
+++ b/man/cpg_overview.3
@@ -1,10 +1,9 @@
 .\"/*
-.\" * Copyright (c) 2008, 2012 Red Hat, Inc.
+.\" * Copyright (c) 2006-2009 Red Hat, Inc.
 .\" *
 .\" * All rights reserved.
 .\" *
-.\" * Authors: Christine Caulfield <ccaulfie@redhat.com>
-.\" *          Fabio M. Di Nitto   <fdinitto@redhat.com>
+.\" * Author: Patrick Caulfield <pcaulfie@redhat.com>
 .\" *
 .\" * This software licensed under BSD license, the text of which follows:
 .\" *
@@ -32,33 +31,52 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH QUORUM_OVERVIEW 8 2012-02-09 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH CPG_OVERVIEW 3 2009-4-15 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
-quorum_overview \- Quorum Library Overview
+cpg_overview \- CPG library overview
 .SH OVERVIEW
-The quorum library is delivered with the corosync project. It is the external interface to
-the quorum service. This service is loaded into all nodes in a corosync cluster and track
-the quorum status of a node. In order for quorum service to be useful, a quorum provider
-must be configured.
+The CPG library is delivered with the corosync project.  This library is used
+to create distributed applications that operate properly during cluster
+partitions, merges, and faults.
 .PP
 The library provides a mechanism to:
 .PP
-* Query the quorum status
+* handle abstraction for multiple instances of a CPG library in one application
 .PP
-* Receive notifications of quorum state changes
-.SH BUGS
-No known bugs at the time of writing. The authors are from outerspace. Deal with it.
+* join one or more groups
+.PP
+* leave one or more groups
+.PP
+* Deliver messages to members of that group
+.PP
+* Deliver configuration changes
+.PP
+* Iterate members of groups
+.PP
+.SH SECURITY
+If encryption is enabled in corosync.conf, the CPG library will encrypt and
+authenticate message contents.  Applications must run as the ais user to be
+validated by corosync on IPC connection, otherwise they will be unable to
+access the corosync services.
+
 .SH "SEE ALSO"
-.BR corosync-quorumtool (8),
-.BR corosync.conf (5),
-.BR votequorum (5),
-.BR quorum_initialize (3),
-.BR quorum_finalize (3),
-.BR quorum_getquorate (3),
-.BR quorum_trackstart (3),
-.BR quorum_trackstop (3),
-.BR quorum_fd_get (3),
-.BR quorum_dispatch (3),
-.BR quorum_context_set (3),
-.BR quorum_context_get (3)
+.BR cpg_overview (3),
+.BR cpg_initialize (3),
+.BR cpg_finalize (3),
+.BR cpg_fd_get (3),
+.BR cpg_dispatch (3),
+.BR cpg_join (3),
+.BR cpg_leave (3),
+.BR cpg_mcast_joined (3),
+.BR cpg_model_initialize (3),
+.BR cpg_membership_get (3),
+.BR cpg_zcb_alloc (3),
+.BR cpg_zcb_free (3),
+.BR cpg_zcb_mcast_joined (3),
+.BR cpg_context_get (3),
+.BR cpg_context_set (3),
+.BR cpg_local_get (3),
+.BR cpg_iteration_initialize (3),
+.BR cpg_iteration_next (3),
+.BR cpg_iteration_finalize (3)
 .PP

--- a/man/cpg_zcb_alloc.3.in
+++ b/man/cpg_zcb_alloc.3.in
@@ -66,7 +66,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_zcb_free.3.in
+++ b/man/cpg_zcb_free.3.in
@@ -58,7 +58,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/cpg_zcb_mcast_joined.3.in
+++ b/man/cpg_zcb_mcast_joined.3.in
@@ -108,7 +108,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 The errors are undocumented.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
+.BR cpg_overview (3),
 .BR cpg_initialize (3),
 .BR cpg_finalize (3),
 .BR cpg_fd_get (3),

--- a/man/index.html
+++ b/man/index.html
@@ -19,7 +19,7 @@
     <p>
       <h2>Daemon, tools and configuration</h2>
 
-      <a href="corosync_overview.8.html">corosync_overview(8)</a>:
+      <a href="corosync_overview.7.html">corosync_overview(7)</a>:
       Overview of the corosync system.
       <br>
 
@@ -81,7 +81,7 @@
 
       <h3>CPG service</h3>
 
-      <a href="cpg_overview.8.html">cpg_overview(8)</a>:
+      <a href="cpg_overview.3.html">cpg_overview(3)</a>:
       Overview of the cpg extended virtual synchrony group
       communication toolkit.
       <br>
@@ -160,7 +160,7 @@
 
       <h3>SAM service</h3>
 
-      <a href="sam_overview.8.html">sam_overview(8)</a>:
+      <a href="sam_overview.3.html">sam_overview(3)</a>:
       Description of sam_overview interface.
       <br>
 
@@ -214,7 +214,7 @@
 
       <h3>QUORUM service</h3>
 
-      <a href="quorum_overview.8.html">quorum_overview(8)</a>:
+      <a href="quorum_overview.3.html">quorum_overview(3)</a>:
       An overview of the quorum service
       <br>
 
@@ -256,7 +256,7 @@
 
       <h3>VOTEQUORUM service</h3>
 
-      <a href="votequorum_overview.8.html">votequorum_overview(8)</a>:
+      <a href="votequorum_overview.3.html">votequorum_overview(3)</a>:
       An overview of the vote-based quorum service
       <br>
 
@@ -326,7 +326,7 @@
 
       <h3>CMAP service</h3>
 
-      <a href="cmap_overview.8.html">cmap_overview(8)</a>:
+      <a href="cmap_overview.3.html">cmap_overview(3)</a>:
       An overview of the configuration map service.
       <br>
 

--- a/man/quorum_context_get.3.in
+++ b/man/quorum_context_get.3.in
@@ -49,7 +49,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_initialize (3),
 .BR quorum_finalize (3),
 .BR quorum_getquorate (3),

--- a/man/quorum_context_set.3.in
+++ b/man/quorum_context_set.3.in
@@ -51,7 +51,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_initialize (3),
 .BR quorum_finalize (3),
 .BR quorum_getquorate (3),

--- a/man/quorum_dispatch.3.in
+++ b/man/quorum_dispatch.3.in
@@ -85,7 +85,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_initialize (3),
 .BR quorum_finalize (3),
 .BR quorum_getquorate (3),

--- a/man/quorum_fd_get.3.in
+++ b/man/quorum_fd_get.3.in
@@ -56,7 +56,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_initialize (3),
 .BR quorum_finalize (3),
 .BR quorum_getquorate (3),

--- a/man/quorum_finalize.3.in
+++ b/man/quorum_finalize.3.in
@@ -53,7 +53,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_initialize (3),
 .BR quorum_getquorate (3),
 .BR quorum_trackstart (3),

--- a/man/quorum_getquorate.3.in
+++ b/man/quorum_getquorate.3.in
@@ -49,7 +49,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_initialize (3),
 .BR quorum_finalize (3),
 .BR quorum_trackstart (3),

--- a/man/quorum_initialize.3.in
+++ b/man/quorum_initialize.3.in
@@ -101,7 +101,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_finalize (3),
 .BR quorum_getquorate (3),
 .BR quorum_trackstart (3),

--- a/man/quorum_overview.3
+++ b/man/quorum_overview.3
@@ -1,9 +1,10 @@
 .\"/*
-.\" * Copyright (c) 2006-2009 Red Hat, Inc.
+.\" * Copyright (c) 2008, 2012 Red Hat, Inc.
 .\" *
 .\" * All rights reserved.
 .\" *
-.\" * Author: Patrick Caulfield <pcaulfie@redhat.com>
+.\" * Authors: Christine Caulfield <ccaulfie@redhat.com>
+.\" *          Fabio M. Di Nitto   <fdinitto@redhat.com>
 .\" *
 .\" * This software licensed under BSD license, the text of which follows:
 .\" *
@@ -31,52 +32,33 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH CPG_OVERVIEW 8 2009-4-15 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH QUORUM_OVERVIEW 3 2012-02-09 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
-cpg_overview \- CPG library overview
+quorum_overview \- Quorum Library Overview
 .SH OVERVIEW
-The CPG library is delivered with the corosync project.  This library is used
-to create distributed applications that operate properly during cluster
-partitions, merges, and faults.
+The quorum library is delivered with the corosync project. It is the external interface to
+the quorum service. This service is loaded into all nodes in a corosync cluster and track
+the quorum status of a node. In order for quorum service to be useful, a quorum provider
+must be configured.
 .PP
 The library provides a mechanism to:
 .PP
-* handle abstraction for multiple instances of a CPG library in one application
+* Query the quorum status
 .PP
-* join one or more groups
-.PP
-* leave one or more groups
-.PP
-* Deliver messages to members of that group
-.PP
-* Deliver configuration changes
-.PP
-* Iterate members of groups
-.PP
-.SH SECURITY
-If encryption is enabled in corosync.conf, the CPG library will encrypt and
-authenticate message contents.  Applications must run as the ais user to be
-validated by corosync on IPC connection, otherwise they will be unable to
-access the corosync services.
-
+* Receive notifications of quorum state changes
+.SH BUGS
+No known bugs at the time of writing. The authors are from outerspace. Deal with it.
 .SH "SEE ALSO"
-.BR cpg_overview (8),
-.BR cpg_initialize (3),
-.BR cpg_finalize (3),
-.BR cpg_fd_get (3),
-.BR cpg_dispatch (3),
-.BR cpg_join (3),
-.BR cpg_leave (3),
-.BR cpg_mcast_joined (3),
-.BR cpg_model_initialize (3),
-.BR cpg_membership_get (3),
-.BR cpg_zcb_alloc (3),
-.BR cpg_zcb_free (3),
-.BR cpg_zcb_mcast_joined (3),
-.BR cpg_context_get (3),
-.BR cpg_context_set (3),
-.BR cpg_local_get (3),
-.BR cpg_iteration_initialize (3),
-.BR cpg_iteration_next (3),
-.BR cpg_iteration_finalize (3)
+.BR corosync-quorumtool (8),
+.BR corosync.conf (5),
+.BR votequorum (5),
+.BR quorum_initialize (3),
+.BR quorum_finalize (3),
+.BR quorum_getquorate (3),
+.BR quorum_trackstart (3),
+.BR quorum_trackstop (3),
+.BR quorum_fd_get (3),
+.BR quorum_dispatch (3),
+.BR quorum_context_set (3),
+.BR quorum_context_get (3)
 .PP

--- a/man/quorum_trackstart.3.in
+++ b/man/quorum_trackstart.3.in
@@ -65,7 +65,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_initialize (3),
 .BR quorum_finalize (3),
 .BR quorum_getquorate (3),

--- a/man/quorum_trackstop.3.in
+++ b/man/quorum_trackstop.3.in
@@ -49,7 +49,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR quorum_overview (8),
+.BR quorum_overview (3),
 .BR quorum_initialize (3),
 .BR quorum_finalize (3),
 .BR quorum_getquorate (3),

--- a/man/sam_overview.3
+++ b/man/sam_overview.3
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH "SAM_OVERVIEW" 8 "21/05/2010" "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH "SAM_OVERVIEW" 3 "21/05/2010" "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 
 .SH NAME
 .P

--- a/man/votequorum.5
+++ b/man/votequorum.5
@@ -399,5 +399,5 @@ No known bugs at the time of writing. The authors are from outerspace. Deal with
 .BR corosync (8),
 .BR corosync.conf (5),
 .BR corosync-quorumtool (8),
-.BR votequorum_overview (8)
+.BR votequorum_overview (3)
 .PP

--- a/man/votequorum_context_get.3.in
+++ b/man/votequorum_context_get.3.in
@@ -49,7 +49,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_context_set.3.in
+++ b/man/votequorum_context_set.3.in
@@ -51,7 +51,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_dispatch.3.in
+++ b/man/votequorum_dispatch.3.in
@@ -85,7 +85,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_fd_get.3.in
+++ b/man/votequorum_fd_get.3.in
@@ -56,7 +56,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_finalize.3.in
+++ b/man/votequorum_finalize.3.in
@@ -53,7 +53,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_getinfo (3),
 .BR votequorum_trackstart (3),

--- a/man/votequorum_getinfo.3.in
+++ b/man/votequorum_getinfo.3.in
@@ -97,7 +97,7 @@ This call returns the CS_OK value if successful, otherwise a generic error is re
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_trackstart (3),

--- a/man/votequorum_initialize.3.in
+++ b/man/votequorum_initialize.3.in
@@ -101,7 +101,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),
 .BR votequorum_trackstart (3),

--- a/man/votequorum_overview.3
+++ b/man/votequorum_overview.3
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH VOTEQUORUM_OVERVIEW 8 2012-01-12 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH VOTEQUORUM_OVERVIEW 3 2012-01-12 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 votequorum_overview \- Votequorum Library Overview
 .SH OVERVIEW

--- a/man/votequorum_qdevice_master_wins.3.in
+++ b/man/votequorum_qdevice_master_wins.3.in
@@ -59,7 +59,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_qdevice_poll.3.in
+++ b/man/votequorum_qdevice_poll.3.in
@@ -64,7 +64,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_qdevice_register.3.in
+++ b/man/votequorum_qdevice_register.3.in
@@ -64,7 +64,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_qdevice_unregister.3.in
+++ b/man/votequorum_qdevice_unregister.3.in
@@ -49,7 +49,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_qdevice_update.3.in
+++ b/man/votequorum_qdevice_update.3.in
@@ -50,7 +50,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_setexpected.3.in
+++ b/man/votequorum_setexpected.3.in
@@ -52,7 +52,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_setvotes.3.in
+++ b/man/votequorum_setvotes.3.in
@@ -49,7 +49,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_trackstart.3.in
+++ b/man/votequorum_trackstart.3.in
@@ -69,7 +69,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),

--- a/man/votequorum_trackstop.3.in
+++ b/man/votequorum_trackstop.3.in
@@ -49,7 +49,7 @@ This call returns the CS_OK value if successful, otherwise an error is returned.
 .SH ERRORS
 @COMMONIPCERRORS@
 .SH "SEE ALSO"
-.BR votequorum_overview (8),
+.BR votequorum_overview (3),
 .BR votequorum_initialize (3),
 .BR votequorum_finalize (3),
 .BR votequorum_getinfo (3),


### PR DESCRIPTION
The _overview manpages are not actually commands and hence belong into
manpage section 7 "Miscellaneous".

References: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=576209
