### PR TITLE
fix some compile warnings

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -1321,11 +1321,8 @@ static int read_uidgid_files_into_icmap(
 	const char *dirname;
 	DIR *dp;
 	struct dirent *dirent;
-	struct dirent *entry;
 	char filename[PATH_MAX + FILENAME_MAX + 1];
 	int res = 0;
-	size_t len;
-	int return_code;
 	struct stat stat_buf;
 	enum main_cp_cb_data_state state = MAIN_CP_CB_DATA_STATE_NORMAL;
 	char key_name[ICMAP_KEYNAME_MAXLEN];
@@ -1336,17 +1333,9 @@ static int read_uidgid_files_into_icmap(
 	if (dp == NULL)
 		return 0;
 
-	len = offsetof(struct dirent, d_name) + FILENAME_MAX + 1;
-
-	entry = malloc(len);
-	if (entry == NULL) {
-		res = 0;
-		goto error_exit;
-	}
-
-	for (return_code = readdir_r(dp, entry, &dirent);
-		dirent != NULL && return_code == 0;
-		return_code = readdir_r(dp, entry, &dirent)) {
+	for (dirent = readdir(dp);
+		dirent != NULL;
+		dirent = readdir(dp)) {
 
 		snprintf(filename, sizeof (filename), "%s/%s", dirname, dirent->d_name);
 		res = stat (filename, &stat_buf);
@@ -1368,7 +1357,6 @@ static int read_uidgid_files_into_icmap(
 	}
 
 error_exit:
-	free (entry);
 	closedir(dp);
 
 	return res;

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -855,7 +855,11 @@ int totemknet_initialize (
 
 	instance->totemknet_target_set_completed = target_set_completed;
 
-	pipe(instance->logpipes);
+	res = pipe(instance->logpipes);
+	if (res) {
+	    KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_CRIT, "failed to create pipe for instance->logpipes");
+	    return -1;
+	}
 	fcntl(instance->logpipes[0], F_SETFL, O_NONBLOCK);
 	fcntl(instance->logpipes[1], F_SETFL, O_NONBLOCK);
 

--- a/exec/wd.c
+++ b/exec/wd.c
@@ -753,7 +753,9 @@ static int wd_exec_exit_fn (void)
 
 	if (dog > 0) {
 		log_printf (LOGSYS_LEVEL_INFO, "magically closing the watchdog.");
-		write (dog, &magic, 1);
+		if(write (dog, &magic, 1) == -1) {
+		    log_printf (LOGSYS_LEVEL_ERROR, "failed to write %c to dog(%d).", magic, dog);
+		}
 	}
 	return 0;
 }

--- a/qdevices/qnetd-algo-lms.c
+++ b/qdevices/qnetd-algo-lms.c
@@ -79,7 +79,7 @@ static enum tlv_reply_error_code do_lms_algorithm(struct qnetd_client *client, c
 	qnetd_client_algo_timer_abort(client);
 
 	if (qnetd_algo_all_ring_ids_match(client, ring_id) == -1) {
-		qnetd_log(LOG_DEBUG, "algo-lms: nodeid %d: ring ID %d/%ld not unique in this membership, waiting",
+		qnetd_log(LOG_DEBUG, "algo-lms: nodeid %d: ring ID (" UTILS_PRI_RING_ID ") not unique in this membership, waiting",
 			  client->node_id, ring_id->node_id, ring_id->seq);
 
 		qnetd_client_algo_timer_schedule(client);
@@ -140,7 +140,7 @@ static enum tlv_reply_error_code do_lms_algorithm(struct qnetd_client *client, c
 		}
 	}
 
-	qnetd_log(LOG_DEBUG, "algo-lms: largest partition is %d/%ld with %d nodes",
+	qnetd_log(LOG_DEBUG, "algo-lms: largest partition is (" UTILS_PRI_RING_ID ") with %d nodes",
 		  largest_partition->ring_id.node_id, largest_partition->ring_id.seq, largest_partition->num_nodes);
 
 	/* Now check if it's really the largest, and not just the joint-largest */
@@ -191,7 +191,7 @@ static enum tlv_reply_error_code do_lms_algorithm(struct qnetd_client *client, c
 				if (other_client->node_id < tb_node_id) {
 					tb_node_id = other_client->node_id;
 					memcpy(&tb_node_ring_id, &other_client->last_ring_id, sizeof(struct tlv_ring_id));
-					qnetd_log(LOG_DEBUG, "algo-lms: Looking for low node ID. found %d (%d/%ld)",
+					qnetd_log(LOG_DEBUG, "algo-lms: Looking for low node ID. found %d (" UTILS_PRI_RING_ID ")",
 						  tb_node_id, tb_node_ring_id.node_id, tb_node_ring_id.seq);
 				}
 			break;
@@ -200,14 +200,14 @@ static enum tlv_reply_error_code do_lms_algorithm(struct qnetd_client *client, c
 				if (other_client->node_id > tb_node_id) {
 					tb_node_id = other_client->node_id;
 					memcpy(&tb_node_ring_id, &other_client->last_ring_id, sizeof(struct tlv_ring_id));
-					qnetd_log(LOG_DEBUG, "algo-lms: Looking for high node ID. found %d (%d/%ld)",
+					qnetd_log(LOG_DEBUG, "algo-lms: Looking for high node ID. found %d (" UTILS_PRI_RING_ID ")",
 						  tb_node_id, tb_node_ring_id.node_id, tb_node_ring_id.seq);
 				}
 			break;
 			case TLV_TIE_BREAKER_MODE_NODE_ID:
 				if (client->tie_breaker.node_id == client->node_id) {
 					memcpy(&tb_node_ring_id, &other_client->last_ring_id, sizeof(struct tlv_ring_id));
-					qnetd_log(LOG_DEBUG, "algo-lms: Looking for nominated node ID. found %d (%d/%ld)",
+					qnetd_log(LOG_DEBUG, "algo-lms: Looking for nominated node ID. found %d (" UTILS_PRI_RING_ID ")",
 						  tb_node_id, tb_node_ring_id.node_id, tb_node_ring_id.seq);
 
 				}
@@ -220,12 +220,12 @@ static enum tlv_reply_error_code do_lms_algorithm(struct qnetd_client *client, c
 		}
 
 		if (client->node_id == tb_node_id || tlv_ring_id_eq(&tb_node_ring_id, ring_id)) {
-			qnetd_log(LOG_DEBUG, "algo-lms: We are in the same partition (%d/%ld) as tie-breaker node id %d. ACK",
+			qnetd_log(LOG_DEBUG, "algo-lms: We are in the same partition (" UTILS_PRI_RING_ID ") as tie-breaker node id %d. ACK",
 				  tb_node_ring_id.node_id, tb_node_ring_id.seq, tb_node_id);
 			*result_vote = info->last_result = TLV_VOTE_ACK;
 		}
 		else {
-			qnetd_log(LOG_DEBUG, "algo-lms: We are NOT in the same partition (%d/%ld) as tie-breaker node id %d. NACK",
+			qnetd_log(LOG_DEBUG, "algo-lms: We are NOT in the same partition (" UTILS_PRI_RING_ID ") as tie-breaker node id %d. NACK",
 				  tb_node_ring_id.node_id, tb_node_ring_id.seq, tb_node_id);
 			*result_vote = info->last_result = TLV_VOTE_NACK;
 		}
@@ -286,7 +286,7 @@ qnetd_algo_lms_membership_node_list_received(struct qnetd_client *client,
     const struct node_list *nodes, enum tlv_vote *result_vote)
 {
 	qnetd_log(LOG_DEBUG, " ");
-	qnetd_log(LOG_DEBUG, "algo-lms: membership list from node %d partition %d/%ld", client->node_id, ring_id->node_id, ring_id->seq);
+	qnetd_log(LOG_DEBUG, "algo-lms: membership list from node %d partition (" UTILS_PRI_RING_ID ")", client->node_id, ring_id->node_id, ring_id->seq);
 
 	return do_lms_algorithm(client, ring_id, result_vote);
 }
@@ -302,7 +302,7 @@ qnetd_algo_lms_quorum_node_list_received(struct qnetd_client *client,
     uint32_t msg_seq_num, enum tlv_quorate quorate, const struct node_list *nodes, enum tlv_vote *result_vote)
 {
 	qnetd_log(LOG_DEBUG, " ");
-	qnetd_log(LOG_DEBUG, "algo-lms: quorum node list from node %d partition %d/%ld", client->node_id, client->last_ring_id.node_id, client->last_ring_id.seq);
+	qnetd_log(LOG_DEBUG, "algo-lms: quorum node list from node %d partition (" UTILS_PRI_RING_ID ")", client->node_id, client->last_ring_id.node_id, client->last_ring_id.seq);
 	return do_lms_algorithm(client, &client->last_ring_id, result_vote);
 }
 

--- a/qdevices/qnetd-algo-utils.c
+++ b/qdevices/qnetd-algo-utils.c
@@ -37,6 +37,7 @@
 #include "qnetd-log.h"
 #include "qnetd-cluster-list.h"
 #include "qnetd-algo-utils.h"
+#include "utils.h"
 
 /*
  * Returns -1 if any node that is supposedly in the same cluster partition
@@ -56,7 +57,7 @@ qnetd_algo_all_ring_ids_match(struct qnetd_client *client, const struct tlv_ring
 		if (other_client == client) {
 			continue; /* We've seen our membership list */
 		}
-		qnetd_log(LOG_DEBUG, "algo-util: all_ring_ids_match: seen nodeid %d (client %p) ring_id (%d/%ld)", other_client->node_id, other_client, other_client->last_ring_id.node_id, other_client->last_ring_id.seq);
+		qnetd_log(LOG_DEBUG, "algo-util: all_ring_ids_match: seen nodeid %d (client %p) ring_id (" UTILS_PRI_RING_ID ")", other_client->node_id, other_client, other_client->last_ring_id.node_id, other_client->last_ring_id.seq);
 
 		/* Look down our node list and see if this client is known to us */
 		TAILQ_FOREACH(node_info, &client->last_membership_node_list, entries) {
@@ -83,7 +84,7 @@ qnetd_algo_all_ring_ids_match(struct qnetd_client *client, const struct tlv_ring
 		 * we need to wait until they have all caught up before making a decision
 		 */
 		if (in_our_partition && !tlv_ring_id_eq(ring_id, &other_client->last_ring_id)) {
-			qnetd_log(LOG_DEBUG, "algo-util: nodeid %d in our partition has different ring_id (%d/%ld) to us (%d/%ld)", other_client->node_id, other_client->last_ring_id.node_id, other_client->last_ring_id.seq, ring_id->node_id, ring_id->seq);
+			qnetd_log(LOG_DEBUG, "algo-util: nodeid %d in our partition has different ring_id (" UTILS_PRI_RING_ID ") to us (" UTILS_PRI_RING_ID ")", other_client->node_id, other_client->last_ring_id.node_id, other_client->last_ring_id.seq, ring_id->node_id, ring_id->seq);
 			return (-1); /* ring IDs don't match */
 		}
 	}
@@ -161,7 +162,7 @@ qnetd_algo_dump_partitions(partitions_list_t *partitions_list)
 	struct qnetd_algo_partition *partition;
 
 	TAILQ_FOREACH(partition, partitions_list, entries) {
-		qnetd_log(LOG_DEBUG, "algo-util: partition %d/%ld (%p) has %d nodes",
+		qnetd_log(LOG_DEBUG, "algo-util: partition (" UTILS_PRI_RING_ID ") (%p) has %d nodes",
 			  partition->ring_id.node_id, partition->ring_id.seq, partition, partition->num_nodes);
 	}
 }

--- a/test/cpghum.c
+++ b/test/cpghum.c
@@ -164,9 +164,9 @@ static void cpg_bm_deliver_fn (
 	// Basic check, packets should all be the right size
 	if (g_write_size && (msg_len != g_write_size)) {
 		length_errors++;
-		fprintf(stderr, "%s: message sizes don't match. got %lu, expected %u\n", group_name->value, msg_len, g_write_size);
+		fprintf(stderr, "%s: message sizes don't match. got %zu, expected %u\n", group_name->value, msg_len, g_write_size);
 		if (do_syslog) {
-			syslog(LOG_ERR, "%s: message sizes don't match. got %lu, expected %u\n", group_name->value, msg_len, g_write_size);
+			syslog(LOG_ERR, "%s: message sizes don't match. got %zu, expected %u\n", group_name->value, msg_len, g_write_size);
 		}
 
 		if (abort_on_error) {


### PR DESCRIPTION
1. readdir_r is deprecated in glibc 2.24, change to readdir
2. fix warings that return values are not used, added warning message
3. type fixes for qnetd_log, syslog and fprintf