### PR TITLE
totemip.c: Fixed Evicted from CPG membership

### DIFF
--- a/exec/totemconfig.h
+++ b/exec/totemconfig.h
@@ -59,6 +59,11 @@ extern int totem_config_keyread (
 	struct totem_config *totem_config,
 	const char **error_string);
 
+extern int get_local_addr_from_config(
+	const char *ipaddr_key_prefix,
+	const char* ring_name,
+	struct totem_ip_address * ip_addr);
+
 extern int totem_config_find_local_addr_in_nodelist(
 	const char *ipaddr_key_prefix,
 	unsigned int *node_pos);


### PR DESCRIPTION
In a two-node cluster, I 've one node configured with open-vswtich:
5: br-fixed: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default
    inet 192.168.124.88/24 scope global br-fixed
    inet 192.168.124.87/24 scope global secondary br-fixed
    inet 192.168.124.83/24 brd 192.168.124.255 scope global secondary tentative br-fixed
    inet 192.168.124.89/24 scope global secondary br-fixed

while I use 192.168.124.83 in node list of corosync.conf with udpu, and the bind_addr is
192.168.124.0. After upgrading corosync on this node, the it uses 192.168.124.88 instead
of 192.168.124.83. As we can see:

corosync-cfgtool -s
Printing ring status.
Local node ID 1084783704

corosync-quorumtool -s
Membership information:
    Nodeid      Votes Name
1084783697          1 d52-54-77-77-01-02
1084783699          1 d52-54-77-77-01-01 (local)

while the other node can only see itself:
corosync-cfgtool -s
Printing ring status.
Local node ID 1084783697
RING ID 0
        id      = 192.168.124.81
        status  = ring 0 active with no faults

corosync-quorumtool -s
Membership information:
    Nodeid      Votes Name
1084783697          1 d52-54-77-77-01-02.virtual.cloud.suse.de (local)

this patch will compare whether the IP is equal to ring0_addr/ring1_addr
in nodelist of corosync.conf, and set exact_match_found to 1 if yes.
This could avoid the above issue.