### PR TITLE
Mid: coroparse: Set a value of poll_period for watchdog monitoring.

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -875,7 +875,6 @@ static int main_config_parser_cb(const char *path,
 			}
 			break;
 		case MAIN_CP_CB_DATA_STATE_RESOURCES_SYSTEM:
-			break;
 		case MAIN_CP_CB_DATA_STATE_RESOURCES_SYSTEM_MEMUSED:
 			if (strcmp(key, "poll_period") == 0) {
 				if (str_to_ull(value, &ull) != 0) {
@@ -886,7 +885,6 @@ static int main_config_parser_cb(const char *path,
 			}
 			break;
 		case MAIN_CP_CB_DATA_STATE_RESOURCES_PROCESS:
-			break;
 		case MAIN_CP_CB_DATA_STATE_RESOURCES_PROCESS_MEMUSED:
 			if (strcmp(key, "poll_period") == 0) {
 				if (str_to_ull(value, &ull) != 0) {


### PR DESCRIPTION
When user set resource.process key newly, poll_period revises the phenomenon that does not become effective.
```
(snip)
resources {
    process {
        xxx {
            recovery: reboot
            poll_period: 10000
        }
    }
}
(snip)
```
I revise the resource.system key equally.

