### PR TITLE
qdevice init: corosync isn't a system facility

### DIFF
--- a/init/corosync-notifyd.in
+++ b/init/corosync-notifyd.in
@@ -11,8 +11,8 @@
 #
 ### BEGIN INIT INFO
 # Provides:		corosync-notifyd
-# Required-Start:	$corosync $cman
-# Required-Stop:	$corosync $cman
+# Required-Start:	corosync cman
+# Required-Stop:	corosync cman
 # Default-Start:
 # Default-Stop:
 # Short-Description:	Starts and stops Corosync Notifier.

--- a/init/corosync-qdevice.in
+++ b/init/corosync-qdevice.in
@@ -11,8 +11,8 @@
 #
 ### BEGIN INIT INFO
 # Provides:		corosync-qdevice
-# Required-Start:	$corosync
-# Required-Stop:	$corosync
+# Required-Start:	corosync
+# Required-Stop:	corosync
 # Default-Start:
 # Default-Stop:
 # Short-Description:	Starts and stops Corosync Qdevice daemon.


### PR DESCRIPTION
Signed-off-by: Ferenc Wágner <wferi@niif.hu>