### PR TITLE
Fix typo: recomended -> recommended

### DIFF
--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -193,7 +193,7 @@ cycles in corosync.
 
 The default is on.
 
-WARNING: This parameter is deprecated. It's recomended to use combination of
+WARNING: This parameter is deprecated. It's recommended to use combination of
 crypto_cipher and crypto_hash.
 
 .TP


### PR DESCRIPTION
This text has been removed on the master branch, so this patch does not apply there.