### PR TITLE
fix: udpu corosync fail after network restart

### DIFF
--- a/exec/totemudpu.c
+++ b/exec/totemudpu.c
@@ -617,7 +617,7 @@ static void timer_function_netif_check_timeout (
 			log_printf (instance->totemudpu_log_level_notice,
 				"The network interface [%s] is now up.",
 				totemip_print (&instance->totem_interface->boundto));
-			instance->netif_state_report = NETIF_STATE_REPORT_DOWN;
+			instance->netif_state_report = NETIF_STATE_REPORT_UP;
 			instance->totemudpu_iface_change_fn (instance->context, &instance->my_id);
 		}
 		/*
@@ -638,7 +638,7 @@ static void timer_function_netif_check_timeout (
 				"The network interface is down.");
 			instance->totemudpu_iface_change_fn (instance->context, &instance->my_id);
 		}
-		instance->netif_state_report = NETIF_STATE_REPORT_UP;
+		instance->netif_state_report = NETIF_STATE_REPORT_DOWN;
 
 	}
 }


### PR DESCRIPTION
In our 2-node cluster corosync failed after any network failure (and because of dlm failing soon after coro, reboot was required).
After this change we no longer fail.

The funniest thing is that it was failing not after 'ifdown', but after 'ifup'.