### PR TITLE
Fix config options not being reset when deleted on reload

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -703,6 +703,7 @@ static void message_handler_req_exec_cfg_reload_config (
 	remove_deleted_entries(temp_map, "totem.");
 	remove_deleted_entries(temp_map, "nodelist.");
 	remove_deleted_entries(temp_map, "quorum.");
+	remove_deleted_entries(temp_map, "uidgid.");
 
 	/* Remove entries that cannot be changed */
 	remove_ro_entries(temp_map);

--- a/exec/main.c
+++ b/exec/main.c
@@ -1006,7 +1006,13 @@ static void set_icmap_ro_keys_flag (void)
 	icmap_set_ro_access("totem.secauth", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.ip_version", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.rrp_mode", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.transport", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.cluster_name", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.netmtu", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.threads", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.version", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.nodeid", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.clear_node_high_bit", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("qb.ipc_type", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("config.reload_in_progress", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("config.totemconfig_reload_in_progress", CS_FALSE, CS_TRUE);

--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -1238,6 +1238,14 @@ static char *votequorum_readconfig(int runtime)
 	log_printf(LOGSYS_LEVEL_DEBUG, "Reading configuration (runtime: %d)", runtime);
 
 	/*
+	 * Set the few things we re-read at runtime back to their defaults
+	 */
+	if (runtime) {
+		two_node = 0;
+		expected_votes = 0;
+	}
+
+	/*
 	 * gather basic data here
 	 */
 	icmap_get_uint32("quorum.expected_votes", &expected_votes);

--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -2173,6 +2173,17 @@ static int votequorum_exec_exit_fn (void)
 	return ret;
 }
 
+static void votequorum_set_icmap_ro_keys(void)
+{
+	icmap_set_ro_access("quorum.allow_downscale", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("quorum.wait_for_all", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("quorum.last_man_standing", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("quorum.last_man_standing_window", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("quorum.expected_votes_tracking", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("quorum.auto_tie_breaker", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("quorum.auto_tie_breaker_node", CS_FALSE, CS_TRUE);
+}
+
 static char *votequorum_exec_init_fn (struct corosync_api_v1 *api)
 {
 	char *error = NULL;
@@ -2219,6 +2230,11 @@ static char *votequorum_exec_init_fn (struct corosync_api_v1 *api)
 		return error;
 	}
 	recalculate_quorum(0, 0);
+
+	/*
+	 * Set RO keys in icmap
+	 */
+	votequorum_set_icmap_ro_keys();
 
 	/*
 	 * Listen for changes


### PR DESCRIPTION
There were several places where defaults were not restored if the keys were removed from corosync.conf and the file reloaded.
    
This patch adds those back so that reloading corosync.conf has the expected effect when keys are deleted.

Also add the RO flag to more keys that are immutable
