### PR TITLE
Remove redundant header file inclusion

### DIFF
--- a/cts/agents/common_test_agent.c
+++ b/cts/agents/common_test_agent.c
@@ -44,7 +44,6 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <poll.h>
-#include <unistd.h>
 #include <fcntl.h>
 
 #include "common_test_agent.h"

--- a/cts/agents/cpg_test_agent.c
+++ b/cts/agents/cpg_test_agent.c
@@ -44,7 +44,6 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <poll.h>
-#include <unistd.h>
 #include <fcntl.h>
 
 #include <qb/qblist.h>

--- a/exec/cmap.c
+++ b/exec/cmap.c
@@ -39,7 +39,6 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <unistd.h>
 #include <poll.h>
 #include <assert.h>
 

--- a/exec/cpg.c
+++ b/exec/cpg.c
@@ -51,8 +51,6 @@
 #include <errno.h>
 #include <time.h>
 #include <assert.h>
-#include <unistd.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/mman.h>
 

--- a/exec/quorum.c
+++ b/exec/quorum.c
@@ -46,8 +46,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <time.h>
-#include <unistd.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 
 #include <corosync/corotypes.h>

--- a/exec/sync.c
+++ b/exec/sync.c
@@ -45,8 +45,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <time.h>
-#include <unistd.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
 
 #include <corosync/corotypes.h>

--- a/exec/vsf_quorum.c
+++ b/exec/vsf_quorum.c
@@ -62,7 +62,6 @@
 #include <qb/qblist.h>
 #include <corosync/mar_gen.h>
 #include <corosync/ipc_quorum.h>
-#include <corosync/mar_gen.h>
 #include <corosync/coroapi.h>
 #include <corosync/logsys.h>
 #include <corosync/icmap.h>

--- a/qdevices/tlv.c
+++ b/qdevices/tlv.c
@@ -32,7 +32,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/types.h>
 #include <arpa/inet.h>
 
 #include <inttypes.h>

--- a/test/cpgbench.c
+++ b/test/cpgbench.c
@@ -40,7 +40,6 @@
 #include <signal.h>
 #include <unistd.h>
 #include <errno.h>
-#include <unistd.h>
 #include <time.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/test/cpgbenchzc.c
+++ b/test/cpgbenchzc.c
@@ -40,14 +40,12 @@
 #include <signal.h>
 #include <unistd.h>
 #include <errno.h>
-#include <unistd.h>
 #include <time.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <sys/un.h>
-#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 

--- a/test/cpghum.c
+++ b/test/cpghum.c
@@ -38,7 +38,6 @@
 #include <signal.h>
 #include <unistd.h>
 #include <errno.h>
-#include <unistd.h>
 #include <time.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/tools/corosync-notifyd.c
+++ b/tools/corosync-notifyd.c
@@ -54,9 +54,6 @@
 #include <qb/qbloop.h>
 #include <qb/qblog.h>
 
-#include <qb/qbdefs.h>
-#include <qb/qbloop.h>
-
 #include <corosync/corotypes.h>
 #include <corosync/cfg.h>
 #include <corosync/quorum.h>

--- a/vqsim/parser.c
+++ b/vqsim/parser.c
@@ -5,7 +5,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <netinet/in.h>
 #ifdef HAVE_READLINE_HISTORY_H
 #include <readline/history.h>


### PR DESCRIPTION
There was a source code redundantly including the same header file.
So, we remove redundant header file inclusion.