### PR TITLE
Config: Flag config uidgid entries

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -703,7 +703,7 @@ static void message_handler_req_exec_cfg_reload_config (
 	remove_deleted_entries(temp_map, "totem.");
 	remove_deleted_entries(temp_map, "nodelist.");
 	remove_deleted_entries(temp_map, "quorum.");
-	remove_deleted_entries(temp_map, "uidgid.");
+	remove_deleted_entries(temp_map, "uidgid.config.");
 
 	/* Remove entries that cannot be changed */
 	remove_ro_entries(temp_map);

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -794,7 +794,7 @@ static int main_config_parser_cb(const char *path,
 					*error_string = error_string_response;
 					return (0);
 				}
-				snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.uid.%u",
+				snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.config.uid.%u",
 						uid);
 				icmap_set_uint8_r(config_map, key_name, 1);
 				add_as_string = 0;
@@ -804,7 +804,7 @@ static int main_config_parser_cb(const char *path,
 					*error_string = error_string_response;
 					return (0);
 				}
-				snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.gid.%u",
+				snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.config.gid.%u",
 						gid);
 				icmap_set_uint8_r(config_map, key_name, 1);
 				add_as_string = 0;
@@ -1203,7 +1203,7 @@ static int uidgid_config_parser_cb(const char *path,
 				*error_string = error_string_response;
 				return (0);
 			}
-			snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.uid.%u",
+			snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.config.uid.%u",
 					uid);
 			icmap_set_uint8_r(config_map, key_name, 1);
 		} else if (strcmp(path, "uidgid.gid") == 0) {
@@ -1212,7 +1212,7 @@ static int uidgid_config_parser_cb(const char *path,
 				*error_string = error_string_response;
 				return (0);
 			}
-			snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.gid.%u",
+			snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.config.gid.%u",
 					gid);
 			icmap_set_uint8_r(config_map, key_name, 1);
 		} else {

--- a/exec/ipc_glue.c
+++ b/exec/ipc_glue.c
@@ -194,7 +194,15 @@ static int32_t cs_ipcs_connection_accept (qb_ipcs_connection_t *c, uid_t euid, g
 	if (icmap_get_uint8(key_name, &u8) == CS_OK && u8 == 1)
 		return 0;
 
+	snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.config.uid.%u", euid);
+	if (icmap_get_uint8(key_name, &u8) == CS_OK && u8 == 1)
+		return 0;
+
 	snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.gid.%u", egid);
+	if (icmap_get_uint8(key_name, &u8) == CS_OK && u8 == 1)
+		return 0;
+
+	snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "uidgid.config.gid.%u", egid);
 	if (icmap_get_uint8(key_name, &u8) == CS_OK && u8 == 1)
 		return 0;
 

--- a/exec/main.c
+++ b/exec/main.c
@@ -1011,6 +1011,7 @@ static void set_icmap_ro_keys_flag (void)
 	icmap_set_ro_access("runtime.totem.", CS_TRUE, CS_TRUE);
 	icmap_set_ro_access("runtime.services.", CS_TRUE, CS_TRUE);
 	icmap_set_ro_access("runtime.config.", CS_TRUE, CS_TRUE);
+	icmap_set_ro_access("uidgid.config.", CS_TRUE, CS_TRUE);
 
 	/*
 	 * Set RO flag for constrete keys of configuration which can't be changed


### PR DESCRIPTION
Uidgid entries parsed from configuration files now has prefix
(uidgid.config.) so they are distinguishable from dynamically added
entries. Entries added from config file are pruned on reload if no
longer exists in config file (dynamic one stays unaffected). Also whole
uidgid.config. prefix is made read only.

This make PCMK work again after configuration reload is called.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>