### PR TITLE
Fix: remove duplicate memcpy in totempg.c: mcast_msg

### DIFF
--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -923,8 +923,6 @@ static int mcast_msg (
 				data_ptr = (unsigned char *)iovec[i].iov_base + copy_base;
 			else {
 				data_ptr = fragmentation_data;
-				memcpy (&fragmentation_data[fragment_size],
-				(unsigned char *)iovec[i].iov_base + copy_base, copy_len);
 			}
 
 			memcpy (&fragmentation_data[fragment_size],


### PR DESCRIPTION
In function mcast_msg of totempg.c, line 923, there is a memcpy call in
"else" branch, and also another memcpy out of the "else" branch, while
the two calls have the same parameters. I think we can remove the memcpy
in "else" branch.