### PR TITLE
systemd: Delete unnecessary soft_margin

### DIFF
--- a/init/corosync.service.in
+++ b/init/corosync.service.in
@@ -19,7 +19,7 @@ Type=forking
 #  Specify a period longer than soft_margin as RestartSec.
 #RestartSec=70
 #  rewrite according to environment.
-#ExecStartPre=/sbin/modprobe softdog soft_margin=60
+#ExecStartPre=/sbin/modprobe softdog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Current timeout value of watchdog device is initialized to 6s inside wd.c.
Therefore I delete soft_margin which has no meaning to set.