### PR TITLE
totemconfig.c: Fixed Evicted from CPG membership

### DIFF
--- a/exec/main.c
+++ b/exec/main.c
@@ -1253,6 +1253,10 @@ int main (int argc, char **argv, char **envp)
 		log_printf (LOGSYS_LEVEL_WARNING, "nodeid appears both in totem section and nodelist. Nodelist one is used.");
 	}
 
+	if (totem_config_warnings & TOTEM_CONFIG_BINDNETADDR_NODELIST_SET) {
+		log_printf (LOGSYS_LEVEL_WARNING, "%s", error_string);
+	}
+
 	if (totem_config_warnings != 0) {
 		log_printf (LOGSYS_LEVEL_WARNING, "Please migrate config file to nodelist.");
 	}

--- a/exec/totemconfig.h
+++ b/exec/totemconfig.h
@@ -45,6 +45,7 @@
 #define TOTEM_CONFIG_WARNING_MEMBERS_IGNORED		(1<<1)
 #define TOTEM_CONFIG_WARNING_MEMBERS_DEPRECATED		(1<<2)
 #define TOTEM_CONFIG_WARNING_TOTEM_NODEID_IGNORED	(1<<3)
+#define TOTEM_CONFIG_BINDNETADDR_NODELIST_SET	(1<<4)
 
 extern int totem_config_read (
 	struct totem_config *totem_config,


### PR DESCRIPTION
In a two-node cluster, I 've one node configured with open-vswtich:
5: br-fixed: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default
inet 192.168.124.88/24 scope global br-fixed
inet 192.168.124.87/24 scope global secondary br-fixed
inet 192.168.124.83/24 brd 192.168.124.255 scope global secondary tentative br-fixed
inet 192.168.124.89/24 scope global secondary br-fixed

while I use 192.168.124.83 in node list of corosync.conf with udpu, and the bind_addr is
192.168.124.0. After upgrading corosync on this node, the it uses 192.168.124.88 instead
of 192.168.124.83. As we can see:

corosync-cfgtool -s
Printing ring status.
Local node ID 1084783704

corosync-quorumtool -s
Membership information:
Nodeid Votes Name
1084783697 1 d52-54-77-77-01-02
1084783699 1 d52-54-77-77-01-01 (local)

while the other node can only see itself:
corosync-cfgtool -s
Printing ring status.
Local node ID 1084783697
RING ID 0
id = 192.168.124.81
status = ring 0 active with no faults

corosync-quorumtool -s
Membership information:
Nodeid Votes Name
1084783697 1 d52-54-77-77-01-02.virtual.cloud.suse.de (local)

this patch will check if there are both nodelist and bindnetaddr and if so, display warning
and use nodelist information.