### PR TITLE
When compiling corosync, files in "doc/corosync/" are unpackaged

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -267,6 +267,7 @@ fi
 %{_mandir}/man5/corosync.conf.5*
 %{_mandir}/man5/votequorum.5*
 %{_mandir}/man8/cmap_keys.8*
+%{_datadir}/doc/corosync/*
 
 # optional testagent rpm
 #


### PR DESCRIPTION
When I compile corosync-2.4.0, it reports errors "Installed
(but unpackaged) file(s) found", all the files are in directory
"%{_datadir}/doc/corosync/". This patch fixes the issue.