### PR TITLE
typo fix: spell errors in qdevice

### DIFF
--- a/qdevices/qdevice-net-algo-test.c
+++ b/qdevices/qdevice-net-algo-test.c
@@ -87,7 +87,7 @@ qdevice_net_algo_test_connected(struct qdevice_net_instance *instance, int *send
  *   if cast_vote_timer_vote = TLV_VOTE_ACK
  *     vote = TLV_VOTE_NACK.
  * Otherwise send_node_list = 1 and vote = TLV_VOTE_NO_CHANGE
- * If send_node_list is set to non zero, node list is send to qnetd
+ * If send_node_list is set to non zero, node list is sent to qnetd
  */
 int
 qdevice_net_algo_test_config_node_list_changed(struct qdevice_net_instance *instance,
@@ -112,7 +112,7 @@ qdevice_net_algo_test_config_node_list_changed(struct qdevice_net_instance *inst
  *   if cast_vote_timer_vote = TLV_VOTE_ACK
  *     vote = TLV_VOTE_NACK.
  * Otherwise send_node_list = 1 and vote = TLV_VOTE_WAIT_FOR_REPLY
- * If send_node_list is set to non zero, node list is send to qnetd
+ * If send_node_list is set to non zero, node list is sent to qnetd
  */
 int
 qdevice_net_algo_test_votequorum_node_list_notify(struct qdevice_net_instance *instance,
@@ -140,7 +140,7 @@ qdevice_net_algo_test_votequorum_node_list_notify(struct qdevice_net_instance *i
  *     vote = TLV_VOTE_NACK.
  * Otherwise send_node_list = 1 and vote = TLV_VOTE_NO_CHANGE
  *
- * If send_node_list is set to non zero, node list is send to qnetd
+ * If send_node_list is set to non zero, node list is sent to qnetd
  */
 int
 qdevice_net_algo_test_votequorum_quorum_notify(struct qdevice_net_instance *instance,
@@ -172,7 +172,7 @@ qdevice_net_algo_test_votequorum_expected_votes_notify(struct qdevice_net_instan
 /*
  * Called when config node list reply is received. Vote is set to value returned by server (and can
  * be overwriten by algorithm). ring_id is returned by server. ring_id_is_valid is set to 1 only if
- * received ring id matches last sent ring id. It usually make sense to not update timer.
+ * received ring id matches last sent ring id. It usually makes sense to not update timer.
  *
  * Callback should return 0 on success or -1 on failure (-> disconnect client).
  */
@@ -309,7 +309,7 @@ qdevice_net_algo_test_echo_reply_received(struct qdevice_net_instance *instance,
  * Called when client is about to send echo request but echo reply to previous echo request
  * was not yet received.
  *
- * Callback should return 0 if processing should continue (echo request is not send but timer is
+ * Callback should return 0 if processing should continue (echo request is not sent but timer is
  * scheduled again) otherwise -1 (-> disconnect client).
  */
 int
@@ -322,7 +322,7 @@ qdevice_net_algo_test_echo_reply_not_received(struct qdevice_net_instance *insta
 }
 
 /*
- * Called when client disconnect from server.
+ * Called when client disconnects from server.
  *
  * disconnect_reason contains one of QDEVICE_NET_DISCONNECT_REASON_
  * try_reconnect can be set to non zero value if reconnect to server should be tried

--- a/qdevices/qnetd-algo-2nodelms.c
+++ b/qdevices/qnetd-algo-2nodelms.c
@@ -87,7 +87,7 @@ qnetd_algo_2nodelms_client_init(struct qnetd_client *client)
  * should ask later for a vote) or wait_for_reply (client should wait for reply).
  *
  * Return TLV_REPLY_ERROR_CODE_NO_ERROR on success, different TLV_REPLY_ERROR_CODE_*
- * on failure (error is send back to client)
+ * on failure (error is sent back to client)
  */
 enum tlv_reply_error_code
 qnetd_algo_2nodelms_config_node_list_received(struct qnetd_client *client,
@@ -128,7 +128,7 @@ qnetd_algo_2nodelms_config_node_list_received(struct qnetd_client *client,
  * should ask later for a vote) or wait_for_reply (client should wait for reply).
  *
  * Return TLV_REPLY_ERROR_CODE_NO_ERROR on success, different TLV_REPLY_ERROR_CODE_*
- * on failure (error is send back to client)
+ * on failure (error is sent back to client)
  */
 
 enum tlv_reply_error_code

--- a/qdevices/qnetd-algo-ffsplit.c
+++ b/qdevices/qnetd-algo-ffsplit.c
@@ -458,8 +458,8 @@ qnetd_algo_ffsplit_update_nodes_state(struct qnetd_client *client, int client_le
 
 /*
  * Send vote info. If client_leaving is set, client is ignored. if send_acks
- * is set, only ACK votes are send (nodes in QNETD_ALGO_FFSPLIT_CLIENT_STATE_SENDING_ACK state),
- * otherwise only NACK votes are send (nodes in QNETD_ALGO_FFSPLIT_CLIENT_STATE_SENDING_NACK state)
+ * is set, only ACK votes are sent (nodes in QNETD_ALGO_FFSPLIT_CLIENT_STATE_SENDING_ACK state),
+ * otherwise only NACK votes are sent (nodes in QNETD_ALGO_FFSPLIT_CLIENT_STATE_SENDING_NACK state)
  *
  * Returns number of send votes
  */

--- a/qdevices/qnetd-algo-test.c
+++ b/qdevices/qnetd-algo-test.c
@@ -60,7 +60,7 @@
  * client is initialized qnetd_client structure.
  *
  * Return TLV_REPLY_ERROR_CODE_NO_ERROR on success, different TLV_REPLY_ERROR_CODE_*
- * on failure (error is send back to client)
+ * on failure (error is sent back to client)
  */
 enum tlv_reply_error_code
 qnetd_algo_test_client_init(struct qnetd_client *client)
@@ -137,7 +137,7 @@ qnetd_algo_test_config_node_list_received(struct qnetd_client *client,
  * should ask later for a vote) or wait_for_reply (client should wait for reply).
  *
  * Return TLV_REPLY_ERROR_CODE_NO_ERROR on success, different TLV_REPLY_ERROR_CODE_*
- * on failure (error is send back to client)
+ * on failure (error is sent back to client)
  */
 
 enum tlv_reply_error_code
@@ -162,7 +162,7 @@ qnetd_algo_test_membership_node_list_received(struct qnetd_client *client,
  * to use qnetd_client_send_vote_info.
  *
  * Return TLV_REPLY_ERROR_CODE_NO_ERROR on success, different TLV_REPLY_ERROR_CODE_*
- * on failure (error is send back to client)
+ * on failure (error is sent back to client)
  */
 enum tlv_reply_error_code
 qnetd_algo_test_quorum_node_list_received(struct qnetd_client *client,
@@ -229,13 +229,13 @@ qnetd_algo_test_vote_info_reply_received(struct qnetd_client *client, uint32_t m
  * Called as a result of qnetd_client_algo_timer_schedule function call after timeout expires.
  *
  * If send_vote is set by callback to non zero value, result_vote must also be set and such vote is
- * send to client. Result_vote is ignored if send_vote = 0 (default).
+ * sent to client. Result_vote is ignored if send_vote = 0 (default).
  *
  * If reschedule timer (default value = 0) is set to non zero value, callback is called again later
  * with same timeout as originaly created.
  *
  * Return TLV_REPLY_ERROR_CODE_NO_ERROR on success, different TLV_REPLY_ERROR_CODE_*
- * on failure (error is send back to client)
+ * on failure (error is sent back to client)
  */
 enum tlv_reply_error_code
 qnetd_algo_test_timer_callback(struct qnetd_client *client, int *reschedule_timer,


### PR DESCRIPTION
There are somwe spell errors in qdevice-net-algo-test.c,
qnetd-algo-2nodelms.c, qnetd-algo-test.c