### PR TITLE
logconfig.c: make syslog_priority and logfile_priority to LOG_INFO

### DIFF
--- a/exec/logconfig.c
+++ b/exec/logconfig.c
@@ -401,7 +401,7 @@ static int corosync_main_config_set (
 			goto parse_error;
 		}
 	}
-	else {
+	else if(strcmp(key_name, "logging.syslog_priority") == 0){
 		if (logsys_config_syslog_priority_set(subsys,
 						      logsys_priority_id_get("info")) < 0) {
 			error_reason = "unable to set syslog level";
@@ -449,7 +449,7 @@ static int corosync_main_config_set (
 			goto parse_error;
 		}
 	}
-	else {
+	else if(strcmp(key_name,"logging.logfile_priority") == 0){
 		if (logsys_config_logfile_priority_set(subsys,
 						      logsys_priority_id_get("info")) < 0) {
 			error_reason = "unable to set syslog level";


### PR DESCRIPTION

logfile_priority and syslog_priority could be modified by 
logging.logger_subsys.{logfile_priority|syslog_priority}. which is aready set by 
logging.{logfile_priority|syslog_priority}, this could lead to the following output
(which are at notice level):

corosync[21419]:   [QUORUM] Using quorum provider corosync_votequorum
corosync[21419]:   [QUORUM] Members[1]: 1084777643
corosync[21419]:   [QUORUM] This node is within the primary component
                   and will provide service.
corosync[21419]:   [QUORUM] Members[3]: 1084777563 1084777584 1084777643

even the syslog_priority is warning. This patch could avoid the
overwrite.