### PR TITLE
logconfig: Fix logging reload disabling logfiles

### DIFF
--- a/exec/logconfig.c
+++ b/exec/logconfig.c
@@ -272,8 +272,9 @@ static int corosync_main_config_log_destination_set (
 			goto parse_error;
 		}
 	}
-	else {
-		/* Set to default */
+	/* Set to default if we are the top-level logger */
+	else if (!subsys && !deprecated) {
+
 		mode = logsys_config_mode_get (subsys);
 		if (default_value) {
 			mode |= mode_mask;
@@ -282,7 +283,7 @@ static int corosync_main_config_log_destination_set (
 			mode &= ~mode_mask;
 		}
 		if (logsys_config_mode_set(subsys, mode) < 0) {
-			sprintf (formatted_error_reason, "unable to unset mode %s", key);
+			sprintf (formatted_error_reason, "unable to change mode %s", key);
 			goto parse_error;
 		}
 	}


### PR DESCRIPTION
In my previous logconfig patch, adding a subsys so the
logging stanzas could disable logging to a file, because
the subsys closed the file used by the main logging.

This patch only applies defaults to higher-level logging and
non-deprecated keys.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>