### PR TITLE
Add Documentation URIs to the systemd service files

### DIFF
--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Corosync Dbus and snmp notifier
+Documentation=man:corosync-notifyd
 Wants=corosync.service
 After=corosync.service
 

--- a/init/corosync-qdevice.service.in
+++ b/init/corosync-qdevice.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Corosync Qdevice daemon
+Documentation=man:corosync-qdevice
 ConditionKernelCommandLine=!nocluster
 Wants=corosync.service
 After=corosync.service

--- a/init/corosync-qnetd.service.in
+++ b/init/corosync-qnetd.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Corosync Qdevice Network daemon
+Documentation=man:corosync-qnetd
 ConditionKernelCommandLine=!nocluster
 Requires=network-online.target
 After=network-online.target

--- a/init/corosync.service.in
+++ b/init/corosync.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Corosync Cluster Engine
+Documentation=man:corosync man:corosync.conf man:corosync_overview
 ConditionKernelCommandLine=!nocluster
 Requires=network-online.target
 After=network-online.target


### PR DESCRIPTION
These are used by systemctl help.

This patch applies to needle as well.