### PR TITLE
Adds doxygen stubs to various functions, structs, macros, and variables

### DIFF
--- a/common_lib/error_conversion.c
+++ b/common_lib/error_conversion.c
@@ -36,6 +36,11 @@
 #include <config.h>
 #include <corosync/corotypes.h>
 
+/**
+ * @brief qb_to_cs_error
+ * @param result
+ * @return
+ */
 cs_error_t qb_to_cs_error (int result)
 {
 	int32_t res;
@@ -117,6 +122,11 @@ cs_error_t qb_to_cs_error (int result)
 	return err;
 }
 
+/**
+ * @brief hdb_error_to_cs
+ * @param res
+ * @return
+ */
 cs_error_t hdb_error_to_cs (int res)
 {
 	if (res == 0) {
@@ -135,6 +145,11 @@ cs_error_t hdb_error_to_cs (int res)
 	}
 }
 
+/**
+ * @brief cs_strerror
+ * @param err
+ * @return
+ */
 const char * cs_strerror(cs_error_t err)
 {
 	switch (err) {

--- a/exec/apidef.c
+++ b/exec/apidef.c
@@ -59,15 +59,24 @@ LOGSYS_DECLARE_SUBSYS ("APIDEF");
 /*
  * Remove compile warnings about type name changes in corosync_tpg_group
  */
+/**
+ *
+ */
 typedef int (*typedef_tpg_join) (
 	void *,
 	const struct corosync_tpg_group *,
 	size_t);
 
+/**
+ *
+ */
 typedef int (*typedef_tpg_leave) (void *,
 	const struct corosync_tpg_group *,
 	size_t);
 
+/**
+ *
+ */
 typedef int (*typedef_tpg_groups_mcast_groups) (
 	void *, int,
 	const struct corosync_tpg_group *,
@@ -75,6 +84,9 @@ typedef int (*typedef_tpg_groups_mcast_groups) (
 	const struct iovec *,
 	unsigned int);
 
+/**
+ *
+ */
 typedef int (*typedef_tpg_groups_send_ok) (
 	void *,
 	const struct corosync_tpg_group *,
@@ -82,16 +94,32 @@ typedef int (*typedef_tpg_groups_send_ok) (
 	struct iovec *,
 	int);
 
+/**
+ * @brief _corosync_public_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 static inline void _corosync_public_exit_error (cs_fatal_error_t err,
 						const char *file,
 						unsigned int line)
   __attribute__((noreturn));
+
+/**
+ * @brief _corosync_public_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 static inline void _corosync_public_exit_error (
 	cs_fatal_error_t err, const char *file, unsigned int line)
 {
 	_corosync_exit_error (err, file, line);
 }
 
+/**
+ *
+ */
 static struct corosync_api_v1 apidef_corosync_api_v1 = {
 	.timer_add_duration = corosync_timer_add_duration,
 	.timer_add_absolute = corosync_timer_add_absolute,
@@ -144,6 +172,10 @@ static struct corosync_api_v1 apidef_corosync_api_v1 = {
 	.poll_dispatch_delete = cs_poll_dispatch_delete
 };
 
+/**
+ * @brief apidef_get
+ * @return
+ */
 struct corosync_api_v1 *apidef_get (void)
 {
 	return (&apidef_corosync_api_v1);

--- a/exec/apidef.h
+++ b/exec/apidef.h
@@ -37,6 +37,10 @@
 
 #include <corosync/coroapi.h>
 
+/**
+ * @brief apidef_get
+ * @return
+ */
 extern struct corosync_api_v1 *apidef_get (void);
 
 #endif /* APIDEF_H_DEFINED*/

--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -238,33 +238,54 @@ struct corosync_service_engine cfg_service_engine = {
 	.confchg_fn				= cfg_confchg_fn
 };
 
+/**
+ * @brief cfg_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *cfg_get_service_engine_ver0 (void)
 {
 	return (&cfg_service_engine);
 }
 
+/**
+ * @brief The req_exec_cfg_ringreenable struct
+ */
 struct req_exec_cfg_ringreenable {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
         mar_message_source_t source __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cfg_reload_config struct
+ */
 struct req_exec_cfg_reload_config {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_message_source_t source __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cfg_killnode struct
+ */
 struct req_exec_cfg_killnode {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
         mar_uint32_t nodeid __attribute__((aligned(8)));
 	mar_name_t reason __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cfg_shutdown struct
+ */
 struct req_exec_cfg_shutdown {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 };
 
 /* IMPL */
 
+/**
+ * @brief cfg_exec_init_fn
+ * @param corosync_api_v1
+ * @return
+ */
 static char *cfg_exec_init_fn (
 	struct corosync_api_v1 *corosync_api_v1)
 {
@@ -274,6 +295,17 @@ static char *cfg_exec_init_fn (
 	return (NULL);
 }
 
+/**
+ * @brief cfg_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void cfg_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -285,6 +317,10 @@ static void cfg_confchg_fn (
 
 /*
  * Tell other nodes we are shutting down
+ */
+/**
+ * @brief send_shutdown
+ * @return
  */
 static int send_shutdown(void)
 {
@@ -306,6 +342,12 @@ static int send_shutdown(void)
 	return 0;
 }
 
+/**
+ * @brief send_test_shutdown
+ * @param only_conn
+ * @param exclude_conn
+ * @param status
+ */
 static void send_test_shutdown(void *only_conn, void *exclude_conn, int status)
 {
 	struct res_lib_cfg_testshutdown res_lib_cfg_testshutdown;
@@ -335,6 +377,9 @@ static void send_test_shutdown(void *only_conn, void *exclude_conn, int status)
 	LEAVE();
 }
 
+/**
+ * @brief check_shutdown_status
+ */
 static void check_shutdown_status(void)
 {
 	ENTER();
@@ -415,6 +460,10 @@ static void shutdown_timer_fn(void *arg)
 	LEAVE();
 }
 
+/**
+ * @brief remove_ci_from_shutdown
+ * @param ci
+ */
 static void remove_ci_from_shutdown(struct cfg_info *ci)
 {
 	ENTER();
@@ -453,7 +502,11 @@ static void remove_ci_from_shutdown(struct cfg_info *ci)
 	LEAVE();
 }
 
-
+/**
+ * @brief cfg_lib_exit_fn
+ * @param conn
+ * @return
+ */
 int cfg_lib_exit_fn (void *conn)
 {
 	struct cfg_info *ci = (struct cfg_info *)api->ipc_private_data_get (conn);
@@ -464,6 +517,11 @@ int cfg_lib_exit_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief cfg_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int cfg_lib_init_fn (void *conn)
 {
 	struct cfg_info *ci = (struct cfg_info *)api->ipc_private_data_get (conn);
@@ -477,6 +535,11 @@ static int cfg_lib_init_fn (void *conn)
 
 /*
  * Executive message handlers
+ */
+/**
+ * @brief message_handler_req_exec_cfg_ringreenable
+ * @param message
+ * @param nodeid
  */
 static void message_handler_req_exec_cfg_ringreenable (
         const void *message,
@@ -502,6 +565,10 @@ static void message_handler_req_exec_cfg_ringreenable (
 	LEAVE();
 }
 
+/**
+ * @brief exec_cfg_killnode_endian_convert
+ * @param msg
+ */
 static void exec_cfg_killnode_endian_convert (void *msg)
 {
 	struct req_exec_cfg_killnode *req_exec_cfg_killnode =
@@ -512,7 +579,11 @@ static void exec_cfg_killnode_endian_convert (void *msg)
 	LEAVE();
 }
 
-
+/**
+ * @brief message_handler_req_exec_cfg_killnode
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cfg_killnode (
         const void *message,
         unsigned int nodeid)
@@ -535,6 +606,11 @@ static void message_handler_req_exec_cfg_killnode (
 /*
  * Self shutdown
  */
+/**
+ * @brief message_handler_req_exec_cfg_shutdown
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cfg_shutdown (
         const void *message,
         unsigned int nodeid)
@@ -549,6 +625,12 @@ static void message_handler_req_exec_cfg_shutdown (
 }
 
 /* strcmp replacement that can handle NULLs */
+/**
+ * @brief nullcheck_strcmp
+ * @param left
+ * @param right
+ * @return
+ */
 static int nullcheck_strcmp(const char* left, const char *right)
 {
 	if (!left && right)
@@ -565,6 +647,11 @@ static int nullcheck_strcmp(const char* left, const char *right)
 /*
  * If a key has changed value in the new file, then warn the user and remove it from the temp_map
  */
+/**
+ * @brief delete_and_notify_if_changed
+ * @param temp_map
+ * @param key_name
+ */
 static void delete_and_notify_if_changed(icmap_map_t temp_map, const char *key_name)
 {
 	if (!(icmap_key_value_eq(temp_map, key_name, icmap_get_global_map(), key_name))) {
@@ -579,6 +666,10 @@ static void delete_and_notify_if_changed(icmap_map_t temp_map, const char *key_n
  * entry that the user wants to change but they cannot.
  *
  * Add more here as needed.
+ */
+/**
+ * @brief remove_ro_entries
+ * @param temp_map
  */
 static void remove_ro_entries(icmap_map_t temp_map)
 {
@@ -609,6 +700,11 @@ static void remove_ro_entries(icmap_map_t temp_map)
  *
  * NOTE: This routine depends entirely on the keys returned by the iterators
  * being in alpha-sorted order.
+ */
+/**
+ * @brief remove_deleted_entries
+ * @param temp_map
+ * @param prefix
  */
 static void remove_deleted_entries(icmap_map_t temp_map, const char *prefix)
 {
@@ -662,6 +758,11 @@ static void remove_deleted_entries(icmap_map_t temp_map, const char *prefix)
 
 /*
  * Reload configuration file
+ */
+/**
+ * @brief message_handler_req_exec_cfg_reload_config
+ * @param message
+ * @param nodeid
  */
 static void message_handler_req_exec_cfg_reload_config (
         const void *message,
@@ -742,6 +843,11 @@ reload_return:
 /*
  * Library Interface Implementation
  */
+/**
+ * @brief message_handler_req_lib_cfg_ringstatusget
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_ringstatusget (
 	void *conn,
 	const void *msg)
@@ -802,6 +908,11 @@ send_response:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_ringreenable
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_ringreenable (
 	void *conn,
 	const void *msg)
@@ -825,6 +936,11 @@ static void message_handler_req_lib_cfg_ringreenable (
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_killnode
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_killnode (
 	void *conn,
 	const void *msg)
@@ -857,7 +973,11 @@ static void message_handler_req_lib_cfg_killnode (
 	LEAVE();
 }
 
-
+/**
+ * @brief message_handler_req_lib_cfg_tryshutdown
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_tryshutdown (
 	void *conn,
 	const void *msg)
@@ -976,6 +1096,11 @@ static void message_handler_req_lib_cfg_tryshutdown (
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_replytoshutdown
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_replytoshutdown (
 	void *conn,
 	const void *msg)
@@ -1012,6 +1137,11 @@ exit_fn:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_get_node_addrs
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_get_node_addrs (void *conn,
 							const void *msg)
 {
@@ -1047,6 +1177,11 @@ static void message_handler_req_lib_cfg_get_node_addrs (void *conn,
 	api->ipc_response_send(conn, res_lib_cfg_get_node_addrs, res_lib_cfg_get_node_addrs->header.size);
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_local_get
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_local_get (void *conn, const void *msg)
 {
 	struct res_lib_cfg_local_get res_lib_cfg_local_get;
@@ -1060,6 +1195,11 @@ static void message_handler_req_lib_cfg_local_get (void *conn, const void *msg)
 		sizeof(res_lib_cfg_local_get));
 }
 
+/**
+ * @brief message_handler_req_lib_cfg_reload_config
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_cfg_reload_config (void *conn, const void *msg)
 {
 	struct req_exec_cfg_reload_config req_exec_cfg_reload_config;

--- a/exec/cmap.c
+++ b/exec/cmap.c
@@ -143,6 +143,10 @@ static void cmap_config_version_track_cb(
 /*
  * Library Handler Definition
  */
+
+/**
+ *
+ */
 static struct corosync_lib_handler cmap_lib_engine[] =
 {
 	{ /* 0 */
@@ -183,6 +187,9 @@ static struct corosync_lib_handler cmap_lib_engine[] =
 	},
 };
 
+/**
+ *
+ */
 static struct corosync_exec_handler cmap_exec_engine[] =
 {
     { /* 0 - MESSAGE_REQ_EXEC_CMAP_MCAST */
@@ -191,6 +198,9 @@ static struct corosync_exec_handler cmap_exec_engine[] =
     },
 };
 
+/**
+ *
+ */
 struct corosync_service_engine cmap_service_engine = {
 	.name				        = "corosync configuration map access",
 	.id					= CMAP_SERVICE,
@@ -212,11 +222,18 @@ struct corosync_service_engine cmap_service_engine = {
 	.sync_abort				= cmap_sync_abort
 };
 
+/**
+ * @brief cmap_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *cmap_get_service_engine_ver0 (void)
 {
 	return (&cmap_service_engine);
 }
 
+/**
+ * @brief The req_exec_cmap_mcast_item struct
+ */
 struct req_exec_cmap_mcast_item {
 	mar_name_t key_name __attribute__((aligned(8)));
 	mar_uint8_t value_type __attribute__((aligned(8)));
@@ -224,6 +241,9 @@ struct req_exec_cmap_mcast_item {
 	uint8_t value[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cmap_mcast struct
+ */
 struct req_exec_cmap_mcast {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
         mar_uint8_t reason __attribute__((aligned(8)));
@@ -242,6 +262,14 @@ static uint64_t cmap_my_config_version = 0;
 static int cmap_first_sync = 1;
 static icmap_track_t cmap_config_version_track;
 
+/**
+ * @brief cmap_config_version_track_cb
+ * @param event
+ * @param key_name
+ * @param new_value
+ * @param old_value
+ * @param user_data
+ */
 static void cmap_config_version_track_cb(
 	int32_t event,
 	const char *key_name,
@@ -267,6 +295,10 @@ static void cmap_config_version_track_cb(
 	LEAVE();
 }
 
+/**
+ * @brief cmap_exec_exit_fn
+ * @return
+ */
 static int cmap_exec_exit_fn(void)
 {
 
@@ -277,6 +309,11 @@ static int cmap_exec_exit_fn(void)
 	return 0;
 }
 
+/**
+ * @brief cmap_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *cmap_exec_init_fn (
 	struct corosync_api_v1 *corosync_api)
 {
@@ -297,6 +334,11 @@ static char *cmap_exec_init_fn (
 	return (NULL);
 }
 
+/**
+ * @brief cmap_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int cmap_lib_init_fn (void *conn)
 {
 	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
@@ -312,6 +354,11 @@ static int cmap_lib_init_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief cmap_lib_exit_fn
+ * @param conn
+ * @return
+ */
 static int cmap_lib_exit_fn (void *conn)
 {
 	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
@@ -350,6 +397,14 @@ static int cmap_lib_exit_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief cmap_sync_init
+ * @param trans_list
+ * @param trans_list_entries
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void cmap_sync_init (
 	const unsigned int *trans_list,
 	size_t trans_list_entries,
@@ -367,6 +422,10 @@ static void cmap_sync_init (
 	}
 }
 
+/**
+ * @brief cmap_sync_process
+ * @return
+ */
 static int cmap_sync_process (void)
 {
 	const char *key = "totem.config_version";
@@ -377,6 +436,9 @@ static int cmap_sync_process (void)
 	return (ret == CS_OK ? 0 : -1);
 }
 
+/**
+ * @brief cmap_sync_activate
+ */
 static void cmap_sync_activate (void)
 {
 
@@ -416,12 +478,20 @@ static void cmap_sync_activate (void)
 	}
 }
 
+/**
+ * @brief cmap_sync_abort
+ */
 static void cmap_sync_abort (void)
 {
 
 
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_set
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_set(void *conn, const void *message)
 {
 	const struct req_lib_cmap_set *req_lib_cmap_set = message;
@@ -443,6 +513,11 @@ static void message_handler_req_lib_cmap_set(void *conn, const void *message)
 	api->ipc_response_send(conn, &res_lib_cmap_set, sizeof(res_lib_cmap_set));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_delete
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_delete(void *conn, const void *message)
 {
 	const struct req_lib_cmap_set *req_lib_cmap_set = message;
@@ -463,6 +538,11 @@ static void message_handler_req_lib_cmap_delete(void *conn, const void *message)
 	api->ipc_response_send(conn, &res_lib_cmap_delete, sizeof(res_lib_cmap_delete));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_get
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_get(void *conn, const void *message)
 {
 	const struct req_lib_cmap_get *req_lib_cmap_get = message;
@@ -521,6 +601,11 @@ error_exit:
 	api->ipc_response_send(conn, &error_res_lib_cmap_get, sizeof(error_res_lib_cmap_get));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_adjust_int
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_adjust_int(void *conn, const void *message)
 {
 	const struct req_lib_cmap_adjust_int *req_lib_cmap_adjust_int = message;
@@ -542,6 +627,11 @@ static void message_handler_req_lib_cmap_adjust_int(void *conn, const void *mess
 	api->ipc_response_send(conn, &res_lib_cmap_adjust_int, sizeof(res_lib_cmap_adjust_int));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_iter_init
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_iter_init(void *conn, const void *message)
 {
 	const struct req_lib_cmap_iter_init *req_lib_cmap_iter_init = message;
@@ -589,6 +679,11 @@ reply_send:
 	api->ipc_response_send(conn, &res_lib_cmap_iter_init, sizeof(res_lib_cmap_iter_init));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_iter_next
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_iter_next(void *conn, const void *message)
 {
 	const struct req_lib_cmap_iter_next *req_lib_cmap_iter_next = message;
@@ -630,6 +725,11 @@ reply_send:
 	api->ipc_response_send(conn, &res_lib_cmap_iter_next, sizeof(res_lib_cmap_iter_next));
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_iter_finalize
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_iter_finalize(void *conn, const void *message)
 {
 	const struct req_lib_cmap_iter_finalize *req_lib_cmap_iter_finalize = message;
@@ -659,6 +759,14 @@ reply_send:
 	api->ipc_response_send(conn, &res_lib_cmap_iter_finalize, sizeof(res_lib_cmap_iter_finalize));
 }
 
+/**
+ * @brief cmap_notify_fn
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void cmap_notify_fn(int32_t event,
 		const char *key_name,
 		struct icmap_notify_value new_val,
@@ -695,6 +803,11 @@ static void cmap_notify_fn(int32_t event,
 	api->ipc_dispatch_iov_send(cmap_track_user_data->conn, iov, 3);
 }
 
+/**
+ * @brief message_handler_req_lib_cmap_track_add
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cmap_track_add(void *conn, const void *message)
 {
 	const struct req_lib_cmap_track_add *req_lib_cmap_track_add = message;
@@ -798,6 +911,13 @@ reply_send:
 	api->ipc_response_send(conn, &res_lib_cmap_track_delete, sizeof(res_lib_cmap_track_delete));
 }
 
+/**
+ * @brief cmap_mcast_send
+ * @param reason
+ * @param argc
+ * @param argv
+ * @return
+ */
 static cs_error_t cmap_mcast_send(enum cmap_mcast_reason reason, int argc, char *argv[])
 {
 	int i;
@@ -878,6 +998,12 @@ free_mem:
 	return (err);
 }
 
+/**
+ * @brief cmap_mcast_item_find
+ * @param message
+ * @param key
+ * @return
+ */
 static struct req_exec_cmap_mcast_item *cmap_mcast_item_find(
 		const void *message,
 		char *key)
@@ -904,6 +1030,12 @@ static struct req_exec_cmap_mcast_item *cmap_mcast_item_find(
 	return (NULL);
 }
 
+/**
+ * @brief message_handler_req_exec_cmap_mcast_reason_sync_nv
+ * @param reason
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cmap_mcast_reason_sync_nv(
 		enum cmap_mcast_reason reason,
 		const void *message,
@@ -943,6 +1075,11 @@ static void message_handler_req_exec_cmap_mcast_reason_sync_nv(
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_cmap_mcast
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cmap_mcast(
 		const void *message,
 		unsigned int nodeid)
@@ -969,6 +1106,10 @@ static void message_handler_req_exec_cmap_mcast(
 	LEAVE();
 }
 
+/**
+ * @brief exec_cmap_mcast_endian_convert
+ * @param message
+ */
 static void exec_cmap_mcast_endian_convert(void *message)
 {
 	struct req_exec_cmap_mcast *req_exec_cmap_mcast = message;

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -63,6 +63,9 @@
 #include "main.h"
 #include "util.h"
 
+/**
+ * @brief The parser_cb_type enum
+ */
 enum parser_cb_type {
 	PARSER_CB_START,
 	PARSER_CB_END,
@@ -71,6 +74,9 @@ enum parser_cb_type {
 	PARSER_CB_ITEM,
 };
 
+/**
+ * @brief The main_cp_cb_data_state enum
+ */
 enum main_cp_cb_data_state {
 	MAIN_CP_CB_DATA_STATE_NORMAL,
 	MAIN_CP_CB_DATA_STATE_TOTEM,
@@ -101,12 +107,18 @@ typedef int (*parser_cb_f)(const char *path,
 			icmap_map_t config_map,
 			void *user_data);
 
+/**
+ * @brief The key_value_list_item struct
+ */
 struct key_value_list_item {
 	char *key;
 	char *value;
 	struct qb_list_head list;
 };
 
+/**
+ * @brief The main_cp_cb_data struct
+ */
 struct main_cp_cb_data {
 	int linknumber;
 	char *bindnetaddr;
@@ -131,10 +143,25 @@ struct main_cp_cb_data {
 	int ring0_addr_added;
 };
 
+/**
+ * @brief read_config_file_into_icmap
+ * @param error_string
+ * @param config_map
+ * @return
+ */
 static int read_config_file_into_icmap(
 	const char **error_string, icmap_map_t config_map);
+
+/**
+ * @brief error_string_response
+ */
 static char error_string_response[512];
 
+/**
+ * @brief uid_determine
+ * @param req_user
+ * @return
+ */
 static int uid_determine (const char *req_user)
 {
 	int pw_uid = 0;
@@ -189,6 +216,11 @@ static int uid_determine (const char *req_user)
 	return pw_uid;
 }
 
+/**
+ * @brief gid_determine
+ * @param req_group
+ * @return
+ */
 static int gid_determine (const char *req_group)
 {
 	int corosync_gid = 0;
@@ -242,6 +274,13 @@ static int gid_determine (const char *req_group)
 
 	return corosync_gid;
 }
+
+/**
+ * @brief strchr_rs
+ * @param haystack
+ * @param byte
+ * @return
+ */
 static char *strchr_rs (const char *haystack, int byte)
 {
 	const char *end_address = strchr (haystack, byte);
@@ -255,6 +294,12 @@ static char *strchr_rs (const char *haystack, int byte)
 	return ((char *) end_address);
 }
 
+/**
+ * @brief coroparse_configparse
+ * @param config_map
+ * @param error_string
+ * @return
+ */
 int coroparse_configparse (icmap_map_t config_map, const char **error_string)
 {
 	if (read_config_file_into_icmap(error_string, config_map)) {
@@ -264,6 +309,12 @@ int coroparse_configparse (icmap_map_t config_map, const char **error_string)
 	return 0;
 }
 
+/**
+ * @brief remove_whitespace
+ * @param string
+ * @param remove_colon_and_brace
+ * @return
+ */
 static char *remove_whitespace(char *string, int remove_colon_and_brace)
 {
 	char *start;
@@ -282,8 +333,17 @@ static char *remove_whitespace(char *string, int remove_colon_and_brace)
 	return start;
 }
 
-
-
+/**
+ * @brief parse_section
+ * @param fp
+ * @param path
+ * @param error_string
+ * @param depth
+ * @param parser_cb
+ * @param config_map
+ * @param user_data
+ * @return
+ */
 static int parse_section(FILE *fp,
 			 char *path,
 			 const char **error_string,
@@ -420,6 +480,13 @@ static int parse_section(FILE *fp,
 	return 0;
 }
 
+/**
+ * @brief safe_atoq_range
+ * @param value_type
+ * @param min_val
+ * @param max_val
+ * @return
+ */
 static int safe_atoq_range(icmap_value_types_t value_type, long long int *min_val, long long int *max_val)
 {
 	switch (value_type) {
@@ -440,6 +507,13 @@ static int safe_atoq_range(icmap_value_types_t value_type, long long int *min_va
  * Convert string str to long long int res. Type of result is target_type and currently only
  * ICMAP_VALUETYPE_[U]INT[8|16|32] is supported.
  * Return 0 on success, -1 on failure.
+ */
+/**
+ * @brief safe_atoq
+ * @param str
+ * @param res
+ * @param target_type
+ * @return
  */
 static int safe_atoq(const char *str, long long int *res, icmap_value_types_t target_type)
 {
@@ -474,6 +548,12 @@ static int safe_atoq(const char *str, long long int *res, icmap_value_types_t ta
 	return (0);
 }
 
+/**
+ * @brief str_to_ull
+ * @param str
+ * @param res
+ * @return
+ */
 static int str_to_ull(const char *str, unsigned long long int *res)
 {
 	unsigned long long int val;
@@ -498,6 +578,17 @@ static int str_to_ull(const char *str, unsigned long long int *res)
 	return (0);
 }
 
+/**
+ * @brief main_config_parser_cb
+ * @param path
+ * @param key
+ * @param value
+ * @param type
+ * @param error_string
+ * @param config_map
+ * @param user_data
+ * @return
+ */
 static int main_config_parser_cb(const char *path,
 			char *key,
 			char *value,
@@ -1259,6 +1350,17 @@ atoi_error:
 	return (0);
 }
 
+/**
+ * @brief uidgid_config_parser_cb
+ * @param path
+ * @param key
+ * @param value
+ * @param type
+ * @param error_string
+ * @param config_map
+ * @param user_data
+ * @return
+ */
 static int uidgid_config_parser_cb(const char *path,
 			char *key,
 			char *value,
@@ -1313,6 +1415,12 @@ static int uidgid_config_parser_cb(const char *path,
 	return (1);
 }
 
+/**
+ * @brief read_uidgid_files_into_icmap
+ * @param error_string
+ * @param config_map
+ * @return
+ */
 static int read_uidgid_files_into_icmap(
 	const char **error_string,
 	icmap_map_t config_map)
@@ -1363,6 +1471,12 @@ error_exit:
 }
 
 /* Read config file and load into icmap */
+/**
+ * @brief read_config_file_into_icmap
+ * @param error_string
+ * @param config_map
+ * @return
+ */
 static int read_config_file_into_icmap(
 	const char **error_string,
 	icmap_map_t config_map)

--- a/exec/cpg.c
+++ b/exec/cpg.c
@@ -76,6 +76,9 @@ LOGSYS_DECLARE_SUBSYS ("CPG");
 
 #define GROUP_HASH_SIZE 32
 
+/**
+ * @brief The cpg_message_req_types enum
+ */
 enum cpg_message_req_types {
 	MESSAGE_REQ_EXEC_CPG_PROCJOIN = 0,
 	MESSAGE_REQ_EXEC_CPG_PROCLEAVE = 1,
@@ -86,11 +89,15 @@ enum cpg_message_req_types {
 	MESSAGE_REQ_EXEC_CPG_PARTIAL_MCAST = 6,
 };
 
+/**
+ * @brief The zcb_mapped struct
+ */
 struct zcb_mapped {
 	struct qb_list_head list;
 	void *addr;
 	size_t size;
 };
+
 /*
  * state`		exec deliver
  * match group name, pid -> if matched deliver for YES:
@@ -128,6 +135,9 @@ struct zcb_mapped {
  * JOIN_STARTED		YES(CS_OK)
  * JOIN_COMPLETED	YES(CS_OK)
  */
+/**
+ * @brief The cpd_state enum
+ */
 enum cpd_state {
 	CPD_STATE_UNJOINED,
 	CPD_STATE_LEAVE_STARTED,
@@ -135,11 +145,17 @@ enum cpd_state {
 	CPD_STATE_JOIN_COMPLETED
 };
 
+/**
+ * @brief The cpg_sync_state enum
+ */
 enum cpg_sync_state {
 	CPGSYNC_DOWNLIST,
 	CPGSYNC_JOINLIST
 };
 
+/**
+ * @brief The cpg_downlist_state_e enum
+ */
 enum cpg_downlist_state_e {
        CPG_DOWNLIST_NONE,
        CPG_DOWNLIST_WAITING_FOR_MESSAGES,
@@ -149,6 +165,9 @@ static enum cpg_downlist_state_e downlist_state;
 static struct qb_list_head downlist_messages_head;
 static struct qb_list_head joinlist_messages_head;
 
+/**
+ * @brief The cpg_pd struct
+ */
 struct cpg_pd {
 	void *conn;
  	mar_cpg_name_t group_name;
@@ -163,6 +182,9 @@ struct cpg_pd {
 	struct qb_list_head zcb_mapped_list_head;
 };
 
+/**
+ * @brief The cpg_iteration_instance struct
+ */
 struct cpg_iteration_instance {
 	hdb_handle_t handle;
 	struct qb_list_head list;
@@ -188,6 +210,9 @@ static enum cpg_sync_state my_sync_state = CPGSYNC_DOWNLIST;
 
 static mar_cpg_ring_id_t last_sync_ring_id;
 
+/**
+ * @brief The process_info struct
+ */
 struct process_info {
 	unsigned int nodeid;
 	uint32_t pid;
@@ -196,6 +221,9 @@ struct process_info {
 };
 QB_LIST_DECLARE (process_info_list_head);
 
+/**
+ * @brief The join_list_entry struct
+ */
 struct join_list_entry {
 	uint32_t pid;
 	mar_cpg_name_t group_name;
@@ -340,7 +368,7 @@ static inline int zcb_all_free (
 static char *cpg_print_group_name (
 	const mar_cpg_name_t *group);
 
-/*
+/**
  * Library Handler Definition
  */
 static struct corosync_lib_handler cpg_lib_engine[] =
@@ -400,6 +428,9 @@ static struct corosync_lib_handler cpg_lib_engine[] =
 
 };
 
+/**
+ *
+ */
 static struct corosync_exec_handler cpg_exec_engine[] =
 {
 	{ /* 0 - MESSAGE_REQ_EXEC_CPG_PROCJOIN */
@@ -453,11 +484,18 @@ struct corosync_service_engine cpg_service_engine = {
 	.sync_abort                             = cpg_sync_abort
 };
 
+/**
+ * @brief cpg_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *cpg_get_service_engine_ver0 (void)
 {
 	return (&cpg_service_engine);
 }
 
+/**
+ * @brief The req_exec_cpg_procjoin struct
+ */
 struct req_exec_cpg_procjoin {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -465,6 +503,9 @@ struct req_exec_cpg_procjoin {
 	mar_uint32_t reason __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cpg_mcast struct
+ */
 struct req_exec_cpg_mcast {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -474,6 +515,9 @@ struct req_exec_cpg_mcast {
 	mar_uint8_t message[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cpg_partial_mcast struct
+ */
 struct req_exec_cpg_partial_mcast {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_cpg_name_t group_name __attribute__((aligned(8)));
@@ -485,12 +529,18 @@ struct req_exec_cpg_partial_mcast {
 	mar_uint8_t message[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cpg_downlist_old struct
+ */
 struct req_exec_cpg_downlist_old {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	mar_uint32_t left_nodes __attribute__((aligned(8)));
 	mar_uint32_t nodeids[PROCESSOR_COUNT_MAX]  __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The req_exec_cpg_downlist struct
+ */
 struct req_exec_cpg_downlist {
 	struct qb_ipc_request_header header __attribute__((aligned(8)));
 	/* merge decisions */
@@ -500,6 +550,9 @@ struct req_exec_cpg_downlist {
 	mar_uint32_t nodeids[PROCESSOR_COUNT_MAX]  __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The downlist_msg struct
+ */
 struct downlist_msg {
 	mar_uint32_t sender_nodeid;
 	mar_uint32_t old_members __attribute__((aligned(8)));
@@ -508,6 +561,9 @@ struct downlist_msg {
 	struct qb_list_head list;
 };
 
+/**
+ * @brief The joinlist_msg struct
+ */
 struct joinlist_msg {
 	mar_uint32_t sender_nodeid;
 	uint32_t pid;
@@ -515,10 +571,18 @@ struct joinlist_msg {
 	struct qb_list_head list;
 };
 
+/**
+ * @brief g_req_exec_cpg_downlist
+ */
 static struct req_exec_cpg_downlist g_req_exec_cpg_downlist;
 
 /*
  * Function print group name. It's not reentrant
+ */
+/**
+ * @brief cpg_print_group_name
+ * @param group
+ * @return
  */
 static char *cpg_print_group_name(const mar_cpg_name_t *group)
 {
@@ -547,6 +611,14 @@ static char *cpg_print_group_name(const mar_cpg_name_t *group)
 	return (res);
 }
 
+/**
+ * @brief cpg_sync_init
+ * @param trans_list
+ * @param trans_list_entries
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void cpg_sync_init (
 	const unsigned int *trans_list,
 	size_t trans_list_entries,
@@ -589,6 +661,10 @@ static void cpg_sync_init (
 	g_req_exec_cpg_downlist.left_nodes = entries;
 }
 
+/**
+ * @brief cpg_sync_process
+ * @return
+ */
 static int cpg_sync_process (void)
 {
 	int res = -1;
@@ -606,6 +682,9 @@ static int cpg_sync_process (void)
 	return (res);
 }
 
+/**
+ * @brief cpg_sync_activate
+ */
 static void cpg_sync_activate (void)
 {
 	memcpy (my_old_member_list, my_member_list,
@@ -625,6 +704,9 @@ static void cpg_sync_activate (void)
 	notify_lib_totem_membership (NULL, my_member_list_entries, my_member_list);
 }
 
+/**
+ * @brief cpg_sync_abort
+ */
 static void cpg_sync_abort (void)
 {
 	downlist_state = CPG_DOWNLIST_NONE;
@@ -632,6 +714,13 @@ static void cpg_sync_abort (void)
 	joinlist_messages_delete ();
 }
 
+/**
+ * @brief notify_lib_totem_membership
+ * @param conn
+ * @param member_list_entries
+ * @param member_list
+ * @return
+ */
 static int notify_lib_totem_membership (
 	void *conn,
 	int member_list_entries,
@@ -669,6 +758,17 @@ static int notify_lib_totem_membership (
 	return CS_OK;
 }
 
+/**
+ * @brief notify_lib_joinlist
+ * @param group_name
+ * @param conn
+ * @param joined_list_entries
+ * @param joined_list
+ * @param left_list_entries
+ * @param left_list
+ * @param id
+ * @return
+ */
 static int notify_lib_joinlist(
 	const mar_cpg_name_t *group_name,
 	void *conn,
@@ -801,6 +901,11 @@ static int notify_lib_joinlist(
 	return CS_OK;
 }
 
+/**
+ * @brief downlist_log
+ * @param msg
+ * @param dl
+ */
 static void downlist_log(const char *msg, struct downlist_msg* dl)
 {
 	log_printf (LOG_DEBUG,
@@ -811,6 +916,10 @@ static void downlist_log(const char *msg, struct downlist_msg* dl)
 		    dl->left_nodes);
 }
 
+/**
+ * @brief downlist_master_choose
+ * @return
+ */
 static struct downlist_msg* downlist_master_choose (void)
 {
 	struct downlist_msg *cmp;
@@ -865,6 +974,9 @@ static struct downlist_msg* downlist_master_choose (void)
 	return best;
 }
 
+/**
+ * @brief downlist_master_choose_and_send
+ */
 static void downlist_master_choose_and_send (void)
 {
 	struct downlist_msg *stored_msg;
@@ -959,6 +1071,10 @@ static void downlist_master_choose_and_send (void)
 /*
  * Remove processes that might have left the group while we were suspended.
  */
+
+/**
+ * @brief joinlist_remove_zombie_pi_entries
+ */
 static void joinlist_remove_zombie_pi_entries (void)
 {
 	struct qb_list_head *pi_iter, *tmp_iter;
@@ -1002,6 +1118,9 @@ static void joinlist_remove_zombie_pi_entries (void)
 	}
 }
 
+/**
+ * @brief joinlist_inform_clients
+ */
 static void joinlist_inform_clients (void)
 {
 	struct joinlist_msg *stored_msg;
@@ -1029,6 +1148,9 @@ static void joinlist_inform_clients (void)
 	joinlist_remove_zombie_pi_entries ();
 }
 
+/**
+ * @brief downlist_messages_delete
+ */
 static void downlist_messages_delete (void)
 {
 	struct downlist_msg *stored_msg;
@@ -1041,6 +1163,9 @@ static void downlist_messages_delete (void)
 	}
 }
 
+/**
+ * @brief joinlist_messages_delete
+ */
 static void joinlist_messages_delete (void)
 {
 	struct joinlist_msg *stored_msg;
@@ -1054,6 +1179,11 @@ static void joinlist_messages_delete (void)
 	qb_list_init (&joinlist_messages_head);
 }
 
+/**
+ * @brief cpg_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *cpg_exec_init_fn (struct corosync_api_v1 *corosync_api)
 {
 	qb_list_init (&downlist_messages_head);
@@ -1062,6 +1192,10 @@ static char *cpg_exec_init_fn (struct corosync_api_v1 *corosync_api)
 	return (NULL);
 }
 
+/**
+ * @brief cpg_iteration_instance_finalize
+ * @param cpg_iteration_instance
+ */
 static void cpg_iteration_instance_finalize (struct cpg_iteration_instance *cpg_iteration_instance)
 {
 	struct qb_list_head *iter, *tmp_iter;
@@ -1077,6 +1211,10 @@ static void cpg_iteration_instance_finalize (struct cpg_iteration_instance *cpg_
 	hdb_handle_destroy (&cpg_iteration_handle_t_db, cpg_iteration_instance->handle);
 }
 
+/**
+ * @brief cpg_pd_finalize
+ * @param cpd
+ */
 static void cpg_pd_finalize (struct cpg_pd *cpd)
 {
 	struct qb_list_head *iter, *tmp_iter;
@@ -1092,6 +1230,11 @@ static void cpg_pd_finalize (struct cpg_pd *cpd)
 	qb_list_del (&cpd->list);
 }
 
+/**
+ * @brief cpg_lib_exit_fn
+ * @param conn
+ * @return
+ */
 static int cpg_lib_exit_fn (void *conn)
 {
 	struct cpg_pd *cpd = (struct cpg_pd *)api->ipc_private_data_get (conn);
@@ -1109,6 +1252,14 @@ static int cpg_lib_exit_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief cpg_node_joinleave_send
+ * @param pid
+ * @param group_name
+ * @param fn
+ * @param reason
+ * @return
+ */
 static int cpg_node_joinleave_send (unsigned int pid, const mar_cpg_name_t *group_name, int fn, int reason)
 {
 	struct req_exec_cpg_procjoin req_exec_cpg_procjoin;
@@ -1131,6 +1282,10 @@ static int cpg_node_joinleave_send (unsigned int pid, const mar_cpg_name_t *grou
 }
 
 /* Can byteswap join & leave messages */
+/**
+ * @brief exec_cpg_procjoin_endian_convert
+ * @param msg
+ */
 static void exec_cpg_procjoin_endian_convert (void *msg)
 {
 	struct req_exec_cpg_procjoin *req_exec_cpg_procjoin = msg;
@@ -1140,6 +1295,10 @@ static void exec_cpg_procjoin_endian_convert (void *msg)
 	req_exec_cpg_procjoin->reason = swab32(req_exec_cpg_procjoin->reason);
 }
 
+/**
+ * @brief exec_cpg_joinlist_endian_convert
+ * @param msg_v
+ */
 static void exec_cpg_joinlist_endian_convert (void *msg_v)
 {
 	char *msg = msg_v;
@@ -1155,10 +1314,18 @@ static void exec_cpg_joinlist_endian_convert (void *msg_v)
 	}
 }
 
+/**
+ * @brief exec_cpg_downlist_endian_convert_old
+ * @param msg
+ */
 static void exec_cpg_downlist_endian_convert_old (void *msg)
 {
 }
 
+/**
+ * @brief exec_cpg_downlist_endian_convert
+ * @param msg
+ */
 static void exec_cpg_downlist_endian_convert (void *msg)
 {
 	struct req_exec_cpg_downlist *req_exec_cpg_downlist = msg;
@@ -1172,7 +1339,10 @@ static void exec_cpg_downlist_endian_convert (void *msg)
 	}
 }
 
-
+/**
+ * @brief exec_cpg_mcast_endian_convert
+ * @param msg
+ */
 static void exec_cpg_mcast_endian_convert (void *msg)
 {
 	struct req_exec_cpg_mcast *req_exec_cpg_mcast = msg;
@@ -1184,6 +1354,10 @@ static void exec_cpg_mcast_endian_convert (void *msg)
 	swab_mar_message_source_t (&req_exec_cpg_mcast->source);
 }
 
+/**
+ * @brief exec_cpg_partial_mcast_endian_convert
+ * @param msg
+ */
 static void exec_cpg_partial_mcast_endian_convert (void *msg)
 {
 	struct req_exec_cpg_partial_mcast *req_exec_cpg_mcast = msg;
@@ -1197,6 +1371,13 @@ static void exec_cpg_partial_mcast_endian_convert (void *msg)
 	swab_mar_message_source_t (&req_exec_cpg_mcast->source);
 }
 
+/**
+ * @brief process_info_find
+ * @param group_name
+ * @param pid
+ * @param nodeid
+ * @return
+ */
 static struct process_info *process_info_find(const mar_cpg_name_t *group_name, uint32_t pid, unsigned int nodeid) {
 	struct qb_list_head *iter;
 
@@ -1212,6 +1393,13 @@ static struct process_info *process_info_find(const mar_cpg_name_t *group_name, 
 	return NULL;
 }
 
+/**
+ * @brief do_proc_join
+ * @param name
+ * @param pid
+ * @param nodeid
+ * @param reason
+ */
 static void do_proc_join(
 	const mar_cpg_name_t *name,
 	uint32_t pid,
@@ -1262,6 +1450,13 @@ static void do_proc_join(
 			    MESSAGE_RES_CPG_CONFCHG_CALLBACK);
 }
 
+/**
+ * @brief do_proc_leave
+ * @param name
+ * @param pid
+ * @param nodeid
+ * @param reason
+ */
 static void do_proc_leave(
 	const mar_cpg_name_t *name,
 	uint32_t pid,
@@ -1292,6 +1487,11 @@ static void do_proc_leave(
 	}
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_downlist_old
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_downlist_old (
 	const void *message,
 	unsigned int nodeid)
@@ -1300,6 +1500,11 @@ static void message_handler_req_exec_cpg_downlist_old (
 		nodeid);
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_downlist
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_downlist(
 	const void *message,
 	unsigned int nodeid)
@@ -1343,6 +1548,11 @@ static void message_handler_req_exec_cpg_downlist(
 }
 
 
+/**
+ * @brief message_handler_req_exec_cpg_procjoin
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_procjoin (
 	const void *message,
 	unsigned int nodeid)
@@ -1359,6 +1569,11 @@ static void message_handler_req_exec_cpg_procjoin (
 		CONFCHG_CPG_REASON_JOIN);
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_procleave
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_procleave (
 	const void *message,
 	unsigned int nodeid)
@@ -1377,6 +1592,11 @@ static void message_handler_req_exec_cpg_procleave (
 
 
 /* Got a proclist from another node */
+/**
+ * @brief message_handler_req_exec_cpg_joinlist
+ * @param message_v
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_joinlist (
 	const void *message_v,
 	unsigned int nodeid)
@@ -1401,6 +1621,11 @@ static void message_handler_req_exec_cpg_joinlist (
 	}
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_mcast
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_mcast (
 	const void *message,
 	unsigned int nodeid)
@@ -1455,6 +1680,11 @@ static void message_handler_req_exec_cpg_mcast (
 	}
 }
 
+/**
+ * @brief message_handler_req_exec_cpg_partial_mcast
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_cpg_partial_mcast (
 	const void *message,
 	unsigned int nodeid)
@@ -1515,6 +1745,10 @@ static void message_handler_req_exec_cpg_partial_mcast (
 }
 
 
+/**
+ * @brief cpg_exec_send_downlist
+ * @return
+ */
 static int cpg_exec_send_downlist(void)
 {
 	struct iovec iov;
@@ -1530,6 +1764,10 @@ static int cpg_exec_send_downlist(void)
 	return (api->totem_mcast (&iov, 1, TOTEM_AGREED));
 }
 
+/**
+ * @brief cpg_exec_send_joinlist
+ * @return
+ */
 static int cpg_exec_send_joinlist(void)
 {
 	int count = 0;
@@ -1579,6 +1817,11 @@ static int cpg_exec_send_joinlist(void)
 	return (api->totem_mcast (&req_exec_cpg_iovec, 1, TOTEM_AGREED));
 }
 
+/**
+ * @brief cpg_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int cpg_lib_init_fn (void *conn)
 {
 	struct cpg_pd *cpd = (struct cpg_pd *)api->ipc_private_data_get (conn);
@@ -1595,6 +1838,11 @@ static int cpg_lib_init_fn (void *conn)
 }
 
 /* Join message from the library */
+/**
+ * @brief message_handler_req_lib_cpg_join
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_join (void *conn, const void *message)
 {
 	const struct req_lib_cpg_join *req_lib_cpg_join = message;
@@ -1668,6 +1916,11 @@ response_send:
 }
 
 /* Leave message from the library */
+/**
+ * @brief message_handler_req_lib_cpg_leave
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_leave (void *conn, const void *message)
 {
 	struct res_lib_cpg_leave res_lib_cpg_leave;
@@ -1705,6 +1958,12 @@ static void message_handler_req_lib_cpg_leave (void *conn, const void *message)
 }
 
 /* Finalize message from library */
+
+/**
+ * @brief message_handler_req_lib_cpg_finalize
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_finalize (
 	void *conn,
 	const void *message)
@@ -1777,6 +2036,14 @@ error_close_unlink:
 	return -1;
 }
 
+/**
+ * @brief zcb_alloc
+ * @param cpd
+ * @param path_to_file
+ * @param size
+ * @param addr
+ * @return
+ */
 static inline int zcb_alloc (
 	struct cpg_pd *cpd,
 	const char *path_to_file,
@@ -1808,6 +2075,11 @@ static inline int zcb_alloc (
 }
 
 
+/**
+ * @brief zcb_free
+ * @param zcb_mapped
+ * @return
+ */
 static inline int zcb_free (struct zcb_mapped *zcb_mapped)
 {
 	unsigned int res;
@@ -1818,6 +2090,12 @@ static inline int zcb_free (struct zcb_mapped *zcb_mapped)
 	return (res);
 }
 
+/**
+ * @brief zcb_by_addr_free
+ * @param cpd
+ * @param addr
+ * @return
+ */
 static inline int zcb_by_addr_free (struct cpg_pd *cpd, void *addr)
 {
 	struct qb_list_head *list, *tmp_iter;
@@ -1836,6 +2114,11 @@ static inline int zcb_by_addr_free (struct cpg_pd *cpd, void *addr)
 	return (res);
 }
 
+/**
+ * @brief zcb_all_free
+ * @param cpd
+ * @return
+ */
 static inline int zcb_all_free (
 	struct cpg_pd *cpd)
 {
@@ -1850,11 +2133,19 @@ static inline int zcb_all_free (
 	return (0);
 }
 
+/**
+ * @brief The u union
+ */
 union u {
 	uint64_t server_addr;
 	void *server_ptr;
 };
 
+/**
+ * @brief void2serveraddr
+ * @param server_ptr
+ * @return
+ */
 static uint64_t void2serveraddr (void *server_ptr)
 {
 	union u u;
@@ -1863,6 +2154,11 @@ static uint64_t void2serveraddr (void *server_ptr)
 	return (u.server_addr);
 }
 
+/**
+ * @brief serveraddr2void
+ * @param server_addr
+ * @return
+ */
 static void *serveraddr2void (uint64_t server_addr)
 {
 	union u u;
@@ -1871,6 +2167,11 @@ static void *serveraddr2void (uint64_t server_addr)
 	return (u.server_ptr);
 };
 
+/**
+ * @brief message_handler_req_lib_cpg_zc_alloc
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_zc_alloc (
 	void *conn,
 	const void *message)
@@ -1898,6 +2199,11 @@ static void message_handler_req_lib_cpg_zc_alloc (
 		res_header.size);
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_zc_free
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_zc_free (
 	void *conn,
 	const void *message)
@@ -1921,6 +2227,11 @@ static void message_handler_req_lib_cpg_zc_free (
 }
 
 /* Fragmented mcast message from the library */
+/**
+ * @brief message_handler_req_lib_cpg_partial_mcast
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_partial_mcast (void *conn, const void *message)
 {
 	const struct req_lib_cpg_partial_mcast *req_lib_cpg_mcast = message;
@@ -1992,6 +2303,12 @@ static void message_handler_req_lib_cpg_partial_mcast (void *conn, const void *m
 }
 
 /* Mcast message from the library */
+
+/**
+ * @brief message_handler_req_lib_cpg_mcast
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_mcast (void *conn, const void *message)
 {
 	const struct req_lib_cpg_mcast *req_lib_cpg_mcast = message;
@@ -2044,6 +2361,11 @@ static void message_handler_req_lib_cpg_mcast (void *conn, const void *message)
 	}
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_zc_execute
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_zc_execute (
 	void *conn,
 	const void *message)
@@ -2110,6 +2432,11 @@ static void message_handler_req_lib_cpg_zc_execute (
 
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_membership
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_membership (void *conn,
 						    const void *message)
 {
@@ -2138,6 +2465,11 @@ static void message_handler_req_lib_cpg_membership (void *conn,
 		sizeof (res_lib_cpg_membership_get));
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_local_get
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_local_get (void *conn,
 						   const void *message)
 {
@@ -2152,6 +2484,11 @@ static void message_handler_req_lib_cpg_local_get (void *conn,
 		sizeof (res_lib_cpg_local_get));
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_iteration_initialize
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_iteration_initialize (
 	void *conn,
 	const void *message)
@@ -2293,6 +2630,11 @@ response_send:
 		sizeof (res_lib_cpg_iterationinitialize));
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_iteration_next
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_iteration_next (
 	void *conn,
 	const void *message)
@@ -2346,6 +2688,11 @@ error_exit:
 		sizeof (res_lib_cpg_iterationnext));
 }
 
+/**
+ * @brief message_handler_req_lib_cpg_iteration_finalize
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_cpg_iteration_finalize (
 	void *conn,
 	const void *message)

--- a/exec/cs_queue.h
+++ b/exec/cs_queue.h
@@ -41,6 +41,9 @@
 #include <errno.h>
 #include "assert.h"
 
+/**
+ * @brief The cs_queue struct
+ */
 struct cs_queue {
 	int head;
 	int tail;
@@ -54,6 +57,14 @@ struct cs_queue {
 	int threaded_mode_enabled;
 };
 
+/**
+ * @brief cs_queue_init
+ * @param cs_queue
+ * @param cs_queue_items
+ * @param size_per_item
+ * @param threaded_mode_enabled
+ * @return
+ */
 static inline int cs_queue_init (struct cs_queue *cs_queue, int cs_queue_items, int size_per_item, int threaded_mode_enabled) {
 	cs_queue->head = 0;
 	cs_queue->tail = cs_queue_items - 1;
@@ -74,6 +85,11 @@ static inline int cs_queue_init (struct cs_queue *cs_queue, int cs_queue_items, 
 	return (0);
 }
 
+/**
+ * @brief cs_queue_reinit
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_reinit (struct cs_queue *cs_queue)
 {
 	if (cs_queue->threaded_mode_enabled) {
@@ -91,6 +107,10 @@ static inline int cs_queue_reinit (struct cs_queue *cs_queue)
 	return (0);
 }
 
+/**
+ * @brief cs_queue_free
+ * @param cs_queue
+ */
 static inline void cs_queue_free (struct cs_queue *cs_queue) {
 	if (cs_queue->threaded_mode_enabled) {
 		pthread_mutex_destroy (&cs_queue->mutex);
@@ -98,6 +118,11 @@ static inline void cs_queue_free (struct cs_queue *cs_queue) {
 	free (cs_queue->items);
 }
 
+/**
+ * @brief cs_queue_is_full
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_is_full (struct cs_queue *cs_queue) {
 	int full;
 
@@ -111,6 +136,11 @@ static inline int cs_queue_is_full (struct cs_queue *cs_queue) {
 	return (full);
 }
 
+/**
+ * @brief cs_queue_is_empty
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_is_empty (struct cs_queue *cs_queue) {
 	int empty;
 
@@ -124,6 +154,11 @@ static inline int cs_queue_is_empty (struct cs_queue *cs_queue) {
 	return (empty);
 }
 
+/**
+ * @brief cs_queue_item_add
+ * @param cs_queue
+ * @param item
+ */
 static inline void cs_queue_item_add (struct cs_queue *cs_queue, void *item)
 {
 	char *cs_queue_item;
@@ -149,6 +184,11 @@ static inline void cs_queue_item_add (struct cs_queue *cs_queue, void *item)
 	}
 }
 
+/**
+ * @brief cs_queue_item_get
+ * @param cs_queue
+ * @return
+ */
 static inline void *cs_queue_item_get (struct cs_queue *cs_queue)
 {
 	char *cs_queue_item;
@@ -166,6 +206,10 @@ static inline void *cs_queue_item_get (struct cs_queue *cs_queue)
 	return ((void *)cs_queue_item);
 }
 
+/**
+ * @brief cs_queue_item_remove
+ * @param cs_queue
+ */
 static inline void cs_queue_item_remove (struct cs_queue *cs_queue) {
 	if (cs_queue->threaded_mode_enabled) {
 		pthread_mutex_lock (&cs_queue->mutex);
@@ -181,6 +225,11 @@ static inline void cs_queue_item_remove (struct cs_queue *cs_queue) {
 	}
 }
 
+/**
+ * @brief cs_queue_items_remove
+ * @param cs_queue
+ * @param rel_count
+ */
 static inline void cs_queue_items_remove (struct cs_queue *cs_queue, int rel_count)
 {
 	if (cs_queue->threaded_mode_enabled) {
@@ -196,7 +245,10 @@ static inline void cs_queue_items_remove (struct cs_queue *cs_queue, int rel_cou
 	}
 }
 
-
+/**
+ * @brief cs_queue_item_iterator_init
+ * @param cs_queue
+ */
 static inline void cs_queue_item_iterator_init (struct cs_queue *cs_queue)
 {
 	if (cs_queue->threaded_mode_enabled) {
@@ -208,6 +260,11 @@ static inline void cs_queue_item_iterator_init (struct cs_queue *cs_queue)
 	}
 }
 
+/**
+ * @brief cs_queue_item_iterator_get
+ * @param cs_queue
+ * @return
+ */
 static inline void *cs_queue_item_iterator_get (struct cs_queue *cs_queue)
 {
 	char *cs_queue_item;
@@ -231,6 +288,11 @@ static inline void *cs_queue_item_iterator_get (struct cs_queue *cs_queue)
 	return ((void *)cs_queue_item);
 }
 
+/**
+ * @brief cs_queue_item_iterator_next
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_item_iterator_next (struct cs_queue *cs_queue)
 {
 	int next_res;
@@ -247,6 +309,11 @@ static inline int cs_queue_item_iterator_next (struct cs_queue *cs_queue)
 	return (next_res);
 }
 
+/**
+ * @brief cs_queue_avail
+ * @param cs_queue
+ * @param avail
+ */
 static inline void cs_queue_avail (struct cs_queue *cs_queue, int *avail)
 {
 	if (cs_queue->threaded_mode_enabled) {
@@ -259,6 +326,11 @@ static inline void cs_queue_avail (struct cs_queue *cs_queue, int *avail)
 	}
 }
 
+/**
+ * @brief cs_queue_used
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_used (struct cs_queue *cs_queue) {
 	int used;
 
@@ -273,6 +345,11 @@ static inline int cs_queue_used (struct cs_queue *cs_queue) {
 	return (used);
 }
 
+/**
+ * @brief cs_queue_usedhw
+ * @param cs_queue
+ * @return
+ */
 static inline int cs_queue_usedhw (struct cs_queue *cs_queue) {
 	int usedhw;
 

--- a/exec/fsm.h
+++ b/exec/fsm.h
@@ -77,6 +77,13 @@ struct cs_fsm {
  * so cs_fsm_process() sets the entry and cs_fsm_state_set()
  * sets the new state.
  */
+/**
+ * @brief cs_fsm_process
+ * @param fsm
+ * @param new_event
+ * @param data
+ * @param cb
+ */
 static inline void cs_fsm_process (struct cs_fsm *fsm, int32_t new_event, void * data, cs_fsm_cb cb)
 {
 	int32_t i;
@@ -98,6 +105,13 @@ static inline void cs_fsm_process (struct cs_fsm *fsm, int32_t new_event, void *
 	}
 }
 
+/**
+ * @brief cs_fsm_state_set
+ * @param fsm
+ * @param next_state
+ * @param data
+ * @param cb
+ */
 static inline void cs_fsm_state_set (struct cs_fsm* fsm, int32_t next_state, void* data, cs_fsm_cb cb)
 {
 	int i;

--- a/exec/icmap.c
+++ b/exec/icmap.c
@@ -129,6 +129,15 @@ static cs_error_t icmap_get_int_r(
  * of arguments validity checks but doesn't copy data (it returns raw item data
  * pointer). It's not very safe tho it's static.
  */
+/**
+ * @brief icmap_get_ref_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 static cs_error_t icmap_get_ref_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -138,6 +147,11 @@ static cs_error_t icmap_get_ref_r(
 
 /*
  * Function implementation
+ */
+/**
+ * @brief icmap_tt_to_qbtt
+ * @param track_type
+ * @return
  */
 static int32_t icmap_tt_to_qbtt(int32_t track_type)
 {
@@ -162,6 +176,11 @@ static int32_t icmap_tt_to_qbtt(int32_t track_type)
 	return (res);
 }
 
+/**
+ * @brief icmap_qbtt_to_tt
+ * @param track_type
+ * @return
+ */
 static int32_t icmap_qbtt_to_tt(int32_t track_type)
 {
 	int32_t res = 0;
@@ -185,6 +204,14 @@ static int32_t icmap_qbtt_to_tt(int32_t track_type)
 	return (res);
 }
 
+/**
+ * @brief icmap_map_free_cb
+ * @param event
+ * @param key
+ * @param old_value
+ * @param value
+ * @param user_data
+ */
 static void icmap_map_free_cb(uint32_t event,
 		char* key, void* old_value,
 		void* value, void* user_data)
@@ -200,6 +227,11 @@ static void icmap_map_free_cb(uint32_t event,
 	}
 }
 
+/**
+ * @brief icmap_init_r
+ * @param result
+ * @return
+ */
 cs_error_t icmap_init_r(icmap_map_t *result)
 {
 	int32_t err;
@@ -218,11 +250,18 @@ cs_error_t icmap_init_r(icmap_map_t *result)
 	return (qb_to_cs_error(err));
 }
 
+/**
+ * @brief icmap_init
+ * @return
+ */
 cs_error_t icmap_init(void)
 {
 	return (icmap_init_r(&icmap_global_map));
 }
 
+/**
+ * @brief icmap_set_ro_access_free
+ */
 static void icmap_set_ro_access_free(void)
 {
 	struct qb_list_head *iter, *tmp_iter;
@@ -236,6 +275,9 @@ static void icmap_set_ro_access_free(void)
 	}
 }
 
+/**
+ * @brief icmap_del_all_track
+ */
 static void icmap_del_all_track(void)
 {
 	struct qb_list_head *iter, *tmp_iter;
@@ -248,6 +290,10 @@ static void icmap_del_all_track(void)
 	}
 }
 
+/**
+ * @brief icmap_fini_r
+ * @param map
+ */
 void icmap_fini_r(const icmap_map_t map)
 {
 
@@ -257,6 +303,9 @@ void icmap_fini_r(const icmap_map_t map)
 	return;
 }
 
+/**
+ * @brief icmap_fini
+ */
 void icmap_fini(void)
 {
 
@@ -274,12 +323,21 @@ void icmap_fini(void)
 	return ;
 }
 
+/**
+ * @brief icmap_get_global_map
+ * @return
+ */
 icmap_map_t icmap_get_global_map(void)
 {
 
 	return (icmap_global_map);
 }
 
+/**
+ * @brief icmap_is_valid_name_char
+ * @param c
+ * @return
+ */
 static int icmap_is_valid_name_char(char c)
 {
 	return ((c >= 'a' && c <= 'z') ||
@@ -288,6 +346,10 @@ static int icmap_is_valid_name_char(char c)
 		c == '.' || c == '_' || c == '-' || c == '/' || c == ':');
 }
 
+/**
+ * @brief icmap_convert_name_to_valid_name
+ * @param key_name
+ */
 void icmap_convert_name_to_valid_name(char *key_name)
 {
 	int i;
@@ -299,6 +361,11 @@ void icmap_convert_name_to_valid_name(char *key_name)
 	}
 }
 
+/**
+ * @brief icmap_check_key_name
+ * @param key_name
+ * @return
+ */
 static int icmap_check_key_name(const char *key_name)
 {
 	int i;
@@ -316,6 +383,11 @@ static int icmap_check_key_name(const char *key_name)
 	return (0);
 }
 
+/**
+ * @brief icmap_get_valuetype_len
+ * @param type
+ * @return
+ */
 static size_t icmap_get_valuetype_len(icmap_value_types_t type)
 {
 	size_t res = 0;
@@ -340,6 +412,13 @@ static size_t icmap_get_valuetype_len(icmap_value_types_t type)
 	return (res);
 }
 
+/**
+ * @brief icmap_check_value_len
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 static int icmap_check_value_len(const void *value, size_t value_len, icmap_value_types_t type)
 {
 
@@ -370,6 +449,14 @@ static int icmap_check_value_len(const void *value, size_t value_len, icmap_valu
 	return (0);
 }
 
+/**
+ * @brief icmap_item_eq
+ * @param item
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 static int icmap_item_eq(const struct icmap_item *item, const void *value, size_t value_len, icmap_value_types_t type)
 {
 	size_t ptr_len;
@@ -395,6 +482,14 @@ static int icmap_item_eq(const struct icmap_item *item, const void *value, size_
 	return (0);
 }
 
+/**
+ * @brief icmap_key_value_eq
+ * @param map1
+ * @param key_name1
+ * @param map2
+ * @param key_name2
+ * @return
+ */
 int icmap_key_value_eq(
 	const icmap_map_t map1,
 	const char *key_name1,
@@ -417,6 +512,15 @@ int icmap_key_value_eq(
 	return (icmap_item_eq(item1, item2->value, item2->value_len, item2->type));
 }
 
+/**
+ * @brief icmap_set_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t icmap_set_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -497,6 +601,14 @@ cs_error_t icmap_set_r(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_set
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t icmap_set(
 	const char *key_name,
 	const void *value,
@@ -507,66 +619,143 @@ cs_error_t icmap_set(
 	return (icmap_set_r(icmap_global_map, key_name, value, value_len, type));
 }
 
+/**
+ * @brief icmap_set_int8_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int8_r(const icmap_map_t map, const char *key_name, int8_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_INT8));
 }
 
+/**
+ * @brief icmap_set_uint8_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint8_r(const icmap_map_t map, const char *key_name, uint8_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_UINT8));
 }
 
+/**
+ * @brief icmap_set_int16_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int16_r(const icmap_map_t map, const char *key_name, int16_t value)
 {
 
 	return (icmap_set_r(map,key_name, &value, sizeof(value), ICMAP_VALUETYPE_INT16));
 }
 
+/**
+ * @brief icmap_set_uint16_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint16_r(const icmap_map_t map, const char *key_name, uint16_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_UINT16));
 }
 
+/**
+ * @brief icmap_set_int32_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int32_r(const icmap_map_t map, const char *key_name, int32_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_INT32));
 }
 
+/**
+ * @brief icmap_set_uint32_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint32_r(const icmap_map_t map, const char *key_name, uint32_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_UINT32));
 }
 
+/**
+ * @brief icmap_set_int64_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int64_r(const icmap_map_t map, const char *key_name, int64_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_INT64));
 }
 
+/**
+ * @brief icmap_set_uint64_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint64_r(const icmap_map_t map, const char *key_name, uint64_t value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_UINT64));
 }
 
+/**
+ * @brief icmap_set_float_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_float_r(const icmap_map_t map, const char *key_name, float value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_FLOAT));
 }
 
+/**
+ * @brief icmap_set_double_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_double_r(const icmap_map_t map, const char *key_name, double value)
 {
 
 	return (icmap_set_r(map, key_name, &value, sizeof(value), ICMAP_VALUETYPE_DOUBLE));
 }
 
+/**
+ * @brief icmap_set_string_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_string_r(const icmap_map_t map, const char *key_name, const char *value)
 {
 
@@ -577,72 +766,144 @@ cs_error_t icmap_set_string_r(const icmap_map_t map, const char *key_name, const
 	return (icmap_set_r(map, key_name, value, strlen(value), ICMAP_VALUETYPE_STRING));
 }
 
+/**
+ * @brief icmap_set_int8
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int8(const char *key_name, int8_t value)
 {
 
 	return (icmap_set_int8_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_uint8
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint8(const char *key_name, uint8_t value)
 {
 
 	return (icmap_set_uint8_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_int16
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int16(const char *key_name, int16_t value)
 {
 
 	return (icmap_set_int16_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_uint16
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint16(const char *key_name, uint16_t value)
 {
 
 	return (icmap_set_uint16_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_int32
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int32(const char *key_name, int32_t value)
 {
 
 	return (icmap_set_int32_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_uint32
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint32(const char *key_name, uint32_t value)
 {
 
 	return (icmap_set_uint32_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_int64
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_int64(const char *key_name, int64_t value)
 {
 
 	return (icmap_set_int64_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_uint64
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_uint64(const char *key_name, uint64_t value)
 {
 
 	return (icmap_set_uint64_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_float
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_float(const char *key_name, float value)
 {
 
 	return (icmap_set_float_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_double
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_double(const char *key_name, double value)
 {
 
 	return (icmap_set_double_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_set_string
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t icmap_set_string(const char *key_name, const char *value)
 {
 
 	return (icmap_set_string_r(icmap_global_map, key_name, value));
 }
 
+/**
+ * @brief icmap_delete_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_delete_r(const icmap_map_t map, const char *key_name)
 {
 	struct icmap_item *item;
@@ -663,12 +924,26 @@ cs_error_t icmap_delete_r(const icmap_map_t map, const char *key_name)
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_delete
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_delete(const char *key_name)
 {
 
 	return (icmap_delete_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_get_ref_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 static cs_error_t icmap_get_ref_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -702,6 +977,15 @@ static cs_error_t icmap_get_ref_r(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_get_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t icmap_get_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -735,6 +1019,14 @@ cs_error_t icmap_get_r(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_get
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t icmap_get(
 	const char *key_name,
 	void *value,
@@ -745,6 +1037,14 @@ cs_error_t icmap_get(
 	return (icmap_get_r(icmap_global_map, key_name, value, value_len, type));
 }
 
+/**
+ * @brief icmap_get_int_r
+ * @param map
+ * @param key_name
+ * @param value
+ * @param type
+ * @return
+ */
 static cs_error_t icmap_get_int_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -772,126 +1072,262 @@ static cs_error_t icmap_get_int_r(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_get_int8_r
+ * @param map
+ * @param key_name
+ * @param i8
+ * @return
+ */
 cs_error_t icmap_get_int8_r(const icmap_map_t map, const char *key_name, int8_t *i8)
 {
 
 	return (icmap_get_int_r(map, key_name, i8, ICMAP_VALUETYPE_INT8));
 }
 
+/**
+ * @brief icmap_get_uint8_r
+ * @param map
+ * @param key_name
+ * @param u8
+ * @return
+ */
 cs_error_t icmap_get_uint8_r(const icmap_map_t map, const char *key_name, uint8_t *u8)
 {
 
 	return (icmap_get_int_r(map, key_name, u8, ICMAP_VALUETYPE_UINT8));
 }
 
+/**
+ * @brief icmap_get_int16_r
+ * @param map
+ * @param key_name
+ * @param i16
+ * @return
+ */
 cs_error_t icmap_get_int16_r(const icmap_map_t map, const char *key_name, int16_t *i16)
 {
 
 	return (icmap_get_int_r(map, key_name, i16, ICMAP_VALUETYPE_INT16));
 }
 
+/**
+ * @brief icmap_get_uint16_r
+ * @param map
+ * @param key_name
+ * @param u16
+ * @return
+ */
 cs_error_t icmap_get_uint16_r(const icmap_map_t map, const char *key_name, uint16_t *u16)
 {
 
 	return (icmap_get_int_r(map, key_name, u16, ICMAP_VALUETYPE_UINT16));
 }
 
+/**
+ * @brief icmap_get_int32_r
+ * @param map
+ * @param key_name
+ * @param i32
+ * @return
+ */
 cs_error_t icmap_get_int32_r(const icmap_map_t map, const char *key_name, int32_t *i32)
 {
 
 	return (icmap_get_int_r(map, key_name, i32, ICMAP_VALUETYPE_INT32));
 }
 
+/**
+ * @brief icmap_get_uint32_r
+ * @param map
+ * @param key_name
+ * @param u32
+ * @return
+ */
 cs_error_t icmap_get_uint32_r(const icmap_map_t map, const char *key_name, uint32_t *u32)
 {
 
 	return (icmap_get_int_r(map, key_name, u32, ICMAP_VALUETYPE_UINT32));
 }
 
+/**
+ * @brief icmap_get_int64_r
+ * @param map
+ * @param key_name
+ * @param i64
+ * @return
+ */
 cs_error_t icmap_get_int64_r(const icmap_map_t map, const char *key_name, int64_t *i64)
 {
 
 	return(icmap_get_int_r(map, key_name, i64, ICMAP_VALUETYPE_INT64));
 }
 
+/**
+ * @brief icmap_get_uint64_r
+ * @param map
+ * @param key_name
+ * @param u64
+ * @return
+ */
 cs_error_t icmap_get_uint64_r(const icmap_map_t map, const char *key_name, uint64_t *u64)
 {
 
 	return (icmap_get_int_r(map, key_name, u64, ICMAP_VALUETYPE_UINT64));
 }
 
+/**
+ * @brief icmap_get_float_r
+ * @param map
+ * @param key_name
+ * @param flt
+ * @return
+ */
 cs_error_t icmap_get_float_r(const icmap_map_t map, const char *key_name, float *flt)
 {
 
 	return (icmap_get_int_r(map, key_name, flt, ICMAP_VALUETYPE_FLOAT));
 }
 
+/**
+ * @brief icmap_get_double_r
+ * @param map
+ * @param key_name
+ * @param dbl
+ * @return
+ */
 cs_error_t icmap_get_double_r(const icmap_map_t map, const char *key_name, double *dbl)
 {
 
 	return (icmap_get_int_r(map, key_name, dbl, ICMAP_VALUETYPE_DOUBLE));
 }
 
+/**
+ * @brief icmap_get_int8
+ * @param key_name
+ * @param i8
+ * @return
+ */
 cs_error_t icmap_get_int8(const char *key_name, int8_t *i8)
 {
 
 	return (icmap_get_int8_r(icmap_global_map, key_name, i8));
 }
 
+/**
+ * @brief icmap_get_uint8
+ * @param key_name
+ * @param u8
+ * @return
+ */
 cs_error_t icmap_get_uint8(const char *key_name, uint8_t *u8)
 {
 
 	return (icmap_get_uint8_r(icmap_global_map, key_name, u8));
 }
 
+/**
+ * @brief icmap_get_int16
+ * @param key_name
+ * @param i16
+ * @return
+ */
 cs_error_t icmap_get_int16(const char *key_name, int16_t *i16)
 {
 
 	return (icmap_get_int16_r(icmap_global_map, key_name, i16));
 }
 
+/**
+ * @brief icmap_get_uint16
+ * @param key_name
+ * @param u16
+ * @return
+ */
 cs_error_t icmap_get_uint16(const char *key_name, uint16_t *u16)
 {
 
 	return (icmap_get_uint16_r(icmap_global_map, key_name, u16));
 }
 
+/**
+ * @brief icmap_get_int32
+ * @param key_name
+ * @param i32
+ * @return
+ */
 cs_error_t icmap_get_int32(const char *key_name, int32_t *i32)
 {
 
 	return (icmap_get_int32_r(icmap_global_map, key_name, i32));
 }
 
+/**
+ * @brief icmap_get_uint32
+ * @param key_name
+ * @param u32
+ * @return
+ */
 cs_error_t icmap_get_uint32(const char *key_name, uint32_t *u32)
 {
 
 	return (icmap_get_uint32_r(icmap_global_map, key_name, u32));
 }
 
+/**
+ * @brief icmap_get_int64
+ * @param key_name
+ * @param i64
+ * @return
+ */
 cs_error_t icmap_get_int64(const char *key_name, int64_t *i64)
 {
 
 	return(icmap_get_int64_r(icmap_global_map, key_name, i64));
 }
 
+/**
+ * @brief icmap_get_uint64
+ * @param key_name
+ * @param u64
+ * @return
+ */
 cs_error_t icmap_get_uint64(const char *key_name, uint64_t *u64)
 {
 
 	return (icmap_get_uint64_r(icmap_global_map, key_name, u64));
 }
 
+/**
+ * @brief icmap_get_float
+ * @param key_name
+ * @param flt
+ * @return
+ */
 cs_error_t icmap_get_float(const char *key_name, float *flt)
 {
 
 	return (icmap_get_float_r(icmap_global_map, key_name, flt));
 }
 
+/**
+ * @brief icmap_get_double
+ * @param key_name
+ * @param dbl
+ * @return
+ */
 cs_error_t icmap_get_double(const char *key_name, double *dbl)
 {
 
 	return (icmap_get_double_r(icmap_global_map, key_name, dbl));
 }
 
+/**
+ * @brief icmap_get_string
+ * @param key_name
+ * @param str
+ * @return
+ */
 cs_error_t icmap_get_string(const char *key_name, char **str)
 {
 	cs_error_t res;
@@ -926,6 +1362,13 @@ return_error:
 	return (res);
 }
 
+/**
+ * @brief icmap_adjust_int_r
+ * @param map
+ * @param key_name
+ * @param step
+ * @return
+ */
 cs_error_t icmap_adjust_int_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -983,6 +1426,12 @@ cs_error_t icmap_adjust_int_r(
 	return (err);
 }
 
+/**
+ * @brief icmap_adjust_int
+ * @param key_name
+ * @param step
+ * @return
+ */
 cs_error_t icmap_adjust_int(
 	const char *key_name,
 	int32_t step)
@@ -991,6 +1440,13 @@ cs_error_t icmap_adjust_int(
 	return (icmap_adjust_int_r(icmap_global_map, key_name, step));
 }
 
+/**
+ * @brief icmap_fast_adjust_int_r
+ * @param map
+ * @param key_name
+ * @param step
+ * @return
+ */
 cs_error_t icmap_fast_adjust_int_r(
 	const icmap_map_t map,
 	const char *key_name,
@@ -1040,6 +1496,12 @@ cs_error_t icmap_fast_adjust_int_r(
 	return (err);
 }
 
+/**
+ * @brief icmap_fast_adjust_int
+ * @param key_name
+ * @param step
+ * @return
+ */
 cs_error_t icmap_fast_adjust_int(
 	const char *key_name,
 	int32_t step)
@@ -1048,57 +1510,119 @@ cs_error_t icmap_fast_adjust_int(
 	return (icmap_fast_adjust_int_r(icmap_global_map, key_name, step));
 }
 
+/**
+ * @brief icmap_inc_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_inc_r(const icmap_map_t map, const char *key_name)
 {
 	return (icmap_adjust_int_r(map, key_name, 1));
 }
 
+/**
+ * @brief icmap_inc
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_inc(const char *key_name)
 {
 	return (icmap_inc_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_dec_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_dec_r(const icmap_map_t map, const char *key_name)
 {
 	return (icmap_adjust_int_r(map, key_name, -1));
 }
 
+/**
+ * @brief icmap_dec
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_dec(const char *key_name)
 {
 	return (icmap_dec_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_fast_inc_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_fast_inc_r(const icmap_map_t map, const char *key_name)
 {
 	return (icmap_fast_adjust_int_r(map, key_name, 1));
 }
 
+/**
+ * @brief icmap_fast_inc
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_fast_inc(const char *key_name)
 {
 	return (icmap_fast_inc_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_fast_dec_r
+ * @param map
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_fast_dec_r(const icmap_map_t map, const char *key_name)
 {
 	return (icmap_fast_adjust_int_r(map, key_name, -1));
 }
 
+/**
+ * @brief icmap_fast_dec
+ * @param key_name
+ * @return
+ */
 cs_error_t icmap_fast_dec(const char *key_name)
 {
 	return (icmap_fast_dec_r(icmap_global_map, key_name));
 }
 
+/**
+ * @brief icmap_iter_init_r
+ * @param map
+ * @param prefix
+ * @return
+ */
 icmap_iter_t icmap_iter_init_r(const icmap_map_t map, const char *prefix)
 {
 	return (qb_map_pref_iter_create(map->qb_map, prefix));
 }
 
+/**
+ * @brief icmap_iter_init
+ * @param prefix
+ * @return
+ */
 icmap_iter_t icmap_iter_init(const char *prefix)
 {
 	return (icmap_iter_init_r(icmap_global_map, prefix));
 }
 
 
+/**
+ * @brief icmap_iter_next
+ * @param iter
+ * @param value_len
+ * @param type
+ * @return
+ */
 const char *icmap_iter_next(icmap_iter_t iter, size_t *value_len, icmap_value_types_t *type)
 {
 	struct icmap_item *item;
@@ -1120,11 +1644,23 @@ const char *icmap_iter_next(icmap_iter_t iter, size_t *value_len, icmap_value_ty
 	return (res);
 }
 
+/**
+ * @brief icmap_iter_finalize
+ * @param iter
+ */
 void icmap_iter_finalize(icmap_iter_t iter)
 {
 	qb_map_iter_free(iter);
 }
 
+/**
+ * @brief icmap_notify_fn
+ * @param event
+ * @param key
+ * @param old_value
+ * @param value
+ * @param user_data
+ */
 static void icmap_notify_fn(uint32_t event, char *key, void *old_value, void *value, void *user_data)
 {
 	icmap_track_t icmap_track = (icmap_track_t)user_data;
@@ -1163,6 +1699,15 @@ static void icmap_notify_fn(uint32_t event, char *key, void *old_value, void *va
 			icmap_track->user_data);
 }
 
+/**
+ * @brief icmap_track_add
+ * @param key_name
+ * @param track_type
+ * @param notify_fn
+ * @param user_data
+ * @param icmap_track
+ * @return
+ */
 cs_error_t icmap_track_add(
 	const char *key_name,
 	int32_t track_type,
@@ -1208,6 +1753,11 @@ cs_error_t icmap_track_add(
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_track_delete
+ * @param icmap_track
+ * @return
+ */
 cs_error_t icmap_track_delete(icmap_track_t icmap_track)
 {
 	int32_t err;
@@ -1224,11 +1774,23 @@ cs_error_t icmap_track_delete(icmap_track_t icmap_track)
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_track_get_user_data
+ * @param icmap_track
+ * @return
+ */
 void *icmap_track_get_user_data(icmap_track_t icmap_track)
 {
 	return (icmap_track->user_data);
 }
 
+/**
+ * @brief icmap_set_ro_access
+ * @param key_name
+ * @param prefix
+ * @param ro_access
+ * @return
+ */
 cs_error_t icmap_set_ro_access(const char *key_name, int prefix, int ro_access)
 {
 	struct qb_list_head *iter, *tmp_iter;
@@ -1276,6 +1838,11 @@ cs_error_t icmap_set_ro_access(const char *key_name, int prefix, int ro_access)
 	return (CS_OK);
 }
 
+/**
+ * @brief icmap_is_key_ro
+ * @param key_name
+ * @return
+ */
 int icmap_is_key_ro(const char *key_name)
 {
 	struct qb_list_head *iter;
@@ -1302,6 +1869,12 @@ int icmap_is_key_ro(const char *key_name)
 
 }
 
+/**
+ * @brief icmap_copy_map
+ * @param dst_map
+ * @param src_map
+ * @return
+ */
 cs_error_t icmap_copy_map(icmap_map_t dst_map, const icmap_map_t src_map)
 {
 	icmap_iter_t iter;

--- a/exec/ipc_glue.c
+++ b/exec/ipc_glue.c
@@ -117,6 +117,11 @@ static struct qb_ipcs_service_handlers corosync_service_funcs = {
 	.connection_destroyed	= cs_ipcs_connection_destroyed,
 };
 
+/**
+ * @brief cs_ipcs_serv_short_name
+ * @param service_id
+ * @return
+ */
 static const char* cs_ipcs_serv_short_name(int32_t service_id)
 {
 	const char *name;
@@ -152,11 +157,20 @@ static const char* cs_ipcs_serv_short_name(int32_t service_id)
 	return name;
 }
 
+/**
+ * @brief cs_ipc_allow_connections
+ * @param allow
+ */
 void cs_ipc_allow_connections(int32_t allow)
 {
 	ipc_allow_connections = allow;
 }
 
+/**
+ * @brief cs_ipcs_service_destroy
+ * @param service_id
+ * @return
+ */
 int32_t cs_ipcs_service_destroy(int32_t service_id)
 {
 	if (ipcs_mapper[service_id].inst) {
@@ -166,6 +180,13 @@ int32_t cs_ipcs_service_destroy(int32_t service_id)
 	return 0;
 }
 
+/**
+ * @brief cs_ipcs_connection_accept
+ * @param c
+ * @param euid
+ * @param egid
+ * @return
+ */
 static int32_t cs_ipcs_connection_accept (qb_ipcs_connection_t *c, uid_t euid, gid_t egid)
 {
 	int32_t service = qb_ipcs_service_id_get(c);
@@ -211,6 +232,13 @@ static int32_t cs_ipcs_connection_accept (qb_ipcs_connection_t *c, uid_t euid, g
 	return -EACCES;
 }
 
+/**
+ * @brief pid_to_name
+ * @param pid
+ * @param out_name
+ * @param name_len
+ * @return
+ */
 static char * pid_to_name (pid_t pid, char *out_name, size_t name_len)
 {
 	char *name;
@@ -255,6 +283,9 @@ static char * pid_to_name (pid_t pid, char *out_name, size_t name_len)
 	return out_name;
 }
 
+/**
+ * @brief The cs_ipcs_conn_context struct
+ */
 struct cs_ipcs_conn_context {
 	char *icmap_path;
 	struct qb_list_head outq_head;
@@ -266,6 +297,10 @@ struct cs_ipcs_conn_context {
 	char data[1];
 };
 
+/**
+ * @brief cs_ipcs_connection_created
+ * @param c
+ */
 static void cs_ipcs_connection_created(qb_ipcs_connection_t *c)
 {
 	int32_t service = 0;
@@ -372,16 +407,29 @@ static void cs_ipcs_connection_created(qb_ipcs_connection_t *c)
 	icmap_set_uint64(key_name, 0);
 }
 
+/**
+ * @brief cs_ipc_refcnt_inc
+ * @param conn
+ */
 void cs_ipc_refcnt_inc(void *conn)
 {
 	qb_ipcs_connection_ref(conn);
 }
 
+/**
+ * @brief cs_ipc_refcnt_dec
+ * @param conn
+ */
 void cs_ipc_refcnt_dec(void *conn)
 {
 	qb_ipcs_connection_unref(conn);
 }
 
+/**
+ * @brief cs_ipcs_private_data_get
+ * @param conn
+ * @return
+ */
 void *cs_ipcs_private_data_get(void *conn)
 {
 	struct cs_ipcs_conn_context *cnx;
@@ -389,6 +437,10 @@ void *cs_ipcs_private_data_get(void *conn)
 	return &cnx->data[0];
 }
 
+/**
+ * @brief cs_ipcs_connection_destroyed
+ * @param c
+ */
 static void cs_ipcs_connection_destroyed (qb_ipcs_connection_t *c)
 {
 	struct cs_ipcs_conn_context *context;
@@ -410,6 +462,11 @@ static void cs_ipcs_connection_destroyed (qb_ipcs_connection_t *c)
 	}
 }
 
+/**
+ * @brief cs_ipcs_connection_closed
+ * @param c
+ * @return
+ */
 static int32_t cs_ipcs_connection_closed (qb_ipcs_connection_t *c)
 {
 	int32_t res = 0;
@@ -443,6 +500,13 @@ static int32_t cs_ipcs_connection_closed (qb_ipcs_connection_t *c)
 	return 0;
 }
 
+/**
+ * @brief cs_ipcs_response_iov_send
+ * @param conn
+ * @param iov
+ * @param iov_len
+ * @return
+ */
 int cs_ipcs_response_iov_send (void *conn,
 	const struct iovec *iov,
 	unsigned int iov_len)
@@ -454,6 +518,13 @@ int cs_ipcs_response_iov_send (void *conn,
 	return rc;
 }
 
+/**
+ * @brief cs_ipcs_response_send
+ * @param conn
+ * @param msg
+ * @param mlen
+ * @return
+ */
 int cs_ipcs_response_send(void *conn, const void *msg, size_t mlen)
 {
 	int32_t rc = qb_ipcs_response_send(conn, msg, mlen);
@@ -463,6 +534,10 @@ int cs_ipcs_response_send(void *conn, const void *msg, size_t mlen)
 	return rc;
 }
 
+/**
+ * @brief outq_flush
+ * @param data
+ */
 static void outq_flush (void *data)
 {
 	qb_ipcs_connection_t *conn = data;
@@ -501,6 +576,12 @@ static void outq_flush (void *data)
 	}
 }
 
+/**
+ * @brief msg_send_or_queue
+ * @param conn
+ * @param iov
+ * @param iov_len
+ */
 static void msg_send_or_queue(qb_ipcs_connection_t *conn, const struct iovec *iov, uint32_t iov_len)
 {
 	int32_t rc = 0;
@@ -554,6 +635,13 @@ static void msg_send_or_queue(qb_ipcs_connection_t *conn, const struct iovec *io
 	context->queued++;
 }
 
+/**
+ * @brief cs_ipcs_dispatch_send
+ * @param conn
+ * @param msg
+ * @param mlen
+ * @return
+ */
 int cs_ipcs_dispatch_send(void *conn, const void *msg, size_t mlen)
 {
 	struct iovec iov;
@@ -563,6 +651,13 @@ int cs_ipcs_dispatch_send(void *conn, const void *msg, size_t mlen)
 	return 0;
 }
 
+/**
+ * @brief cs_ipcs_dispatch_iov_send
+ * @param conn
+ * @param iov
+ * @param iov_len
+ * @return
+ */
 int cs_ipcs_dispatch_iov_send (void *conn,
 	const struct iovec *iov,
 	unsigned int iov_len)
@@ -571,6 +666,13 @@ int cs_ipcs_dispatch_iov_send (void *conn,
 	return 0;
 }
 
+/**
+ * @brief cs_ipcs_msg_process
+ * @param c
+ * @param data
+ * @param size
+ * @return
+ */
 static int32_t cs_ipcs_msg_process(qb_ipcs_connection_t *c,
 		void *data, size_t size)
 {
@@ -645,29 +747,63 @@ static int32_t cs_ipcs_msg_process(qb_ipcs_connection_t *c,
 	return res;
 }
 
-
+/**
+ * @brief cs_ipcs_job_add
+ * @param p
+ * @param data
+ * @param fn
+ * @return
+ */
 static int32_t cs_ipcs_job_add(enum qb_loop_priority p,	void *data, qb_loop_job_dispatch_fn fn)
 {
 	return qb_loop_job_add(cs_poll_handle_get(), p, data, fn);
 }
 
+/**
+ * @brief cs_ipcs_dispatch_add
+ * @param p
+ * @param fd
+ * @param events
+ * @param data
+ * @param fn
+ * @return
+ */
 static int32_t cs_ipcs_dispatch_add(enum qb_loop_priority p, int32_t fd, int32_t events,
 	void *data, qb_ipcs_dispatch_fn_t fn)
 {
 	return qb_loop_poll_add(cs_poll_handle_get(), p, fd, events, data, fn);
 }
 
+/**
+ * @brief cs_ipcs_dispatch_mod
+ * @param p
+ * @param fd
+ * @param events
+ * @param data
+ * @param fn
+ * @return
+ */
 static int32_t cs_ipcs_dispatch_mod(enum qb_loop_priority p, int32_t fd, int32_t events,
 	void *data, qb_ipcs_dispatch_fn_t fn)
 {
 	return qb_loop_poll_mod(cs_poll_handle_get(), p, fd, events, data, fn);
 }
 
+/**
+ * @brief cs_ipcs_dispatch_del
+ * @param fd
+ * @return
+ */
 static int32_t cs_ipcs_dispatch_del(int32_t fd)
 {
 	return qb_loop_poll_del(cs_poll_handle_get(), fd);
 }
 
+/**
+ * @brief cs_ipcs_low_fds_event
+ * @param not_enough
+ * @param fds_available
+ */
 static void cs_ipcs_low_fds_event(int32_t not_enough, int32_t fds_available)
 {
 	ipc_not_enough_fds_left = not_enough;
@@ -681,12 +817,23 @@ static void cs_ipcs_low_fds_event(int32_t not_enough, int32_t fds_available)
 	}
 }
 
+/**
+ * @brief cs_ipcs_q_level_get
+ * @return
+ */
 int32_t cs_ipcs_q_level_get(void)
 {
 	return ipc_fc_totem_queue_level;
 }
 
+/**
+ * @brief ipcs_check_for_flow_control_timer
+ */
 static qb_loop_timer_handle ipcs_check_for_flow_control_timer;
+
+/**
+ * @brief cs_ipcs_check_for_flow_control
+ */
 static void cs_ipcs_check_for_flow_control(void)
 {
 	int32_t i;
@@ -732,24 +879,40 @@ static void cs_ipcs_check_for_flow_control(void)
 	}
 }
 
+/**
+ * @brief cs_ipcs_fc_quorum_changed
+ * @param quorate
+ * @param context
+ */
 static void cs_ipcs_fc_quorum_changed(int quorate, void *context)
 {
 	ipc_fc_is_quorate = quorate;
 	cs_ipcs_check_for_flow_control();
 }
 
+/**
+ * @brief cs_ipcs_totem_queue_level_changed
+ * @param level
+ */
 static void cs_ipcs_totem_queue_level_changed(enum totem_q_level level)
 {
 	ipc_fc_totem_queue_level = level;
 	cs_ipcs_check_for_flow_control();
 }
 
+/**
+ * @brief cs_ipcs_sync_state_changed
+ * @param sync_in_process
+ */
 void cs_ipcs_sync_state_changed(int32_t sync_in_process)
 {
 	ipc_fc_sync_in_process = sync_in_process;
 	cs_ipcs_check_for_flow_control();
 }
 
+/**
+ * @brief cs_ipcs_stats_update
+ */
 void cs_ipcs_stats_update(void)
 {
 	int32_t i;
@@ -810,6 +973,10 @@ void cs_ipcs_stats_update(void)
 	}
 }
 
+/**
+ * @brief cs_get_ipc_type
+ * @return
+ */
 static enum qb_ipc_type cs_get_ipc_type (void)
 {
 	char *str;
@@ -847,6 +1014,11 @@ static enum qb_ipc_type cs_get_ipc_type (void)
 	return ret;
 }
 
+/**
+ * @brief cs_ipcs_service_init
+ * @param service
+ * @return
+ */
 const char *cs_ipcs_service_init(struct corosync_service_engine *service)
 {
 	const char *serv_short_name;
@@ -887,6 +1059,9 @@ const char *cs_ipcs_service_init(struct corosync_service_engine *service)
 	return NULL;
 }
 
+/**
+ * @brief cs_ipcs_init
+ */
 void cs_ipcs_init(void)
 {
 	api = apidef_get ();

--- a/exec/logconfig.c
+++ b/exec/logconfig.c
@@ -76,6 +76,14 @@ static char error_string_response[512];
  *
  * Returns: 0 on success, -1 on failure
  **/
+/**
+ * @brief insert_into_buffer
+ * @param target_buffer
+ * @param bufferlen
+ * @param entry
+ * @param after
+ * @return
+ */
 static int insert_into_buffer(
 	char *target_buffer,
 	size_t bufferlen,
@@ -129,6 +137,11 @@ static int insert_into_buffer(
 /*
  * format set is the only global specific option that
  * doesn't apply at system/subsystem level.
+ */
+/**
+ * @brief corosync_main_config_format_set
+ * @param error_string
+ * @return
  */
 static int corosync_main_config_format_set (
 	const char **error_string)
@@ -228,6 +241,17 @@ parse_error:
 	return (-1);
 }
 
+/**
+ * @brief corosync_main_config_log_destination_set
+ * @param path
+ * @param key
+ * @param subsys
+ * @param error_string
+ * @param mode_mask
+ * @param deprecated
+ * @param replacement
+ * @return
+ */
 static int corosync_main_config_log_destination_set (
 	const char *path,
 	const char *key,
@@ -297,6 +321,13 @@ parse_error:
 	return (-1);
 }
 
+/**
+ * @brief corosync_main_config_set
+ * @param path
+ * @param subsys
+ * @param error_string
+ * @return
+ */
 static int corosync_main_config_set (
 	const char *path,
 	const char *subsys,
@@ -502,6 +533,11 @@ parse_error:
 	return (-1);
 }
 
+/**
+ * @brief corosync_main_config_read_logging
+ * @param error_string
+ * @return
+ */
 static int corosync_main_config_read_logging (
 	const char **error_string)
 {
@@ -569,6 +605,14 @@ parse_error:
 }
 
 #ifdef LOGCONFIG_USE_ICMAP 
+/**
+ * @brief main_logging_notify
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void main_logging_notify(
 		int32_t event,
 		const char *key_name,
@@ -576,6 +620,16 @@ static void main_logging_notify(
 		struct icmap_notify_value old_val,
 		void *user_data)
 #else
+/**
+ * @brief main_logging_notify
+ * @param cmap_handle_unused
+ * @param cmap_track_handle_unused
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void main_logging_notify(
 		cmap_handle_t cmap_handle_unused,
 		cmap_handle_t cmap_track_handle_unused,
@@ -614,6 +668,10 @@ static void main_logging_notify(
 }
 
 #ifdef LOGCONFIG_USE_ICMAP
+
+/**
+ * @brief add_logsys_config_notification
+ */
 static void add_logsys_config_notification(void)
 {
 	icmap_track_t icmap_track = NULL;
@@ -631,6 +689,10 @@ static void add_logsys_config_notification(void)
 			&icmap_track);
 }
 #else
+
+/**
+ * @brief add_logsys_config_notification
+ */
 static void add_logsys_config_notification(void)
 {
 	cmap_track_handle_t cmap_track;

--- a/exec/logsys.c
+++ b/exec/logsys.c
@@ -83,6 +83,10 @@ static struct syslog_names prioritynames[] =
 /*
  * need unlogical order to preserve 64bit alignment
  */
+
+/**
+ * @brief The logsys_logger struct
+ */
 struct logsys_logger {
 	char subsys[LOGSYS_MAX_SUBSYS_NAMELEN];	/* subsystem name */
 	char *logfile;				/* log to file */
@@ -118,6 +122,11 @@ static char *format_buffer=NULL;
 
 static int logsys_thread_started = 0;
 
+/**
+ * @brief _logsys_config_subsys_get_unlocked
+ * @param subsys
+ * @return
+ */
 static int _logsys_config_subsys_get_unlocked (const char *subsys)
 {
 	unsigned int i;
@@ -139,6 +148,13 @@ static int _logsys_config_subsys_get_unlocked (const char *subsys)
 /*
  * we need a version that can work when somebody else is already
  * holding a config mutex lock or we will never get out of here
+ */
+/**
+ * @brief logsys_config_file_set_unlocked
+ * @param subsysid
+ * @param error_string
+ * @param file
+ * @return
  */
 static int logsys_config_file_set_unlocked (
 		int subsysid,
@@ -251,6 +267,11 @@ static int logsys_config_file_set_unlocked (
 	return (0);
 }
 
+/**
+ * @brief logsys_subsys_init
+ * @param subsys
+ * @param subsysid
+ */
 static void logsys_subsys_init (
 		const char *subsys,
 		int subsysid)
@@ -272,6 +293,11 @@ static void logsys_subsys_init (
 	logsys_loggers[subsysid].file_idx = 0;
 }
 
+/**
+ * @brief _logsys_tags_stringify
+ * @param tags
+ * @return
+ */
 static const char *_logsys_tags_stringify(uint32_t tags)
 {
 	if (tags == QB_LOG_TAG_LIBQB_MSG) {
@@ -281,6 +307,9 @@ static const char *_logsys_tags_stringify(uint32_t tags)
 	}
 }
 
+/**
+ * @brief logsys_system_fini
+ */
 void logsys_system_fini (void)
 {
 	int i;
@@ -299,6 +328,14 @@ void logsys_system_fini (void)
  * Internal API - exported
  */
 
+/**
+ * @brief _logsys_system_setup
+ * @param mainsystem
+ * @param mode
+ * @param syslog_facility
+ * @param syslog_priority
+ * @return
+ */
 int _logsys_system_setup(
 	const char *mainsystem,
 	unsigned int mode,
@@ -410,6 +447,11 @@ int _logsys_system_setup(
 }
 
 
+/**
+ * @brief _logsys_subsys_filename_add
+ * @param s
+ * @param filename
+ */
 static void _logsys_subsys_filename_add (int32_t s, const char *filename)
 {
 	int i;
@@ -432,6 +474,12 @@ static void _logsys_subsys_filename_add (int32_t s, const char *filename)
 	}
 }
 
+/**
+ * @brief _logsys_subsys_create
+ * @param subsys
+ * @param filename
+ * @return
+ */
 int _logsys_subsys_create (const char *subsys, const char *filename)
 {
 	int i;
@@ -466,6 +514,11 @@ int _logsys_subsys_create (const char *subsys, const char *filename)
 	return i;
 }
 
+/**
+ * @brief _logsys_config_subsys_get
+ * @param subsys
+ * @return
+ */
 int _logsys_config_subsys_get (const char *subsys)
 {
 	unsigned int i;
@@ -479,6 +532,12 @@ int _logsys_config_subsys_get (const char *subsys)
 	return i;
 }
 
+/**
+ * @brief _logsys_config_mode_set_unlocked
+ * @param subsysid
+ * @param new_mode
+ * @return
+ */
 static int32_t _logsys_config_mode_set_unlocked(int32_t subsysid, uint32_t new_mode)
 {
 	if ( logsys_loggers[subsysid].mode == new_mode) {
@@ -502,6 +561,12 @@ static int32_t _logsys_config_mode_set_unlocked(int32_t subsysid, uint32_t new_m
 	return 0;
 }
 
+/**
+ * @brief logsys_config_mode_set
+ * @param subsys
+ * @param mode
+ * @return
+ */
 int logsys_config_mode_set (const char *subsys, unsigned int mode)
 {
 	int i;
@@ -524,6 +589,11 @@ int logsys_config_mode_set (const char *subsys, unsigned int mode)
 	return i;
 }
 
+/**
+ * @brief logsys_config_mode_get
+ * @param subsys
+ * @return
+ */
 unsigned int logsys_config_mode_get (const char *subsys)
 {
 	int i;
@@ -536,6 +606,13 @@ unsigned int logsys_config_mode_get (const char *subsys)
 	return logsys_loggers[i].mode;
 }
 
+/**
+ * @brief logsys_config_file_set
+ * @param subsys
+ * @param error_string
+ * @param file
+ * @return
+ */
 int logsys_config_file_set (
 		const char *subsys,
 		const char **error_string,
@@ -566,6 +643,11 @@ int logsys_config_file_set (
 	return res;
 }
 
+/**
+ * @brief logsys_file_format_get
+ * @param file_format
+ * @param buf_len
+ */
 static void
 logsys_file_format_get(char* file_format, int buf_len)
 {
@@ -582,6 +664,11 @@ logsys_file_format_get(char* file_format, int buf_len)
 	}
 }
 
+/**
+ * @brief logsys_format_set
+ * @param format
+ * @return
+ */
 int logsys_format_set (const char *format)
 {
 	int i;
@@ -640,11 +727,21 @@ int logsys_format_set (const char *format)
 	return 0;
 }
 
+/**
+ * @brief logsys_format_get
+ * @return
+ */
 char *logsys_format_get (void)
 {
 	return format_buffer;
 }
 
+/**
+ * @brief logsys_config_syslog_facility_set
+ * @param subsys
+ * @param facility
+ * @return
+ */
 int logsys_config_syslog_facility_set (
 	const char *subsys,
 	unsigned int facility)
@@ -652,6 +749,12 @@ int logsys_config_syslog_facility_set (
 	return qb_log_ctl(QB_LOG_SYSLOG, QB_LOG_CONF_FACILITY, facility);
 }
 
+/**
+ * @brief logsys_config_syslog_priority_set
+ * @param subsys
+ * @param priority
+ * @return
+ */
 int logsys_config_syslog_priority_set (
 	const char *subsys,
 	unsigned int priority)
@@ -679,6 +782,12 @@ int logsys_config_syslog_priority_set (
 	return i;
 }
 
+/**
+ * @brief logsys_config_logfile_priority_set
+ * @param subsys
+ * @param priority
+ * @return
+ */
 int logsys_config_logfile_priority_set (
 	const char *subsys,
 	unsigned int priority)
@@ -706,6 +815,11 @@ int logsys_config_logfile_priority_set (
 }
 
 
+/**
+ * @brief _logsys_config_apply_per_file
+ * @param s
+ * @param filename
+ */
 static void _logsys_config_apply_per_file(int32_t s, const char *filename)
 {
 	uint32_t syslog_priority = logsys_loggers[s].syslog_priority;
@@ -752,6 +866,10 @@ static void _logsys_config_apply_per_file(int32_t s, const char *filename)
 	}
 }
 
+/**
+ * @brief _logsys_config_apply_per_subsys
+ * @param s
+ */
 static void _logsys_config_apply_per_subsys(int32_t s)
 {
 	int32_t f;
@@ -766,6 +884,9 @@ static void _logsys_config_apply_per_subsys(int32_t s)
 	logsys_loggers[s].dirty = QB_FALSE;
 }
 
+/**
+ * @brief logsys_config_apply
+ */
 void logsys_config_apply(void)
 {
 	int32_t s;
@@ -778,6 +899,12 @@ void logsys_config_apply(void)
 	}
 }
 
+/**
+ * @brief logsys_config_debug_set
+ * @param subsys
+ * @param debug
+ * @return
+ */
 int logsys_config_debug_set (
 	const char *subsys,
 	unsigned int debug)
@@ -804,6 +931,11 @@ int logsys_config_debug_set (
 	return i;
 }
 
+/**
+ * @brief logsys_priority_id_get
+ * @param name
+ * @return
+ */
 int logsys_priority_id_get (const char *name)
 {
 	unsigned int i;
@@ -816,6 +948,10 @@ int logsys_priority_id_get (const char *name)
 	return (-1);
 }
 
+/**
+ * @brief logsys_thread_start
+ * @return
+ */
 int logsys_thread_start (void)
 {
 	int i;

--- a/exec/mon.c
+++ b/exec/mon.c
@@ -146,11 +146,21 @@ struct cs_fsm_entry mon_fsm_table[] = {
 	{ MON_S_FAILED,  MON_E_FAILURE,		NULL,			{-1} },
 };
 
+/**
+ * @brief mon_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *mon_get_service_engine_ver0 (void)
 {
 	return (&mon_service_engine);
 }
 
+/**
+ * @brief mon_res_state_to_str
+ * @param fsm
+ * @param state
+ * @return
+ */
 static const char * mon_res_state_to_str(struct cs_fsm* fsm,
 	int32_t state)
 {
@@ -168,6 +178,12 @@ static const char * mon_res_state_to_str(struct cs_fsm* fsm,
 	return NULL;
 }
 
+/**
+ * @brief mon_res_event_to_str
+ * @param fsm
+ * @param event
+ * @return
+ */
 static const char * mon_res_event_to_str(struct cs_fsm* fsm,
 	int32_t event)
 {
@@ -182,6 +198,15 @@ static const char * mon_res_event_to_str(struct cs_fsm* fsm,
 	return NULL;
 }
 
+/**
+ * @brief mon_fsm_cb
+ * @param fsm
+ * @param cb_event
+ * @param curr_state
+ * @param next_state
+ * @param fsm_event
+ * @param data
+ */
 static void mon_fsm_cb (struct cs_fsm *fsm, int cb_event, int32_t curr_state,
 	int32_t next_state, int32_t fsm_event, void *data)
 {
@@ -213,6 +238,12 @@ static void mon_fsm_cb (struct cs_fsm *fsm, int cb_event, int32_t curr_state,
 	}
 }
 
+/**
+ * @brief mon_fsm_state_set
+ * @param fsm
+ * @param next_state
+ * @param inst
+ */
 static void mon_fsm_state_set (struct cs_fsm* fsm,
 	enum mon_resource_state next_state, struct resource_instance* inst)
 {
@@ -234,6 +265,12 @@ static void mon_fsm_state_set (struct cs_fsm* fsm,
 }
 
 
+/**
+ * @brief mon_config_changed
+ * @param fsm
+ * @param event
+ * @param data
+ */
 static void mon_config_changed (struct cs_fsm* fsm, int32_t event, void * data)
 {
 	struct resource_instance * inst = (struct resource_instance *)data;
@@ -312,6 +349,12 @@ static void mon_config_changed (struct cs_fsm* fsm, int32_t event, void * data)
 	}
 }
 
+/**
+ * @brief mon_resource_failed
+ * @param fsm
+ * @param event
+ * @param data
+ */
 void mon_resource_failed (struct cs_fsm* fsm, int32_t event, void * data)
 {
 	struct resource_instance * inst = (struct resource_instance *)data;
@@ -319,6 +362,10 @@ void mon_resource_failed (struct cs_fsm* fsm, int32_t event, void * data)
 	mon_fsm_state_set (fsm, MON_S_FAILED, inst);
 }
 
+/**
+ * @brief percent_mem_used_get
+ * @return
+ */
 static int32_t percent_mem_used_get(void)
 {
 	sg_mem_stats *mem_stats;
@@ -343,6 +390,10 @@ static int32_t percent_mem_used_get(void)
 	return ((total - freemem) * 100) / total;
 }
 
+/**
+ * @brief mem_update_stats_fn
+ * @param data
+ */
 static void mem_update_stats_fn (void *data)
 {
 	struct resource_instance * inst = (struct resource_instance *)data;
@@ -368,6 +419,10 @@ static void mem_update_stats_fn (void *data)
 		inst, inst->update_stats_fn, &inst->timer_handle);
 }
 
+/**
+ * @brief min15_loadavg_get
+ * @return
+ */
 static double min15_loadavg_get(void)
 {
 	sg_load_stats *load_stats;
@@ -385,6 +440,10 @@ static double min15_loadavg_get(void)
 	return load_stats->min15;
 }
 
+/**
+ * @brief load_update_stats_fn
+ * @param data
+ */
 static void load_update_stats_fn (void *data)
 {
 	struct resource_instance * inst = (struct resource_instance *)data;
@@ -410,6 +469,14 @@ static void load_update_stats_fn (void *data)
 		inst, inst->update_stats_fn, &inst->timer_handle);
 }
 
+/**
+ * @brief mon_key_changed_cb
+ * @param event
+ * @param key_name
+ * @param new_value
+ * @param old_value
+ * @param user_data
+ */
 static void mon_key_changed_cb (
 	int32_t event,
 	const char *key_name,
@@ -442,6 +509,10 @@ static void mon_key_changed_cb (
 	}
 }
 
+/**
+ * @brief mon_instance_init
+ * @param inst
+ */
 static void mon_instance_init (struct resource_instance* inst)
 {
 	uint64_t tmp_value;
@@ -492,6 +563,11 @@ static void mon_instance_init (struct resource_instance* inst)
 			mon_key_changed_cb, inst, &icmap_track);
 }
 
+/**
+ * @brief mon_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *mon_exec_init_fn (struct corosync_api_v1 *corosync_api)
 {
 #ifdef HAVE_LIBSTATGRAB_GE_090

--- a/exec/pload.c
+++ b/exec/pload.c
@@ -172,6 +172,11 @@ do {								\
 /*
  * tell all cluster nodes to start mcasting
  */
+/**
+ * @brief pload_send_start
+ * @param count
+ * @param size
+ */
 static void pload_send_start (uint32_t count, uint32_t size)
 {
 	struct req_exec_pload_start req_exec_pload_start;
@@ -188,6 +193,11 @@ static void pload_send_start (uint32_t count, uint32_t size)
 
 /*
  * send N empty data messages of size X
+ */
+/**
+ * @brief pload_send_message
+ * @param arg
+ * @return
  */
 static int pload_send_message (const void *arg)
 {
@@ -226,6 +236,14 @@ static int pload_send_message (const void *arg)
 /*
  * hook into icmap to read config at runtime
  * we do NOT start by default, ever!
+ */
+/**
+ * @brief pload_read_config
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
  */
 static void pload_read_config(
 	int32_t event,
@@ -266,6 +284,11 @@ static void pload_read_config(
 /*
  * exec functions
  */
+/**
+ * @brief pload_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *pload_exec_init_fn (struct corosync_api_v1 *corosync_api)
 {
 	icmap_track_t pload_track = NULL;
@@ -290,6 +313,10 @@ static char *pload_exec_init_fn (struct corosync_api_v1 *corosync_api)
  * network messages/onwire handlers
  */
 
+/**
+ * @brief req_exec_pload_start_endian_convert
+ * @param msg
+ */
 static void req_exec_pload_start_endian_convert (void *msg)
 {
 	struct req_exec_pload_start *req_exec_pload_start = msg;
@@ -298,6 +325,11 @@ static void req_exec_pload_start_endian_convert (void *msg)
 	req_exec_pload_start->msg_size = swab32(req_exec_pload_start->msg_size);
 }
 
+/**
+ * @brief message_handler_req_exec_pload_start
+ * @param msg
+ * @param nodeid
+ */
 static void message_handler_req_exec_pload_start (
 	const void *msg,
 	unsigned int nodeid)
@@ -322,10 +354,19 @@ static void message_handler_req_exec_pload_start (
 		&start_mcasting_handle);
 }
 
+/**
+ * @brief req_exec_pload_mcast_endian_convert
+ * @param msg
+ */
 static void req_exec_pload_mcast_endian_convert (void *msg)
 {
 }
 
+/**
+ * @brief message_handler_req_exec_pload_mcast
+ * @param msg
+ * @param nodeid
+ */
 static void message_handler_req_exec_pload_mcast (
 	const void *msg,
 	unsigned int nodeid)

--- a/exec/quorum.c
+++ b/exec/quorum.c
@@ -62,6 +62,10 @@ LOGSYS_DECLARE_SUBSYS ("QUORUM");
 
 static struct quorum_callin_functions *corosync_quorum_fns = NULL;
 
+/**
+ * @brief corosync_quorum_is_quorate
+ * @return
+ */
 int corosync_quorum_is_quorate (void)
 {
 	if (corosync_quorum_fns) {
@@ -72,6 +76,12 @@ int corosync_quorum_is_quorate (void)
 	}
 }
 
+/**
+ * @brief corosync_quorum_register_callback
+ * @param fn
+ * @param context
+ * @return
+ */
 int corosync_quorum_register_callback (quorum_callback_fn_t fn, void *context)
 {
 	if (corosync_quorum_fns) {
@@ -82,6 +92,12 @@ int corosync_quorum_register_callback (quorum_callback_fn_t fn, void *context)
 	}
 }
 
+/**
+ * @brief corosync_quorum_unregister_callback
+ * @param fn
+ * @param context
+ * @return
+ */
 int corosync_quorum_unregister_callback (quorum_callback_fn_t fn, void *context)
 {
 	if (corosync_quorum_fns) {
@@ -92,6 +108,11 @@ int corosync_quorum_unregister_callback (quorum_callback_fn_t fn, void *context)
 	}
 }
 
+/**
+ * @brief corosync_quorum_initialize
+ * @param fns
+ * @return
+ */
 int corosync_quorum_initialize (struct quorum_callin_functions *fns)
 {
 	if (corosync_quorum_fns)
@@ -101,6 +122,10 @@ int corosync_quorum_initialize (struct quorum_callin_functions *fns)
 	return 0;
 }
 
+/**
+ * @brief quorum_none
+ * @return
+ */
 int quorum_none(void)
 {
 	if (corosync_quorum_fns)

--- a/exec/schedwrk.c
+++ b/exec/schedwrk.c
@@ -49,6 +49,12 @@ struct schedwrk_instance {
 	int lock;
 };
 
+/**
+ * @brief schedwrk_do
+ * @param type
+ * @param context
+ * @return
+ */
 static int schedwrk_do (enum totem_callback_token_type type, const void *context)
 {
 	hdb_handle_t handle = *((hdb_handle_t *)context);
@@ -80,6 +86,9 @@ error_exit:
 	return (-1);
 }
 
+/**
+ * @brief schedwrk_init
+ */
 void schedwrk_init (
 	void (*serialize_lock_fn) (void),
 	void (*serialize_unlock_fn) (void))
@@ -88,6 +97,13 @@ void schedwrk_init (
 	serialize_unlock = serialize_unlock_fn;
 }
 
+/**
+ * @brief schedwrk_internal_create
+ * @param handle
+ * @param context
+ * @param lock
+ * @return
+ */
 static int schedwrk_internal_create (
 	hdb_handle_t *handle,
 	int (schedwrk_fn) (const void *),
@@ -134,6 +150,11 @@ error_exit:
  * handle pointer is internally used by totempg_callback_token_create. To make schedwrk work,
  * handle must be pointer to ether heap or .text or static memory (not stack) which is not
  * changed by caller.
+ *
+ * @brief schedwrk_create
+ * @param handle
+ * @param context
+ * @return
  */
 int schedwrk_create (
 	hdb_handle_t *handle,
@@ -143,6 +164,12 @@ int schedwrk_create (
 	return schedwrk_internal_create (handle, schedwrk_fn, context, 1);
 }
 
+/**
+ * @brief schedwrk_create_nolock
+ * @param handle
+ * @param context
+ * @return
+ */
 int schedwrk_create_nolock (
 	hdb_handle_t *handle,
 	int (schedwrk_fn) (const void *),
@@ -151,6 +178,10 @@ int schedwrk_create_nolock (
 	return schedwrk_internal_create (handle, schedwrk_fn, context, 0);
 }
 
+/**
+ * @brief schedwrk_destroy
+ * @param handle
+ */
 void schedwrk_destroy (hdb_handle_t handle)
 {
 	hdb_handle_destroy (&schedwrk_instance_database, handle);

--- a/exec/service.c
+++ b/exec/service.c
@@ -114,6 +114,12 @@ const char *service_stats_tx[SERVICES_COUNT_MAX][SERVICE_HANDLER_MAXIMUM_COUNT];
 
 static void (*service_unlink_all_complete) (void) = NULL;
 
+/**
+ * @brief corosync_service_link_and_init
+ * @param corosync_api
+ * @param service
+ * @return
+ */
 char *corosync_service_link_and_init (
 	struct corosync_api_v1 *corosync_api,
 	struct default_service *service)
@@ -180,6 +186,10 @@ char *corosync_service_link_and_init (
 	return NULL;
 }
 
+/**
+ * @brief service_priority_max
+ * @return
+ */
 static int service_priority_max(void)
 {
 	int lpc = 0, max = 0;
@@ -193,6 +203,14 @@ static int service_priority_max(void)
 
 /*
  * use the force
+ */
+/**
+ * @brief corosync_service_unlink_and_exit_priority
+ * @param corosync_api
+ * @param lowest_priority
+ * @param current_priority
+ * @param current_service_engine
+ * @return
  */
 static unsigned int
 corosync_service_unlink_and_exit_priority (
@@ -253,6 +271,13 @@ corosync_service_unlink_and_exit_priority (
 	return (0);
 }
 
+/**
+ * @brief service_unlink_and_exit
+ * @param corosync_api
+ * @param service_name
+ * @param service_ver
+ * @return
+ */
 static unsigned int service_unlink_and_exit (
 	struct corosync_api_v1 *corosync_api,
 	const char *service_name,
@@ -336,6 +361,11 @@ static unsigned int service_unlink_and_exit (
 /*
  * Links default services into the executive
  */
+/**
+ * @brief corosync_service_defaults_link_and_init
+ * @param corosync_api
+ * @return
+ */
 unsigned int corosync_service_defaults_link_and_init (struct corosync_api_v1 *corosync_api)
 {
 	unsigned int i;
@@ -360,6 +390,10 @@ unsigned int corosync_service_defaults_link_and_init (struct corosync_api_v1 *co
 	return (0);
 }
 
+/**
+ * @brief service_exit_schedwrk_handler
+ * @param data
+ */
 static void service_exit_schedwrk_handler (void *data) {
 	int res;
 	static int current_priority = 0;
@@ -391,6 +425,10 @@ static void service_exit_schedwrk_handler (void *data) {
 		service_exit_schedwrk_handler);
 }
 
+/**
+ * @brief corosync_service_unlink_all
+ * @param api
+ */
 void corosync_service_unlink_all (
 	struct corosync_api_v1 *api,
 	void (*unlink_all_complete) (void))
@@ -417,6 +455,9 @@ void corosync_service_unlink_all (
 		service_exit_schedwrk_handler);
 }
 
+/**
+ * @brief The service_unlink_and_exit_data struct
+ */
 struct service_unlink_and_exit_data {
 	hdb_handle_t handle;
 	struct corosync_api_v1 *api;
@@ -424,6 +465,10 @@ struct service_unlink_and_exit_data {
 	unsigned int ver;
 };
 
+/**
+ * @brief service_unlink_and_exit_schedwrk_handler
+ * @param data
+ */
 static void service_unlink_and_exit_schedwrk_handler (void *data)
 {
 	struct service_unlink_and_exit_data *service_unlink_and_exit_data =
@@ -445,8 +490,18 @@ static void service_unlink_and_exit_schedwrk_handler (void *data)
 	}
 }
 
+/**
+ *
+ */
 typedef int (*schedwrk_cast) (const void *);
 
+/**
+ * @brief corosync_service_unlink_and_exit
+ * @param api
+ * @param service_name
+ * @param service_ver
+ * @return
+ */
 unsigned int corosync_service_unlink_and_exit (
         struct corosync_api_v1 *api,
         const char *service_name,

--- a/exec/sync.c
+++ b/exec/sync.c
@@ -168,6 +168,10 @@ int (*my_sync_callbacks_retrieve) (
 		int service_id,
                 struct sync_callbacks *callbacks);
 
+/**
+ * @brief sync_init
+ * @return
+ */
 int sync_init (
         int (*sync_callbacks_retrieve) (
                 int service_id,
@@ -201,6 +205,11 @@ int sync_init (
 	return (0);
 }
 
+/**
+ * @brief sync_barrier_handler
+ * @param nodeid
+ * @param msg
+ */
 static void sync_barrier_handler (unsigned int nodeid, const void *msg)
 {
 	const struct req_exec_barrier_message *req_exec_barrier_message = msg;
@@ -242,6 +251,14 @@ static void sync_barrier_handler (unsigned int nodeid, const void *msg)
 	}
 }
 
+/**
+ * @brief dummy_sync_init
+ * @param trans_list
+ * @param trans_list_entries
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void dummy_sync_init (
 	const unsigned int *trans_list,
 	size_t trans_list_entries,
@@ -251,19 +268,35 @@ static void dummy_sync_init (
 {
 }
 
+/**
+ * @brief dummy_sync_abort
+ */
 static void dummy_sync_abort (void)
 {
 }
 
+/**
+ * @brief dummy_sync_process
+ * @return
+ */
 static int dummy_sync_process (void)
 {
 	return (0);
 }
 
+/**
+ * @brief dummy_sync_activate
+ */
 static void dummy_sync_activate (void)
 {
 }
 
+/**
+ * @brief service_entry_compare
+ * @param a
+ * @param b
+ * @return
+ */
 static int service_entry_compare (const void *a, const void *b)
 {
 	const struct service_entry *service_entry_a = a;
@@ -272,6 +305,11 @@ static int service_entry_compare (const void *a, const void *b)
 	return (service_entry_a->service_id > service_entry_b->service_id);
 }
 
+/**
+ * @brief sync_memb_determine
+ * @param nodeid
+ * @param msg
+ */
 static void sync_memb_determine (unsigned int nodeid, const void *msg)
 {
 	const struct req_exec_memb_determine_message *req_exec_memb_determine_message = msg;
@@ -297,6 +335,11 @@ static void sync_memb_determine (unsigned int nodeid, const void *msg)
 	}
 }
 
+/**
+ * @brief sync_service_build_handler
+ * @param nodeid
+ * @param msg
+ */
 static void sync_service_build_handler (unsigned int nodeid, const void *msg)
 {
 	const struct req_exec_service_build_message *req_exec_service_build_message = msg;
@@ -360,6 +403,13 @@ static void sync_service_build_handler (unsigned int nodeid, const void *msg)
 	}
 }
 
+/**
+ * @brief sync_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static void sync_deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
@@ -381,6 +431,9 @@ static void sync_deliver_fn (
 	}
 }
 
+/**
+ * @brief memb_determine_message_transmit
+ */
 static void memb_determine_message_transmit (void)
 {
 	struct iovec iovec;
@@ -400,6 +453,9 @@ static void memb_determine_message_transmit (void)
 		&iovec, 1, TOTEMPG_AGREED);
 }
 
+/**
+ * @brief barrier_message_transmit
+ */
 static void barrier_message_transmit (void)
 {
 	struct iovec iovec;
@@ -418,6 +474,10 @@ static void barrier_message_transmit (void)
 		&iovec, 1, TOTEMPG_AGREED);
 }
 
+/**
+ * @brief service_build_message_transmit
+ * @param service_build_message
+ */
 static void service_build_message_transmit (struct req_exec_service_build_message *service_build_message)
 {
 	struct iovec iovec;
@@ -435,12 +495,18 @@ static void service_build_message_transmit (struct req_exec_service_build_messag
 		&iovec, 1, TOTEMPG_AGREED);
 }
 
+/**
+ * @brief sync_barrier_enter
+ */
 static void sync_barrier_enter (void)
 {
 	my_state = SYNC_BARRIER;
 	barrier_message_transmit ();
 }
 
+/**
+ * @brief sync_process_enter
+ */
 static void sync_process_enter (void)
 {
 	int i;
@@ -464,6 +530,12 @@ static void sync_process_enter (void)
 		NULL);
 }
 
+/**
+ * @brief sync_servicelist_build_enter
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void sync_servicelist_build_enter (
 	const unsigned int *member_list,
 	size_t member_list_entries,
@@ -518,6 +590,11 @@ static void sync_servicelist_build_enter (
 	service_build_message_transmit (&service_build);
 }
 
+/**
+ * @brief schedwrk_processor
+ * @param context
+ * @return
+ */
 static int schedwrk_processor (const void *context)
 {
 	int res = 0;
@@ -566,6 +643,12 @@ static int schedwrk_processor (const void *context)
 	return (0);
 }
 
+/**
+ * @brief sync_start
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 void sync_start (
         const unsigned int *member_list,
         size_t member_list_entries,
@@ -584,6 +667,12 @@ void sync_start (
 	}
 }
 
+/**
+ * @brief sync_save_transitional
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 void sync_save_transitional (
         const unsigned int *member_list,
         size_t member_list_entries,
@@ -595,6 +684,9 @@ void sync_save_transitional (
 	my_trans_list_entries = member_list_entries;
 }
 
+/**
+ * @brief sync_abort
+ */
 void sync_abort (void)
 {
 	ENTER();
@@ -611,6 +703,10 @@ void sync_abort (void)
 	memset (&my_ring_id, 0,	sizeof (struct memb_ring_id));
 }
 
+/**
+ * @brief sync_memb_list_determine
+ * @param ring_id
+ */
 void sync_memb_list_determine (const struct memb_ring_id *ring_id)
 {
 	ENTER();
@@ -620,6 +716,9 @@ void sync_memb_list_determine (const struct memb_ring_id *ring_id)
 	memb_determine_message_transmit ();
 }
 
+/**
+ * @brief sync_memb_list_abort
+ */
 void sync_memb_list_abort (void)
 {
 	ENTER();

--- a/exec/timer.c
+++ b/exec/timer.c
@@ -40,6 +40,13 @@
 #include <qb/qbdefs.h>
 #include <qb/qbutil.h>
 
+/**
+ * @brief corosync_timer_add_absolute
+ * @param nanosec_from_epoch
+ * @param data
+ * @param handle
+ * @return
+ */
 int corosync_timer_add_absolute (
 		unsigned long long nanosec_from_epoch,
 		void *data,
@@ -55,6 +62,13 @@ int corosync_timer_add_absolute (
 				 handle);
 }
 
+/**
+ * @brief corosync_timer_add_duration
+ * @param nanosec_duration
+ * @param data
+ * @param handle
+ * @return
+ */
 int corosync_timer_add_duration (
 	unsigned long long nanosec_duration,
 	void *data,
@@ -69,12 +83,21 @@ int corosync_timer_add_duration (
 				 handle);
 }
 
+/**
+ * @brief corosync_timer_delete
+ * @param th
+ */
 void corosync_timer_delete (
 	corosync_timer_handle_t th)
 {
 	qb_loop_timer_del(cs_poll_handle_get(), th);
 }
 
+/**
+ * @brief corosync_timer_expire_time_get
+ * @param th
+ * @return
+ */
 unsigned long long corosync_timer_expire_time_get (
 	corosync_timer_handle_t th)
 {
@@ -89,6 +112,10 @@ unsigned long long corosync_timer_expire_time_get (
 	return (expire);
 }
 
+/**
+ * @brief cs_timer_time_get
+ * @return
+ */
 unsigned long long cs_timer_time_get (void)
 {
 	return qb_util_nano_from_epoch_get();

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -91,6 +91,12 @@ static void add_totem_config_notification(struct totem_config *totem_config);
 
 
 /* All the volatile parameters are uint32s, luckily */
+/**
+ * @brief totem_get_param_by_name
+ * @param totem_config
+ * @param param_name
+ * @return
+ */
 static uint32_t *totem_get_param_by_name(struct totem_config *totem_config, const char *param_name)
 {
 	if (strcmp(param_name, "totem.token") == 0)
@@ -135,6 +141,14 @@ static uint32_t *totem_get_param_by_name(struct totem_config *totem_config, cons
  * Read key_name from icmap. If key is not found or key_name == delete_key or if allow_zero is false
  * and readed value is zero, default value is used and stored into totem_config.
  */
+/**
+ * @brief totem_volatile_config_set_value
+ * @param totem_config
+ * @param key_name
+ * @param deleted_key
+ * @param default_value
+ * @param allow_zero_value
+ */
 static void totem_volatile_config_set_value (struct totem_config *totem_config,
 	const char *key_name, const char *deleted_key, unsigned int default_value,
 	int allow_zero_value)
@@ -168,6 +182,11 @@ static void totem_volatile_config_set_value (struct totem_config *totem_config,
  * Read and validate config values from cmap and store them into totem_config. If key doesn't exists,
  * default value is stored. deleted_key is name of key beeing processed by delete operation
  * from cmap. It is considered as non existing even if it can be read. Can be NULL.
+ */
+/**
+ * @brief totem_volatile_config_read
+ * @param totem_config
+ * @param deleted_key
  */
 static void totem_volatile_config_read (struct totem_config *totem_config, const char *deleted_key)
 {
@@ -223,6 +242,12 @@ static void totem_volatile_config_read (struct totem_config *totem_config, const
 	totem_volatile_config_set_value(totem_config, "totem.heartbeat_failures_allowed", deleted_key, 0, 1);
 }
 
+/**
+ * @brief totem_volatile_config_validate
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 static int totem_volatile_config_validate (
 	struct totem_config *totem_config,
 	const char **error_string)
@@ -303,6 +328,11 @@ parse_error:
 
 }
 
+/**
+ * @brief totem_get_crypto
+ * @param totem_config
+ * @return
+ */
 static int totem_get_crypto(struct totem_config *totem_config)
 {
 	char *str;
@@ -370,6 +400,10 @@ static int totem_get_crypto(struct totem_config *totem_config)
 	return 0;
 }
 
+/**
+ * @brief totem_config_get_ip_version
+ * @return
+ */
 static int totem_config_get_ip_version(void)
 {
 	int res;
@@ -389,6 +423,11 @@ static int totem_config_get_ip_version(void)
 	return (res);
 }
 
+/**
+ * @brief generate_cluster_id
+ * @param cluster_name
+ * @return
+ */
 static uint16_t generate_cluster_id (const char *cluster_name)
 {
 	int i;
@@ -402,6 +441,15 @@ static uint16_t generate_cluster_id (const char *cluster_name)
 	return (value & 0xFFFF);
 }
 
+/**
+ * @brief get_cluster_mcast_addr
+ * @param cluster_name
+ * @param bindnet
+ * @param ringnumber
+ * @param ip_version
+ * @param res
+ * @return
+ */
 static int get_cluster_mcast_addr (
 		const char *cluster_name,
 		unsigned int linknumber,
@@ -438,6 +486,12 @@ static int get_cluster_mcast_addr (
 	return (err);
 }
 
+/**
+ * @brief generate_nodeid_for_duplicate_test
+ * @param totem_config
+ * @param addr
+ * @return
+ */
 static unsigned int generate_nodeid_for_duplicate_test(
 	struct totem_config *totem_config,
 	char *addr)
@@ -462,6 +516,12 @@ static unsigned int generate_nodeid_for_duplicate_test(
 	return nodeid;
 }
 
+/**
+ * @brief check_for_duplicate_nodeids
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 static int check_for_duplicate_nodeids(
 	struct totem_config *totem_config,
 	const char **error_string)
@@ -551,7 +611,11 @@ static int check_for_duplicate_nodeids(
 	return retval;
 }
 
-
+/**
+ * @brief find_local_node_in_nodelist
+ * @param totem_config
+ * @return
+ */
 static int find_local_node_in_nodelist(struct totem_config *totem_config)
 {
 	icmap_iter_t iter;
@@ -608,6 +672,12 @@ static int find_local_node_in_nodelist(struct totem_config *totem_config)
  * are changed so for same ring, ip existing in both set1 and set2 are cleared
  * (set to 0), and ips which are only in set1 or set2 remains untouched.
  * totempg_node_add/remove is called.
+ */
+/**
+ * @brief compute_interfaces_diff
+ * @param interface_count
+ * @param set1
+ * @param set2
  */
 static void compute_interfaces_diff(int interface_count,
 	struct totem_interface *set1,
@@ -669,6 +739,11 @@ static void compute_interfaces_diff(int interface_count,
 	}
 }
 
+/**
+ * @brief put_nodelist_members_to_config
+ * @param totem_config
+ * @param reload
+ */
 static void put_nodelist_members_to_config(struct totem_config *totem_config, int reload)
 {
 	icmap_iter_t iter, iter2;
@@ -761,6 +836,14 @@ static void put_nodelist_members_to_config(struct totem_config *totem_config, in
 	}
 }
 
+/**
+ * @brief nodelist_dynamic_notify
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void nodelist_dynamic_notify(
 	int32_t event,
 	const char *key_name,
@@ -804,6 +887,12 @@ static void nodelist_dynamic_notify(
  * match).
  *
  * Returns 1 on success (address was found, node_pos is then correctly set) or 0 on failure.
+ */
+/**
+ * @brief totem_config_find_local_addr_in_nodelist
+ * @param ipaddr_key_prefix
+ * @param node_pos
+ * @return
  */
 int totem_config_find_local_addr_in_nodelist(const char *ipaddr_key_prefix, unsigned int *node_pos)
 {
@@ -897,6 +986,10 @@ int totem_config_find_local_addr_in_nodelist(const char *ipaddr_key_prefix, unsi
 	return (node_found);
 }
 
+/**
+ * @brief config_convert_nodelist_to_interface
+ * @param totem_config
+ */
 static void config_convert_nodelist_to_interface(struct totem_config *totem_config)
 {
 	int res = 0;
@@ -932,7 +1025,13 @@ static void config_convert_nodelist_to_interface(struct totem_config *totem_conf
 	}
 }
 
-
+/**
+ * @brief totem_config_read
+ * @param totem_config
+ * @param error_string
+ * @param warnings
+ * @return
+ */
 extern int totem_config_read (
 	struct totem_config *totem_config,
 	const char **error_string,
@@ -1282,7 +1381,12 @@ extern int totem_config_read (
 	return 0;
 }
 
-
+/**
+ * @brief totem_config_validate
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 int totem_config_validate (
 	struct totem_config *totem_config,
 	const char **error_string)
@@ -1447,6 +1551,13 @@ parse_error:
 
 }
 
+/**
+ * @brief read_keyfile
+ * @param key_location
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 static int read_keyfile (
 	const char *key_location,
 	struct totem_config *totem_config,
@@ -1496,6 +1607,12 @@ parse_error:
 	return (-1);
 }
 
+/**
+ * @brief totem_config_keyread
+ * @param totem_config
+ * @param error_string
+ * @return
+ */
 int totem_config_keyread (
 	struct totem_config *totem_config,
 	const char **error_string)
@@ -1556,6 +1673,10 @@ key_error:
 
 }
 
+/**
+ * @brief debug_dump_totem_config
+ * @param totem_config
+ */
 static void debug_dump_totem_config(const struct totem_config *totem_config)
 {
 
@@ -1580,6 +1701,14 @@ static void debug_dump_totem_config(const struct totem_config *totem_config)
 	log_printf(LOGSYS_LEVEL_DEBUG, "max_network_delay (%d ms)", totem_config->max_network_delay);
 }
 
+/**
+ * @brief totem_change_notify
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void totem_change_notify(
 	int32_t event,
 	const char *key_name,
@@ -1636,6 +1765,14 @@ static void totem_change_notify(
 	}
 }
 
+/**
+ * @brief totem_reload_notify
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void totem_reload_notify(
 	int32_t event,
 	const char *key_name,
@@ -1673,6 +1810,10 @@ static void totem_reload_notify(
 	}
 }
 
+/**
+ * @brief add_totem_config_notification
+ * @param totem_config
+ */
 static void add_totem_config_notification(struct totem_config *totem_config)
 {
 	icmap_track_t icmap_track;

--- a/exec/totemip.c
+++ b/exec/totemip.c
@@ -68,6 +68,12 @@ void totemip_nosigpipe(int s)
 #endif
 
 /* Compare two addresses */
+/**
+ * @brief totemip_equal
+ * @param addr1
+ * @param addr2
+ * @return
+ */
 int totemip_equal(const struct totem_ip_address *addr1,
 		  const struct totem_ip_address *addr2)
 {
@@ -92,12 +98,22 @@ int totemip_equal(const struct totem_ip_address *addr1,
 }
 
 /* Copy a totem_ip_address */
+/**
+ * @brief totemip_copy
+ * @param addr1
+ * @param addr2
+ */
 void totemip_copy(struct totem_ip_address *addr1,
 		  const struct totem_ip_address *addr2)
 {
 	memcpy(addr1, addr2, sizeof(struct totem_ip_address));
 }
 
+/**
+ * @brief totemip_copy_endian_convert
+ * @param addr1
+ * @param addr2
+ */
 void totemip_copy_endian_convert(struct totem_ip_address *addr1,
 				 const struct totem_ip_address *addr2)
 {
@@ -110,6 +126,11 @@ void totemip_copy_endian_convert(struct totem_ip_address *addr1,
  * Multicast address range is 224.0.0.0 to 239.255.255.255 this
  * translates to the first 4 bits == 1110 (0xE).
  * http://en.wikipedia.org/wiki/Multicast_address
+ */
+/**
+ * @brief totemip_is_mcast
+ * @param ip_addr
+ * @return
  */
 int32_t totemip_is_mcast(struct totem_ip_address *ip_addr)
 {
@@ -127,6 +148,12 @@ int32_t totemip_is_mcast(struct totem_ip_address *ip_addr)
 }
 
 /* For sorting etc. params are void * for qsort's benefit */
+/**
+ * @brief totemip_compare
+ * @param a
+ * @param b
+ * @return
+ */
 int totemip_compare(const void *a, const void *b)
 {
 	int i;
@@ -179,6 +206,12 @@ int totemip_compare(const void *a, const void *b)
 }
 
 /* Build a localhost totem_ip_address */
+/**
+ * @brief totemip_localhost
+ * @param family
+ * @param localhost
+ * @return
+ */
 int totemip_localhost(int family, struct totem_ip_address *localhost)
 {
 	const char *addr_text;
@@ -202,6 +235,11 @@ int totemip_localhost(int family, struct totem_ip_address *localhost)
 	return 0;
 }
 
+/**
+ * @brief totemip_localhost_check
+ * @param addr
+ * @return
+ */
 int totemip_localhost_check(const struct totem_ip_address *addr)
 {
 	struct totem_ip_address localhost;
@@ -211,6 +249,11 @@ int totemip_localhost_check(const struct totem_ip_address *addr)
 	return totemip_equal(addr, &localhost);
 }
 
+/**
+ * @brief totemip_print
+ * @param addr
+ * @return
+ */
 const char *totemip_print(const struct totem_ip_address *addr)
 {
 	static char buf[INET6_ADDRSTRLEN];
@@ -219,6 +262,14 @@ const char *totemip_print(const struct totem_ip_address *addr)
 }
 
 /* Make a totem_ip_address into a usable sockaddr_storage */
+/**
+ * @brief totemip_totemip_to_sockaddr_convert
+ * @param ip_addr
+ * @param port
+ * @param saddr
+ * @param addrlen
+ * @return
+ */
 int totemip_totemip_to_sockaddr_convert(struct totem_ip_address *ip_addr,
 					uint16_t port, struct sockaddr_storage *saddr, int *addrlen)
 {
@@ -260,6 +311,13 @@ int totemip_totemip_to_sockaddr_convert(struct totem_ip_address *ip_addr,
 /* Converts an address string string into a totem_ip_address.
    family can be AF_INET, AF_INET6 or 0 ("for "don't care")
 */
+/**
+ * @brief totemip_parse
+ * @param totemip
+ * @param addr
+ * @param family
+ * @return
+ */
 int totemip_parse(struct totem_ip_address *totemip, const char *addr, int family)
 {
 	struct addrinfo *ainfo;
@@ -292,6 +350,12 @@ int totemip_parse(struct totem_ip_address *totemip, const char *addr, int family
 }
 
 /* Make a sockaddr_* into a totem_ip_address */
+/**
+ * @brief totemip_sockaddr_to_totemip_convert
+ * @param saddr
+ * @param ip_addr
+ * @return
+ */
 int totemip_sockaddr_to_totemip_convert(const struct sockaddr_storage *saddr,
 					struct totem_ip_address *ip_addr)
 {
@@ -318,6 +382,11 @@ int totemip_sockaddr_to_totemip_convert(const struct sockaddr_storage *saddr,
 	return ret;
 }
 
+/**
+ * @brief totemip_getifaddrs
+ * @param addrs
+ * @return
+ */
 int totemip_getifaddrs(struct qb_list_head *addrs)
 {
 	struct ifaddrs *ifap, *ifa;
@@ -386,6 +455,10 @@ error_free_ifaddrs:
 	return (-1);
 }
 
+/**
+ * @brief totemip_freeifaddrs
+ * @param addrs
+ */
 void totemip_freeifaddrs(struct qb_list_head *addrs)
 {
 	struct totem_ip_if_address *if_addr;
@@ -401,6 +474,15 @@ void totemip_freeifaddrs(struct qb_list_head *addrs)
 	qb_list_init(addrs);
 }
 
+/**
+ * @brief totemip_iface_check
+ * @param bindnet
+ * @param boundto
+ * @param interface_up
+ * @param interface_num
+ * @param mask_high_bit
+ * @return
+ */
 int totemip_iface_check(struct totem_ip_address *bindnet,
 			struct totem_ip_address *boundto,
 			int *interface_up,
@@ -492,6 +574,11 @@ finished:
 #define TOTEMIP_IPV4_HEADER_SIZE	20
 #define TOTEMIP_IPV6_HEADER_SIZE	40
 
+/**
+ * @brief totemip_udpip_header_size
+ * @param family
+ * @return
+ */
 size_t totemip_udpip_header_size(int family)
 {
 	size_t header_size;

--- a/exec/totemnet.c
+++ b/exec/totemnet.c
@@ -49,6 +49,9 @@
 #define LOGSYS_UTILS_ONLY 1
 #include <corosync/logsys.h>
 
+/**
+ * @brief The transport struct
+ */
 struct transport {
 	const char *name;
 
@@ -211,6 +214,9 @@ struct transport transport_entries[] = {
 	}
 };
 
+/**
+ * @brief The totemnet_instance struct
+ */
 struct totemnet_instance {
 	void *transport_context;
 
@@ -236,6 +242,11 @@ do {									\
 		(const char *)format, ##args);				\
 } while (0);
 
+/**
+ * @brief totemnet_instance_initialize
+ * @param instance
+ * @param config
+ */
 static void totemnet_instance_initialize (
 	struct totemnet_instance *instance,
 	struct totem_config *config)
@@ -254,6 +265,13 @@ static void totemnet_instance_initialize (
 	instance->transport = &transport_entries[transport];
 }
 
+/**
+ * @brief totemnet_crypto_set
+ * @param net_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemnet_crypto_set (
 	void *net_context,
 	const char *cipher_type,
@@ -268,6 +286,11 @@ int totemnet_crypto_set (
 	return res;
 }
 
+/**
+ * @brief totemnet_finalize
+ * @param net_context
+ * @return
+ */
 int totemnet_finalize (
 	void *net_context)
 {
@@ -279,6 +302,16 @@ int totemnet_finalize (
 	return (res);
 }
 
+/**
+ * @brief totemnet_initialize
+ * @param loop_pt
+ * @param net_context
+ * @param totem_config
+ * @param stats
+ * @param interface_no
+ * @param context
+ * @return
+ */
 int totemnet_initialize (
 	qb_loop_t *loop_pt,
 	void **net_context,
@@ -328,6 +361,11 @@ error_destroy:
 	return (-1);
 }
 
+/**
+ * @brief totemnet_buffer_alloc
+ * @param net_context
+ * @return
+ */
 void *totemnet_buffer_alloc (void *net_context)
 {
 	struct totemnet_instance *instance = net_context;
@@ -336,6 +374,11 @@ void *totemnet_buffer_alloc (void *net_context)
 	return instance->transport->buffer_alloc();
 }
 
+/**
+ * @brief totemnet_buffer_release
+ * @param net_context
+ * @param ptr
+ */
 void totemnet_buffer_release (void *net_context, void *ptr)
 {
 	struct totemnet_instance *instance = net_context;
@@ -344,6 +387,12 @@ void totemnet_buffer_release (void *net_context, void *ptr)
 	instance->transport->buffer_release (ptr);
 }
 
+/**
+ * @brief totemnet_processor_count_set
+ * @param net_context
+ * @param processor_count
+ * @return
+ */
 int totemnet_processor_count_set (
 	void *net_context,
 	int processor_count)
@@ -355,6 +404,11 @@ int totemnet_processor_count_set (
 	return (res);
 }
 
+/**
+ * @brief totemnet_recv_flush
+ * @param net_context
+ * @return
+ */
 int totemnet_recv_flush (void *net_context)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
@@ -365,6 +419,11 @@ int totemnet_recv_flush (void *net_context)
 	return (res);
 }
 
+/**
+ * @brief totemnet_send_flush
+ * @param net_context
+ * @return
+ */
 int totemnet_send_flush (void *net_context)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
@@ -375,6 +434,13 @@ int totemnet_send_flush (void *net_context)
 	return (res);
 }
 
+/**
+ * @brief totemnet_token_send
+ * @param net_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemnet_token_send (
 	void *net_context,
 	const void *msg,
@@ -387,6 +453,14 @@ int totemnet_token_send (
 
 	return (res);
 }
+
+/**
+ * @brief totemnet_mcast_flush_send
+ * @param net_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemnet_mcast_flush_send (
 	void *net_context,
 	const void *msg,
@@ -400,6 +474,13 @@ int totemnet_mcast_flush_send (
 	return (res);
 }
 
+/**
+ * @brief totemnet_mcast_noflush_send
+ * @param net_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemnet_mcast_noflush_send (
 	void *net_context,
 	const void *msg,
@@ -413,6 +494,11 @@ int totemnet_mcast_noflush_send (
 	return (res);
 }
 
+/**
+ * @brief totemnet_iface_check
+ * @param net_context
+ * @return
+ */
 extern int totemnet_iface_check (void *net_context)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
@@ -423,6 +509,12 @@ extern int totemnet_iface_check (void *net_context)
 	return (res);
 }
 
+/**
+ * @brief totemnet_net_mtu_adjust
+ * @param net_context
+ * @param totem_config
+ * @return
+ */
 extern int totemnet_net_mtu_adjust (void *net_context, struct totem_config *totem_config)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
@@ -432,6 +524,13 @@ extern int totemnet_net_mtu_adjust (void *net_context, struct totem_config *tote
 	return (res);
 }
 
+/**
+ * @brief totemnet_iface_get
+ * @param net_context
+ * @param status
+ * @param iface_count
+ * @return
+ */
 int totemnet_ifaces_get (
 	void *net_context,
 	char ***status,
@@ -445,6 +544,12 @@ int totemnet_ifaces_get (
 	return (res);
 }
 
+/**
+ * @brief totemnet_token_target_set
+ * @param net_context
+ * @param token_target
+ * @return
+ */
 int totemnet_token_target_set (
 	void *net_context,
 	const struct totem_ip_address *token_target)
@@ -457,6 +562,11 @@ int totemnet_token_target_set (
 	return (res);
 }
 
+/**
+ * @brief totemnet_recv_mcast_empty
+ * @param net_context
+ * @return
+ */
 extern int totemnet_recv_mcast_empty (
 	void *net_context)
 {
@@ -468,6 +578,12 @@ extern int totemnet_recv_mcast_empty (
 	return (res);
 }
 
+/**
+ * @brief totemnet_member_add
+ * @param net_context
+ * @param member
+ * @return
+ */
 extern int totemnet_member_add (
 	void *net_context,
 	const struct totem_ip_address *local,
@@ -488,6 +604,12 @@ extern int totemnet_member_add (
 	return (res);
 }
 
+/**
+ * @brief totemnet_member_remove
+ * @param net_context
+ * @param member
+ * @return
+ */
 extern int totemnet_member_remove (
 	void *net_context,
 	const struct totem_ip_address *member,
@@ -506,6 +628,13 @@ extern int totemnet_member_remove (
 	return (res);
 }
 
+/**
+ * @brief totemnet_member_set_active
+ * @param net_context
+ * @param member
+ * @param active
+ * @return
+ */
 int totemnet_member_set_active (
 	void *net_context,
 	const struct totem_ip_address *member,

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -282,12 +282,21 @@ static int msg_count_send_ok (int msg_count);
 
 static int byte_count_send_ok (int byte_count);
 
+/**
+ * @brief totempg_waiting_trans_ack_cb
+ * @param waiting_trans_ack
+ */
 static void totempg_waiting_trans_ack_cb (int waiting_trans_ack)
 {
 	log_printf(LOG_DEBUG, "waiting_trans_ack changed to %u", waiting_trans_ack);
 	totempg_waiting_transack = waiting_trans_ack;
 }
 
+/**
+ * @brief assembly_ref
+ * @param nodeid
+ * @return
+ */
 static struct assembly *assembly_ref (unsigned int nodeid)
 {
 	struct assembly *assembly;
@@ -344,12 +353,20 @@ static struct assembly *assembly_ref (unsigned int nodeid)
 	return (assembly);
 }
 
+/**
+ * @brief assembly_deref
+ * @param assembly
+ */
 static void assembly_deref (struct assembly *assembly)
 {
 	qb_list_del (&assembly->list);
 	qb_list_add (&assembly->list, &assembly_list_free);
 }
 
+/**
+ * @brief assembly_deref_from_normal_and_trans
+ * @param nodeid
+ */
 static void assembly_deref_from_normal_and_trans (int nodeid)
 {
 	int j;
@@ -376,6 +393,17 @@ static void assembly_deref_from_normal_and_trans (int nodeid)
 
 }
 
+/**
+ * @brief app_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static inline void app_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -413,6 +441,11 @@ static inline void app_confchg_fn (
 	}
 }
 
+/**
+ * @brief group_endian_convert
+ * @param msg
+ * @param msg_len
+ */
 static inline void group_endian_convert (
 	void *msg,
 	int msg_len)
@@ -446,6 +479,15 @@ static inline void group_endian_convert (
 	}
 }
 
+/**
+ * @brief group_matches
+ * @param iovec
+ * @param iov_len
+ * @param groups_b
+ * @param group_b_cnt
+ * @param adjust_iovec
+ * @return
+ */
 static inline int group_matches (
 	struct iovec *iovec,
 	unsigned int iov_len,
@@ -504,6 +546,13 @@ static inline int group_matches (
 }
 
 
+/**
+ * @brief app_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static inline void app_deliver_fn (
 	unsigned int nodeid,
 	void *msg,
@@ -572,6 +621,17 @@ static inline void app_deliver_fn (
 	}
 }
 
+/**
+ * @brief totempg_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void totempg_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -587,6 +647,13 @@ static void totempg_confchg_fn (
 		ring_id);
 }
 
+/**
+ * @brief totempg_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static void totempg_deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
@@ -715,8 +782,17 @@ static void totempg_deliver_fn (
  * depends on poll abstraction, POSIX, IPV4
  */
 
+/**
+ * @brief callback_token_received_handle
+ */
 void *callback_token_received_handle;
 
+/**
+ * @brief callback_token_received_fn
+ * @param type
+ * @param data
+ * @return
+ */
 int callback_token_received_fn (enum totem_callback_token_type type,
 				const void *data)
 {
@@ -771,6 +847,12 @@ int callback_token_received_fn (enum totem_callback_token_type type,
 /*
  * Initialize the totem process group abstraction
  */
+/**
+ * @brief totempg_initialize
+ * @param poll_handle
+ * @param totem_config
+ * @return
+ */
 int totempg_initialize (
 	qb_loop_t *poll_handle,
 	struct totem_config *totem_config)
@@ -819,6 +901,9 @@ int totempg_initialize (
 	return (res);
 }
 
+/**
+ * @brief totempg_finalize
+ */
 void totempg_finalize (void)
 {
 	if (totempg_threaded_mode == 1) {
@@ -832,6 +917,13 @@ void totempg_finalize (void)
 
 /*
  * Multicast a message
+ */
+/**
+ * @brief mcast_msg
+ * @param iovec_in
+ * @param iov_len
+ * @param guarantee
+ * @return
  */
 static int mcast_msg (
 	struct iovec *iovec_in,
@@ -1008,6 +1100,11 @@ error_exit:
 /*
  * Determine if a message of msg_size could be queued
  */
+/**
+ * @brief msg_count_send_ok
+ * @param msg_count
+ * @return
+ */
 static int msg_count_send_ok (
 	int msg_count)
 {
@@ -1019,6 +1116,11 @@ static int msg_count_send_ok (
 	return ((avail - totempg_reserved) > msg_count);
 }
 
+/**
+ * @brief byte_count_send_ok
+ * @param byte_count
+ * @return
+ */
 static int byte_count_send_ok (
 	int byte_count)
 {
@@ -1032,6 +1134,11 @@ static int byte_count_send_ok (
 	return (avail >= msg_count);
 }
 
+/**
+ * @brief send_reserve
+ * @param msg_size
+ * @return
+ */
 static int send_reserve (
 	int msg_size)
 {
@@ -1044,6 +1151,10 @@ static int send_reserve (
 	return (msg_count);
 }
 
+/**
+ * @brief send_release
+ * @param msg_count
+ */
 static void send_release (
 	int msg_count)
 {
@@ -1056,6 +1167,10 @@ static void send_release (
 #define MESSAGE_QUEUE_MAX	((4 * MESSAGE_SIZE_MAX) / totempg_totem_config->net_mtu)
 #endif /* HAVE_SMALL_MEMORY_FOOTPRINT */
 
+/**
+ * @brief q_level_precent_used
+ * @return
+ */
 static uint32_t q_level_precent_used(void)
 {
 	return (100 - (((totemsrp_avail(totemsrp_context) - totempg_reserved) * 100) / MESSAGE_QUEUE_MAX));
@@ -1080,6 +1195,10 @@ int totempg_callback_token_create (
 	return (res);
 }
 
+/**
+ * @brief totempg_callback_token_destroy
+ * @param handle_out
+ */
 void totempg_callback_token_destroy (
 	void *handle_out)
 {
@@ -1092,10 +1211,11 @@ void totempg_callback_token_destroy (
 	}
 }
 
-/*
- *	vi: set autoindent tabstop=4 shiftwidth=4 :
+/**
+ * @brief totempg_groups_initialize
+ * @param totempg_groups_instance
+ * @return
  */
-
 int totempg_groups_initialize (
 	void **totempg_groups_instance,
 
@@ -1144,6 +1264,13 @@ error_exit:
 	return (-1);
 }
 
+/**
+ * @brief totempg_groups_join
+ * @param totempg_groups_instance
+ * @param groups
+ * @param group_cnt
+ * @return
+ */
 int totempg_groups_join (
 	void *totempg_groups_instance,
 	const struct totempg_group *groups,
@@ -1176,6 +1303,13 @@ error_exit:
 	return (res);
 }
 
+/**
+ * @brief totempg_groups_leave
+ * @param totempg_groups_instance
+ * @param groups
+ * @param group_cnt
+ * @return
+ */
 int totempg_groups_leave (
 	void *totempg_groups_instance,
 	const struct totempg_group *groups,
@@ -1194,6 +1328,14 @@ int totempg_groups_leave (
 #define MAX_IOVECS_FROM_APP 32
 #define MAX_GROUPS_PER_MSG 32
 
+/**
+ * @brief totempg_groups_mcast_joined
+ * @param totempg_groups_instance
+ * @param iovec
+ * @param iov_len
+ * @param guarantee
+ * @return
+ */
 int totempg_groups_mcast_joined (
 	void *totempg_groups_instance,
 	const struct iovec *iovec,
@@ -1235,6 +1377,10 @@ int totempg_groups_mcast_joined (
 	return (res);
 }
 
+/**
+ * @brief check_q_level
+ * @param totempg_groups_instance
+ */
 static void check_q_level(
 	void *totempg_groups_instance)
 {
@@ -1256,6 +1402,10 @@ static void check_q_level(
 	}
 }
 
+/**
+ * @brief totempg_check_q_level
+ * @param totempg_groups_instance
+ */
 void totempg_check_q_level(
 	void *totempg_groups_instance)
 {
@@ -1264,6 +1414,13 @@ void totempg_check_q_level(
 	check_q_level(instance);
 }
 
+/**
+ * @brief totempg_groups_joined_reserve
+ * @param totempg_groups_instance
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 int totempg_groups_joined_reserve (
 	void *totempg_groups_instance,
 	const struct iovec *iovec,
@@ -1308,6 +1465,11 @@ error_exit:
 }
 
 
+/**
+ * @brief totempg_groups_joined_release
+ * @param msg_count
+ * @return
+ */
 int totempg_groups_joined_release (int msg_count)
 {
 	if (totempg_threaded_mode == 1) {
@@ -1322,6 +1484,16 @@ int totempg_groups_joined_release (int msg_count)
 	return 0;
 }
 
+/**
+ * @brief totempg_groups_mcast_groups
+ * @param totempg_groups_instance
+ * @param guarantee
+ * @param groups
+ * @param groups_cnt
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 int totempg_groups_mcast_groups (
 	void *totempg_groups_instance,
 	int guarantee,
@@ -1366,6 +1538,15 @@ int totempg_groups_mcast_groups (
 /*
  * Returns -1 if error, 0 if can't send, 1 if can send the message
  */
+/**
+ * @brief totempg_groups_send_ok_groups
+ * @param totempg_groups_instance
+ * @param groups
+ * @param groups_cnt
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 int totempg_groups_send_ok_groups (
 	void *totempg_groups_instance,
 	const struct totempg_group *groups,
@@ -1396,6 +1577,15 @@ int totempg_groups_send_ok_groups (
 	return (res);
 }
 
+/**
+ * @brief totempg_ifaces_get
+ * @param nodeid
+ * @param interfaces
+ * @param interfaces_size
+ * @param status
+ * @param iface_count
+ * @return
+ */
 int totempg_ifaces_get (
 	unsigned int nodeid,
 	struct totem_ip_address *interfaces,
@@ -1416,16 +1606,31 @@ int totempg_ifaces_get (
 	return (res);
 }
 
+/**
+ * @brief totempg_event_signal
+ * @param type
+ * @param value
+ */
 void totempg_event_signal (enum totem_event_type type, int value)
 {
 	totemsrp_event_signal (totemsrp_context, type, value);
 }
 
+/**
+ * @brief totempg_get_stats
+ * @return
+ */
 void* totempg_get_stats (void)
 {
 	return &totempg_stats;
 }
 
+/**
+ * @brief totempg_crypto_set
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totempg_crypto_set (
 	const char *cipher_type,
 	const char *hash_type)
@@ -1437,6 +1642,10 @@ int totempg_crypto_set (
 	return (res);
 }
 
+/**
+ * @brief totempg_ring_reenable
+ * @return
+ */
 int totempg_ring_reenable (void)
 {
 	int res;
@@ -1447,6 +1656,11 @@ int totempg_ring_reenable (void)
 }
 
 #define ONE_IFACE_LEN 63
+/**
+ * @brief totempg_ifaces_print
+ * @param nodeid
+ * @return
+ */
 const char *totempg_ifaces_print (unsigned int nodeid)
 {
 	static char iface_string[256 * INTERFACE_MAX];
@@ -1474,26 +1688,48 @@ const char *totempg_ifaces_print (unsigned int nodeid)
 	return (iface_string);
 }
 
+/**
+ * @brief totempg_my_nodeid_get
+ * @return
+ */
 unsigned int totempg_my_nodeid_get (void)
 {
 	return (totemsrp_my_nodeid_get(totemsrp_context));
 }
 
+/**
+ * @brief totempg_my_family_get
+ * @return
+ */
 int totempg_my_family_get (void)
 {
 	return (totemsrp_my_family_get(totemsrp_context));
 }
+
+/**
+ * @brief totempg_service_ready_register
+ */
 extern void totempg_service_ready_register (
 	void (*totem_service_ready) (void))
 {
 	totemsrp_service_ready_register (totemsrp_context, totem_service_ready);
 }
 
+/**
+ * @brief totempg_queue_level_register_callback
+ * @param fn
+ */
 void totempg_queue_level_register_callback (totem_queue_level_changed_fn fn)
 {
 	totem_queue_level_changed = fn;
 }
 
+/**
+ * @brief totempg_member_add
+ * @param member
+ * @param ring_no
+ * @return
+ */
 extern int totempg_member_add (
 	const struct totem_ip_address *member,
 	int ring_no)
@@ -1501,6 +1737,12 @@ extern int totempg_member_add (
 	return totemsrp_member_add (totemsrp_context, member, ring_no);
 }
 
+/**
+ * @brief totempg_member_remove
+ * @param member
+ * @param ring_no
+ * @return
+ */
 extern int totempg_member_remove (
 	const struct totem_ip_address *member,
 	int ring_no)
@@ -1508,12 +1750,18 @@ extern int totempg_member_remove (
 	return totemsrp_member_remove (totemsrp_context, member, ring_no);
 }
 
+/**
+ * @brief totempg_threaded_mode_enable
+ */
 void totempg_threaded_mode_enable (void)
 {
 	totempg_threaded_mode = 1;
 	totemsrp_threaded_mode_enable (totemsrp_context);
 }
 
+/**
+ * @brief totempg_trans_ack
+ */
 void totempg_trans_ack (void)
 {
 	totemsrp_trans_ack (totemsrp_context);

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -698,6 +698,11 @@ do {												\
 		fmt ": %s (%d)\n", ##args, _error_ptr, err_num);				\
 	} while(0)
 
+/**
+ * @brief gsfrom_to_msg
+ * @param gsfrom
+ * @return
+ */
 static const char* gsfrom_to_msg(enum gather_state_from gsfrom)
 {
 	if (gsfrom <= TOTEMSRP_GSFROM_MAX) {
@@ -708,6 +713,10 @@ static const char* gsfrom_to_msg(enum gather_state_from gsfrom)
 	}
 }
 
+/**
+ * @brief totemsrp_instance_initialize
+ * @param instance
+ */
 static void totemsrp_instance_initialize (struct totemsrp_instance *instance)
 {
 	memset (instance, 0, sizeof (struct totemsrp_instance));
@@ -741,6 +750,11 @@ static void totemsrp_instance_initialize (struct totemsrp_instance *instance)
 	instance->waiting_trans_ack = 1;
 }
 
+/**
+ * @brief pause_flush
+ * @param instance
+ * @return
+ */
 static int pause_flush (struct totemsrp_instance *instance)
 {
 	uint64_t now_msec;
@@ -763,6 +777,12 @@ static int pause_flush (struct totemsrp_instance *instance)
 	return (res);
 }
 
+/**
+ * @brief token_event_stats_collector
+ * @param type
+ * @param void_instance
+ * @return
+ */
 static int token_event_stats_collector (enum totem_callback_token_type type, const void *void_instance)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)void_instance;
@@ -798,6 +818,11 @@ static int token_event_stats_collector (enum totem_callback_token_type type, con
 	return 0;
 }
 
+/**
+ * @brief totempg_mtu_changed
+ * @param context
+ * @param net_mtu
+ */
 static void totempg_mtu_changed(void *context, int net_mtu)
 {
 	struct totemsrp_instance *instance = context;
@@ -811,6 +836,14 @@ static void totempg_mtu_changed(void *context, int net_mtu)
 
 /*
  * Exported interfaces
+ */
+/**
+ * @brief totemsrp_initialize
+ * @param poll_handle
+ * @param srp_context
+ * @param totem_config
+ * @param stats
+ * @return
  */
 int totemsrp_initialize (
 	qb_loop_t *poll_handle,
@@ -1000,6 +1033,10 @@ error_exit:
 	return (-1);
 }
 
+/**
+ * @brief totemsrp_finalize
+ * @param srp_context
+ */
 void totemsrp_finalize (
 	void *srp_context)
 {
@@ -1022,6 +1059,16 @@ void totemsrp_finalize (
  *
  * Function returns 0 on success, otherwise if interfaces array is not big enough, -2 is returned,
  * and if interface was not found, -1 is returned.
+ */
+/**
+ * @brief totemsrp_ifaces_get
+ * @param srp_context
+ * @param nodeid
+ * @param interfaces
+ * @param interfaces_size
+ * @param status
+ * @param iface_count
+ * @return
  */
 int totemsrp_ifaces_get (
 	void *srp_context,
@@ -1081,6 +1128,13 @@ finish:
 	return (res);
 }
 
+/**
+ * @brief totemsrp_crypto_set
+ * @param srp_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemsrp_crypto_set (
 	void *srp_context,
 	const char *cipher_type,
@@ -1094,7 +1148,11 @@ int totemsrp_crypto_set (
 	return (res);
 }
 
-
+/**
+ * @brief totemsrp_my_nodeid_get
+ * @param srp_context
+ * @return
+ */
 unsigned int totemsrp_my_nodeid_get (
 	void *srp_context)
 {
@@ -1106,6 +1164,11 @@ unsigned int totemsrp_my_nodeid_get (
 	return (res);
 }
 
+/**
+ * @brief totemsrp_my_family_get
+ * @param srp_context
+ * @return
+ */
 int totemsrp_my_family_get (
 	void *srp_context)
 {
@@ -1117,6 +1180,11 @@ int totemsrp_my_family_get (
 	return (res);
 }
 
+/**
+ * @brief totemsrp_ring_reenable
+ * @param srp_context
+ * @return
+ */
 int totemsrp_ring_reenable (
         void *srp_context)
 {
@@ -1126,6 +1194,12 @@ int totemsrp_ring_reenable (
 
 /*
  * Set operations for use by the membership algorithm
+ */
+/**
+ * @brief srp_addr_equal
+ * @param a
+ * @param b
+ * @return
  */
 static int srp_addr_equal (const struct srp_addr *a, const struct srp_addr *b)
 {
@@ -1141,6 +1215,11 @@ static int srp_addr_equal (const struct srp_addr *a, const struct srp_addr *b)
 	return (1);
 }
 
+/**
+ * @brief srp_addr_copy
+ * @param dest
+ * @param src
+ */
 static void srp_addr_copy (struct srp_addr *dest, const struct srp_addr *src)
 {
 	unsigned int i;
@@ -1152,6 +1231,12 @@ static void srp_addr_copy (struct srp_addr *dest, const struct srp_addr *src)
 	}
 }
 
+/**
+ * @brief srp_addr_to_nodeid
+ * @param nodeid_out
+ * @param srp_addr_in
+ * @param entries
+ */
 static void srp_addr_to_nodeid (
 	unsigned int *nodeid_out,
 	struct srp_addr *srp_addr_in,
@@ -1164,6 +1249,11 @@ static void srp_addr_to_nodeid (
 	}
 }
 
+/**
+ * @brief srp_addr_copy_endian_convert
+ * @param out
+ * @param in
+ */
 static void srp_addr_copy_endian_convert (struct srp_addr *out, const struct srp_addr *in)
 {
 	int i;
@@ -1173,11 +1263,24 @@ static void srp_addr_copy_endian_convert (struct srp_addr *out, const struct srp
 	}
 }
 
+/**
+ * @brief memb_consensus_reset
+ * @param instance
+ */
 static void memb_consensus_reset (struct totemsrp_instance *instance)
 {
 	instance->consensus_list_entries = 0;
 }
 
+/**
+ * @brief memb_set_subtract
+ * @param out_list
+ * @param out_list_entries
+ * @param one_list
+ * @param one_list_entries
+ * @param two_list
+ * @param two_list_entries
+ */
 static void memb_set_subtract (
         struct srp_addr *out_list, int *out_list_entries,
         struct srp_addr *one_list, int one_list_entries,
@@ -1207,6 +1310,11 @@ static void memb_set_subtract (
 /*
  * Set consensus for a specific processor
  */
+/**
+ * @brief memb_consensus_set
+ * @param instance
+ * @param addr
+ */
 static void memb_consensus_set (
 	struct totemsrp_instance *instance,
 	const struct srp_addr *addr)
@@ -1234,6 +1342,12 @@ static void memb_consensus_set (
 /*
  * Is consensus set for a specific processor
  */
+/**
+ * @brief memb_consensus_isset
+ * @param instance
+ * @param addr
+ * @return
+ */
 static int memb_consensus_isset (
 	struct totemsrp_instance *instance,
 	const struct srp_addr *addr)
@@ -1250,6 +1364,11 @@ static int memb_consensus_isset (
 
 /*
  * Is consensus agreed upon based upon consensus database
+ */
+/**
+ * @brief memb_consensus_agreed
+ * @param instance
+ * @return
  */
 static int memb_consensus_agreed (
 	struct totemsrp_instance *instance)
@@ -1284,6 +1403,14 @@ static int memb_consensus_agreed (
 	return (agreed);
 }
 
+/**
+ * @brief memb_consensus_notset
+ * @param instance
+ * @param no_consensus_list
+ * @param no_consensus_list_entries
+ * @param comparison_list
+ * @param comparison_list_entries
+ */
 static void memb_consensus_notset (
 	struct totemsrp_instance *instance,
 	struct srp_addr *no_consensus_list,
@@ -1305,6 +1432,14 @@ static void memb_consensus_notset (
 
 /*
  * Is set1 equal to set2 Entries can be in different orders
+ */
+/**
+ * @brief memb_set_equal
+ * @param set1
+ * @param set1_entries
+ * @param set2
+ * @param set2_entries
+ * @return
  */
 static int memb_set_equal (
 	struct srp_addr *set1, int set1_entries,
@@ -1336,6 +1471,14 @@ static int memb_set_equal (
 /*
  * Is subset fully contained in fullset
  */
+/**
+ * @brief memb_set_subset
+ * @param subset
+ * @param subset_entries
+ * @param fullset
+ * @param fullset_entries
+ * @return
+ */
 static int memb_set_subset (
 	const struct srp_addr *subset, int subset_entries,
 	const struct srp_addr *fullset, int fullset_entries)
@@ -1363,6 +1506,13 @@ static int memb_set_subset (
 /*
  * merge subset into fullset taking care not to add duplicates
  */
+/**
+ * @brief memb_set_merge
+ * @param subset
+ * @param subset_entries
+ * @param fullset
+ * @param fullset_entries
+ */
 static void memb_set_merge (
 	const struct srp_addr *subset, int subset_entries,
 	struct srp_addr *fullset, int *fullset_entries)
@@ -1387,6 +1537,16 @@ static void memb_set_merge (
 	return;
 }
 
+/**
+ * @brief memb_set_and_with_ring_id
+ * @param set1
+ * @param set1_ring_ids
+ * @param set1_entries
+ * @param set2
+ * @param set2_entries
+ * @param old_ring_id
+ * @param and_entries
+ */
 static void memb_set_and_with_ring_id (
 	struct srp_addr *set1,
 	struct memb_ring_id *set1_ring_ids,
@@ -1422,6 +1582,12 @@ static void memb_set_and_with_ring_id (
 }
 
 #ifdef CODE_COVERAGE
+/**
+ * @brief memb_set_print
+ * @param string
+ * @param list
+ * @param list_entries
+ */
 static void memb_set_print (
 	char *string,
         struct srp_addr *list,
@@ -1447,6 +1613,12 @@ static void my_leave_memb_clear(
         instance->my_leave_memb_entries = 0;
 }
 
+/**
+ * @brief my_leave_memb_match
+ * @param instance
+ * @param nodeid
+ * @return
+ */
 static unsigned int my_leave_memb_match(
         struct totemsrp_instance *instance,
         unsigned int nodeid)
@@ -1463,6 +1635,11 @@ static unsigned int my_leave_memb_match(
         return ret;
 }
 
+/**
+ * @brief my_leave_memb_set
+ * @param instance
+ * @param nodeid
+ */
 static void my_leave_memb_set(
         struct totemsrp_instance *instance,
         unsigned int nodeid)
@@ -1486,19 +1663,32 @@ static void my_leave_memb_set(
         }
 }
 
-
+/**
+ * @brief totemsrp_buffer_alloc
+ * @param instance
+ * @return
+ */
 static void *totemsrp_buffer_alloc (struct totemsrp_instance *instance)
 {
 	assert (instance != NULL);
 	return totemnet_buffer_alloc (instance->totemnet_context);
 }
 
+/**
+ * @brief totemsrp_buffer_release
+ * @param instance
+ * @param ptr
+ */
 static void totemsrp_buffer_release (struct totemsrp_instance *instance, void *ptr)
 {
 	assert (instance != NULL);
 	totemnet_buffer_release (instance->totemnet_context, ptr);
 }
 
+/**
+ * @brief reset_token_retransmit_timeout
+ * @param instance
+ */
 static void reset_token_retransmit_timeout (struct totemsrp_instance *instance)
 {
 	int32_t res;
@@ -1517,6 +1707,10 @@ static void reset_token_retransmit_timeout (struct totemsrp_instance *instance)
 
 }
 
+/**
+ * @brief start_merge_detect_timeout
+ * @param instance
+ */
 static void start_merge_detect_timeout (struct totemsrp_instance *instance)
 {
 	int32_t res;
@@ -1536,6 +1730,10 @@ static void start_merge_detect_timeout (struct totemsrp_instance *instance)
 	}
 }
 
+/**
+ * @brief cancel_merge_detect_timeout
+ * @param instance
+ */
 static void cancel_merge_detect_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_merge_detect_timeout);
@@ -1545,6 +1743,10 @@ static void cancel_merge_detect_timeout (struct totemsrp_instance *instance)
 /*
  * ring_state_* is used to save and restore the sort queue
  * state when a recovery operation fails (and enters gather)
+ */
+/**
+ * @brief old_ring_state_save
+ * @param instance
  */
 static void old_ring_state_save (struct totemsrp_instance *instance)
 {
@@ -1560,6 +1762,10 @@ static void old_ring_state_save (struct totemsrp_instance *instance)
 	}
 }
 
+/**
+ * @brief old_ring_state_restore
+ * @param instance
+ */
 static void old_ring_state_restore (struct totemsrp_instance *instance)
 {
 	instance->my_aru = instance->old_ring_state_aru;
@@ -1569,6 +1775,10 @@ static void old_ring_state_restore (struct totemsrp_instance *instance)
 		instance->my_aru, instance->my_high_seq_received);
 }
 
+/**
+ * @brief old_ring_state_reset
+ * @param instance
+ */
 static void old_ring_state_reset (struct totemsrp_instance *instance)
 {
 	log_printf (instance->totemsrp_log_level_debug,
@@ -1576,6 +1786,10 @@ static void old_ring_state_reset (struct totemsrp_instance *instance)
 	instance->old_ring_state_saved = 0;
 }
 
+/**
+ * @brief reset_pause_timeout
+ * @param instance
+ */
 static void reset_pause_timeout (struct totemsrp_instance *instance)
 {
 	int32_t res;
@@ -1592,6 +1806,10 @@ static void reset_pause_timeout (struct totemsrp_instance *instance)
 	}
 }
 
+/**
+ * @brief reset_token_timeout
+ * @param instance
+ */
 static void reset_token_timeout (struct totemsrp_instance *instance) {
 	int32_t res;
 
@@ -1607,6 +1825,10 @@ static void reset_token_timeout (struct totemsrp_instance *instance) {
 	}
 }
 
+/**
+ * @brief reset_heartbeat_timeout
+ * @param instance
+ */
 static void reset_heartbeat_timeout (struct totemsrp_instance *instance) {
 	int32_t res;
 
@@ -1623,19 +1845,35 @@ static void reset_heartbeat_timeout (struct totemsrp_instance *instance) {
 }
 
 
+/**
+ * @brief cancel_token_timeout
+ * @param instance
+ */
 static void cancel_token_timeout (struct totemsrp_instance *instance) {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_orf_token_timeout);
 }
 
+/**
+ * @brief cancel_heartbeat_timeout
+ * @param instance
+ */
 static void cancel_heartbeat_timeout (struct totemsrp_instance *instance) {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_heartbeat_timeout);
 }
 
+/**
+ * @brief cancel_token_retransmit_timeout
+ * @param instance
+ */
 static void cancel_token_retransmit_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_del (instance->totemsrp_poll_handle, instance->timer_orf_token_retransmit_timeout);
 }
 
+/**
+ * @brief start_token_hold_retransmit_timeout
+ * @param instance
+ */
 static void start_token_hold_retransmit_timeout (struct totemsrp_instance *instance)
 {
 	int32_t res;
@@ -1651,12 +1889,20 @@ static void start_token_hold_retransmit_timeout (struct totemsrp_instance *insta
 	}
 }
 
+/**
+ * @brief cancel_token_hold_retransmit_timeout
+ * @param instance
+ */
 static void cancel_token_hold_retransmit_timeout (struct totemsrp_instance *instance)
 {
 	qb_loop_timer_del (instance->totemsrp_poll_handle,
 		instance->timer_orf_token_hold_retransmit_timeout);
 }
 
+/**
+ * @brief memb_state_consensus_timeout_expired
+ * @param instance
+ */
 static void memb_state_consensus_timeout_expired (
 		struct totemsrp_instance *instance)
 {
@@ -1691,6 +1937,10 @@ static void memb_merge_detect_transmit (struct totemsrp_instance *instance);
 /*
  * Timers used for various states of the membership algorithm
  */
+/**
+ * @brief timer_function_pause_timeout
+ * @param data
+ */
 static void timer_function_pause_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -1699,6 +1949,10 @@ static void timer_function_pause_timeout (void *data)
 	reset_pause_timeout (instance);
 }
 
+/**
+ * @brief memb_recovery_state_token_loss
+ * @param instance
+ */
 static void memb_recovery_state_token_loss (struct totemsrp_instance *instance)
 {
 	old_ring_state_restore (instance);
@@ -1706,6 +1960,10 @@ static void memb_recovery_state_token_loss (struct totemsrp_instance *instance)
 	instance->stats.recovery_token_lost++;
 }
 
+/**
+ * @brief timer_function_orf_token_timeout
+ * @param data
+ */
 static void timer_function_orf_token_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -1745,6 +2003,10 @@ static void timer_function_orf_token_timeout (void *data)
 	}
 }
 
+/**
+ * @brief timer_function_heartbeat_timeout
+ * @param data
+ */
 static void timer_function_heartbeat_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -1753,6 +2015,10 @@ static void timer_function_heartbeat_timeout (void *data)
 	timer_function_orf_token_timeout(data);
 }
 
+/**
+ * @brief memb_timer_function_state_gather
+ * @param data
+ */
 static void memb_timer_function_state_gather (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -1786,12 +2052,20 @@ static void memb_timer_function_state_gather (void *data)
 	}
 }
 
+/**
+ * @brief memb_timer_function_gather_consensus_timeout
+ * @param data
+ */
 static void memb_timer_function_gather_consensus_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
 	memb_state_consensus_timeout_expired (instance);
 }
 
+/**
+ * @brief deliver_messages_from_recovery_to_regular
+ * @param instance
+ */
 static void deliver_messages_from_recovery_to_regular (struct totemsrp_instance *instance)
 {
 	unsigned int i;
@@ -1868,6 +2142,10 @@ static void deliver_messages_from_recovery_to_regular (struct totemsrp_instance 
 
 /*
  * Change states in the state machine of the membership algorithm
+ */
+/**
+ * @brief memb_state_operational_enter
+ * @param instance
  */
 static void memb_state_operational_enter (struct totemsrp_instance *instance)
 {
@@ -2093,6 +2371,11 @@ static void memb_state_operational_enter (struct totemsrp_instance *instance)
 	return;
 }
 
+/**
+ * @brief memb_state_gather_enter
+ * @param instance
+ * @param gather_from
+ */
 static void memb_state_gather_enter (
 	struct totemsrp_instance *instance,
 	enum gather_state_from gather_from)
@@ -2168,8 +2451,16 @@ static void memb_state_gather_enter (
 	return;
 }
 
+/**
+ * @brief timer_function_token_retransmit_timeout
+ * @param data
+ */
 static void timer_function_token_retransmit_timeout (void *data);
 
+/**
+ * @brief target_set_completed
+ * @param context
+ */
 static void target_set_completed (
 	void *context)
 {
@@ -2179,6 +2470,10 @@ static void target_set_completed (
 
 }
 
+/**
+ * @brief memb_state_commit_enter
+ * @param instance
+ */
 static void memb_state_commit_enter (
 	struct totemsrp_instance *instance)
 {
@@ -2222,6 +2517,11 @@ static void memb_state_commit_enter (
 	 */
 }
 
+/**
+ * @brief memb_state_recovery_enter
+ * @param instance
+ * @param commit_token
+ */
 static void memb_state_recovery_enter (
 	struct totemsrp_instance *instance,
 	struct memb_commit_token *commit_token)
@@ -2413,6 +2713,12 @@ originated:
 	return;
 }
 
+/**
+ * @brief totemsrp_event_signal
+ * @param srp_context
+ * @param type
+ * @param value
+ */
 void totemsrp_event_signal (void *srp_context, enum totem_event_type type, int value)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)srp_context;
@@ -2422,6 +2728,14 @@ void totemsrp_event_signal (void *srp_context, enum totem_event_type type, int v
 	return;
 }
 
+/**
+ * @brief totemsrp_mcast
+ * @param srp_context
+ * @param iovec
+ * @param iov_len
+ * @param guarantee
+ * @return
+ */
 int totemsrp_mcast (
 	void *srp_context,
 	struct iovec *iovec,
@@ -2491,6 +2805,11 @@ error_mcast:
 /*
  * Determine if there is room to queue a new message
  */
+/**
+ * @brief totemsrp_avail
+ * @param srp_context
+ * @return
+ */
 int totemsrp_avail (void *srp_context)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)srp_context;
@@ -2512,6 +2831,12 @@ int totemsrp_avail (void *srp_context)
  */
 /*
  * Recast message to mcast group if it is available
+ */
+/**
+ * @brief orf_token_remcast
+ * @param instance
+ * @param seq
+ * @return
  */
 static int orf_token_remcast (
 	struct totemsrp_instance *instance,
@@ -2556,6 +2881,11 @@ static int orf_token_remcast (
 
 /*
  * Free all freeable messages from ring
+ */
+/**
+ * @brief messages_free
+ * @param instance
+ * @param token_aru
  */
 static void messages_free (
 	struct totemsrp_instance *instance,
@@ -2611,6 +2941,10 @@ static void messages_free (
 	}
 }
 
+/**
+ * @brief update_aru
+ * @param instance
+ */
 static void update_aru (
 	struct totemsrp_instance *instance)
 {
@@ -2646,6 +2980,13 @@ static void update_aru (
 
 /*
  * Multicasts pending messages onto the ring (requires orf_token possession)
+ */
+/**
+ * @brief orf_token_mcast
+ * @param instance
+ * @param token
+ * @param fcc_mcasts_allowed
+ * @return
  */
 static int orf_token_mcast (
 	struct totemsrp_instance *instance,
@@ -2725,6 +3066,13 @@ static int orf_token_mcast (
 /*
  * Remulticasts messages in orf_token's retransmit list (requires orf_token)
  * Modify's orf_token's rtr to include retransmits required by this process
+ */
+/**
+ * @brief orf_token_rtr
+ * @param instance
+ * @param orf_token
+ * @param fcc_allowed
+ * @return
  */
 static int orf_token_rtr (
 	struct totemsrp_instance *instance,
@@ -2857,6 +3205,10 @@ static int orf_token_rtr (
 	return (instance->fcc_remcast_current);
 }
 
+/**
+ * @brief token_retransmit
+ * @param instance
+ */
 static void token_retransmit (struct totemsrp_instance *instance)
 {
 	totemnet_token_send (instance->totemnet_context,
@@ -2868,6 +3220,10 @@ static void token_retransmit (struct totemsrp_instance *instance)
  * Retransmit the regular token if no mcast or token has
  * been received in retransmit token period retransmit
  * the token to the next processor
+ */
+/**
+ * @brief timer_function_token_retransmit_timeout
+ * @param data
  */
 static void timer_function_token_retransmit_timeout (void *data)
 {
@@ -2885,6 +3241,10 @@ static void timer_function_token_retransmit_timeout (void *data)
 	}
 }
 
+/**
+ * @brief timer_function_token_hold_retransmit_timeout
+ * @param data
+ */
 static void timer_function_token_hold_retransmit_timeout (void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -2901,6 +3261,10 @@ static void timer_function_token_hold_retransmit_timeout (void *data)
 	}
 }
 
+/**
+ * @brief timer_function_merge_detect_timeout
+ * @param data
+ */
 static void timer_function_merge_detect_timeout(void *data)
 {
 	struct totemsrp_instance *instance = data;
@@ -2922,6 +3286,13 @@ static void timer_function_merge_detect_timeout(void *data)
 
 /*
  * Send orf_token to next member (requires orf_token)
+ */
+/**
+ * @brief token_send
+ * @param instance
+ * @param orf_token
+ * @param forward_token
+ * @return
  */
 static int token_send (
 	struct totemsrp_instance *instance,
@@ -2950,6 +3321,11 @@ static int token_send (
 	return (res);
 }
 
+/**
+ * @brief token_hold_cancel_send
+ * @param instance
+ * @return
+ */
 static int token_hold_cancel_send (struct totemsrp_instance *instance)
 {
 	struct token_hold_cancel token_hold_cancel;
@@ -2981,6 +3357,11 @@ static int token_hold_cancel_send (struct totemsrp_instance *instance)
 	return (0);
 }
 
+/**
+ * @brief orf_token_send_initial
+ * @param instance
+ * @return
+ */
 static int orf_token_send_initial (struct totemsrp_instance *instance)
 {
 	struct orf_token orf_token;
@@ -3020,6 +3401,10 @@ static int orf_token_send_initial (struct totemsrp_instance *instance)
 	return (res);
 }
 
+/**
+ * @brief memb_state_commit_token_update
+ * @param instance
+ */
 static void memb_state_commit_token_update (
 	struct totemsrp_instance *instance)
 {
@@ -3087,6 +3472,10 @@ static void memb_state_commit_token_update (
 	assert (instance->commit_token->header.nodeid);
 }
 
+/**
+ * @brief memb_state_commit_token_target_set
+ * @param instance
+ */
 static void memb_state_commit_token_target_set (
 	struct totemsrp_instance *instance)
 {
@@ -3101,6 +3490,12 @@ static void memb_state_commit_token_target_set (
 		      instance->commit_token->addr_entries].addr[0]);
 }
 
+/**
+ * @brief memb_state_commit_token_send_recovery
+ * @param instance
+ * @param commit_token
+ * @return
+ */
 static int memb_state_commit_token_send_recovery (
 	struct totemsrp_instance *instance,
 	struct memb_commit_token *commit_token)
@@ -3131,6 +3526,11 @@ static int memb_state_commit_token_send_recovery (
 	return (0);
 }
 
+/**
+ * @brief memb_state_commit_token_send
+ * @param instance
+ * @return
+ */
 static int memb_state_commit_token_send (
 	struct totemsrp_instance *instance)
 {
@@ -3160,7 +3560,11 @@ static int memb_state_commit_token_send (
 	return (0);
 }
 
-
+/**
+ * @brief memb_lowest_in_config
+ * @param instance
+ * @return
+ */
 static int memb_lowest_in_config (struct totemsrp_instance *instance)
 {
 	struct srp_addr token_memb[PROCESSOR_COUNT_MAX];
@@ -3185,6 +3589,12 @@ static int memb_lowest_in_config (struct totemsrp_instance *instance)
 	return (totemip_compare (lowest_addr, &instance->my_id.addr[0]) == 0);
 }
 
+/**
+ * @brief srp_addr_compare
+ * @param a
+ * @param b
+ * @return
+ */
 static int srp_addr_compare (const void *a, const void *b)
 {
 	const struct srp_addr *srp_a = (const struct srp_addr *)a;
@@ -3193,6 +3603,10 @@ static int srp_addr_compare (const void *a, const void *b)
 	return (totemip_compare (&srp_a->addr[0], &srp_b->addr[0]));
 }
 
+/**
+ * @brief memb_state_commit_token_create
+ * @param instance
+ */
 static void memb_state_commit_token_create (
 	struct totemsrp_instance *instance)
 {
@@ -3238,6 +3652,10 @@ static void memb_state_commit_token_create (
 		sizeof (struct memb_commit_token_memb_entry) * token_memb_entries);
 }
 
+/**
+ * @brief memb_join_message_send
+ * @param instance
+ */
 static void memb_join_message_send (struct totemsrp_instance *instance)
 {
 	char memb_join_data[40000];
@@ -3290,6 +3708,10 @@ static void memb_join_message_send (struct totemsrp_instance *instance)
 		addr_idx);
 }
 
+/**
+ * @brief memb_leave_message_send
+ * @param instance
+ */
 static void memb_leave_message_send (struct totemsrp_instance *instance)
 {
 	char memb_join_data[40000];
@@ -3360,6 +3782,10 @@ static void memb_leave_message_send (struct totemsrp_instance *instance)
 		addr_idx);
 }
 
+/**
+ * @brief memb_merge_detect_transmit
+ * @param instance
+ */
 static void memb_merge_detect_transmit (struct totemsrp_instance *instance)
 {
 	struct memb_merge_detect memb_merge_detect;
@@ -3379,6 +3805,11 @@ static void memb_merge_detect_transmit (struct totemsrp_instance *instance)
 		sizeof (struct memb_merge_detect));
 }
 
+/**
+ * @brief memb_ring_id_set
+ * @param instance
+ * @param ring_id
+ */
 static void memb_ring_id_set (
 	struct totemsrp_instance *instance,
 	const struct memb_ring_id *ring_id)
@@ -3387,6 +3818,9 @@ static void memb_ring_id_set (
 	memcpy (&instance->my_ring_id, ring_id, sizeof (struct memb_ring_id));
 }
 
+/**
+ *
+ */
 int totemsrp_callback_token_create (
 	void *srp_context,
 	void **handle_out,
@@ -3422,6 +3856,11 @@ int totemsrp_callback_token_create (
 	return (0);
 }
 
+/**
+ * @brief totemsrp_callback_token_destroy
+ * @param srp_context
+ * @param handle_out
+ */
 void totemsrp_callback_token_destroy (void *srp_context, void **handle_out)
 {
 	struct token_callback_instance *h;
@@ -3435,6 +3874,11 @@ void totemsrp_callback_token_destroy (void *srp_context, void **handle_out)
 	}
 }
 
+/**
+ * @brief token_callbacks_execute
+ * @param instance
+ * @param type
+ */
 static void token_callbacks_execute (
 	struct totemsrp_instance *instance,
 	enum totem_callback_token_type type)
@@ -3480,6 +3924,11 @@ static void token_callbacks_execute (
 /*
  * Flow control functions
  */
+/**
+ * @brief backlog_get
+ * @param instance
+ * @return
+ */
 static unsigned int backlog_get (struct totemsrp_instance *instance)
 {
 	unsigned int backlog = 0;
@@ -3504,6 +3953,12 @@ static unsigned int backlog_get (struct totemsrp_instance *instance)
 	return (backlog);
 }
 
+/**
+ * @brief fcc_calculate
+ * @param instance
+ * @param token
+ * @return
+ */
 static int fcc_calculate (
 	struct totemsrp_instance *instance,
 	struct orf_token *token)
@@ -3537,6 +3992,12 @@ static int fcc_calculate (
 /*
  * don't overflow the RTR sort queue
  */
+/**
+ * @brief fcc_rtr_limit
+ * @param instance
+ * @param token
+ * @param transmits_allowed
+ */
 static void fcc_rtr_limit (
 	struct totemsrp_instance *instance,
 	struct orf_token *token,
@@ -3555,6 +4016,12 @@ static void fcc_rtr_limit (
 	}
 }
 
+/**
+ * @brief fcc_token_update
+ * @param instance
+ * @param token
+ * @param msgs_transmitted
+ */
 static void fcc_token_update (
 	struct totemsrp_instance *instance,
 	struct orf_token *token,
@@ -3573,6 +4040,15 @@ static void fcc_token_update (
 unsigned long long int tv_old;
 /*
  * message handler called when TOKEN message type received
+ */
+
+/**
+ * @brief message_handler_orf_token
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
  */
 static int message_handler_orf_token (
 	struct totemsrp_instance *instance,
@@ -3880,6 +4356,12 @@ printf ("token seq %d\n", token->seq);
 	return (0);
 }
 
+/**
+ * @brief messages_deliver_to_app
+ * @param instance
+ * @param skip
+ * @param end_point
+ */
 static void messages_deliver_to_app (
 	struct totemsrp_instance *instance,
 	int skip,
@@ -3984,6 +4466,14 @@ static void messages_deliver_to_app (
 
 /*
  * recv message handler called when MCAST message type received
+ */
+/**
+ * @brief message_handler_mcast
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
  */
 static int message_handler_mcast (
 	struct totemsrp_instance *instance,
@@ -4099,6 +4589,14 @@ static int message_handler_mcast (
 	return (0);
 }
 
+/**
+ * @brief message_handler_memb_merge_detect
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
+ */
 static int message_handler_memb_merge_detect (
 	struct totemsrp_instance *instance,
 	const void *msg,
@@ -4159,6 +4657,11 @@ static int message_handler_memb_merge_detect (
 	return (0);
 }
 
+/**
+ * @brief memb_join_process
+ * @param instance
+ * @param memb_join
+ */
 static void memb_join_process (
 	struct totemsrp_instance *instance,
 	const struct memb_join *memb_join)
@@ -4308,6 +4811,11 @@ out:
 	}
 }
 
+/**
+ * @brief memb_join_endian_convert
+ * @param in
+ * @param out
+ */
 static void memb_join_endian_convert (const struct memb_join *in, struct memb_join *out)
 {
 	int i;
@@ -4337,6 +4845,11 @@ static void memb_join_endian_convert (const struct memb_join *in, struct memb_jo
 	}
 }
 
+/**
+ * @brief memb_commit_token_endian_convert
+ * @param in
+ * @param out
+ */
 static void memb_commit_token_endian_convert (const struct memb_commit_token *in, struct memb_commit_token *out)
 {
 	int i;
@@ -4376,6 +4889,11 @@ static void memb_commit_token_endian_convert (const struct memb_commit_token *in
 	}
 }
 
+/**
+ * @brief orf_token_endian_convert
+ * @param in
+ * @param out
+ */
 static void orf_token_endian_convert (const struct orf_token *in, struct orf_token *out)
 {
 	int i;
@@ -4400,6 +4918,11 @@ static void orf_token_endian_convert (const struct orf_token *in, struct orf_tok
 	}
 }
 
+/**
+ * @brief mcast_endian_convert
+ * @param in
+ * @param out
+ */
 static void mcast_endian_convert (const struct mcast *in, struct mcast *out)
 {
 	out->header.type = in->header.type;
@@ -4416,6 +4939,11 @@ static void mcast_endian_convert (const struct mcast *in, struct mcast *out)
 	srp_addr_copy_endian_convert (&out->system_from, &in->system_from);
 }
 
+/**
+ * @brief memb_merge_detect_endian_convert
+ * @param in
+ * @param out
+ */
 static void memb_merge_detect_endian_convert (
 	const struct memb_merge_detect *in,
 	struct memb_merge_detect *out)
@@ -4428,6 +4956,12 @@ static void memb_merge_detect_endian_convert (
 	srp_addr_copy_endian_convert (&out->system_from, &in->system_from);
 }
 
+/**
+ * @brief ignore_join_under_operational
+ * @param instance
+ * @param memb_join
+ * @return
+ */
 static int ignore_join_under_operational (
 	struct totemsrp_instance *instance,
 	const struct memb_join *memb_join)
@@ -4458,6 +4992,14 @@ static int ignore_join_under_operational (
 	return (0);
 }
 
+/**
+ * @brief message_handler_memb_join
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
+ */
 static int message_handler_memb_join (
 	struct totemsrp_instance *instance,
 	const void *msg,
@@ -4527,6 +5069,14 @@ static int message_handler_memb_join (
 	return (0);
 }
 
+/**
+ * @brief message_handler_memb_commit_token
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
+ */
 static int message_handler_memb_commit_token (
 	struct totemsrp_instance *instance,
 	const void *msg,
@@ -4614,6 +5164,14 @@ static int message_handler_memb_commit_token (
 	return (0);
 }
 
+/**
+ * @brief message_handler_token_hold_cancel
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_needed
+ * @return
+ */
 static int message_handler_token_hold_cancel (
 	struct totemsrp_instance *instance,
 	const void *msg,
@@ -4633,6 +5191,12 @@ static int message_handler_token_hold_cancel (
 	return (0);
 }
 
+/**
+ * @brief main_deliver_fn
+ * @param context
+ * @param msg
+ * @param msg_len
+ */
 void main_deliver_fn (
 	void *context,
 	const void *msg,
@@ -4684,6 +5248,12 @@ printf ("wrong message type\n");
 		message_header->endian_detector != ENDIAN_LOCAL);
 }
 
+/**
+ * @brief main_iface_change_fn
+ * @param context
+ * @param iface_addr
+ * @param iface_no
+ */
 void main_iface_change_fn (
 	void *context,
 	const struct totem_ip_address *iface_addr,
@@ -4724,10 +5294,18 @@ void main_iface_change_fn (
 	}
 }
 
+/**
+ * @brief totemsrp_net_mtu_adjust
+ * @param totem_config
+ */
 void totemsrp_net_mtu_adjust (struct totem_config *totem_config) {
 	totem_config->net_mtu -= sizeof (struct mcast);
 }
 
+/**
+ * @brief totemsrp_service_ready_register
+ * @param context
+ */
 void totemsrp_service_ready_register (
 	void *context,
         void (*totem_service_ready) (void))
@@ -4737,6 +5315,13 @@ void totemsrp_service_ready_register (
 	instance->totemsrp_service_ready_fn = totem_service_ready;
 }
 
+/**
+ * @brief totemsrp_member_add
+ * @param context
+ * @param member
+ * @param ring_no
+ * @return
+ */
 int totemsrp_member_add (
         void *context,
         const struct totem_ip_address *member,
@@ -4750,6 +5335,13 @@ int totemsrp_member_add (
 	return (res);
 }
 
+/**
+ * @brief totemsrp_member_remove
+ * @param context
+ * @param member
+ * @param ring_no
+ * @return
+ */
 int totemsrp_member_remove (
         void *context,
         const struct totem_ip_address *member,
@@ -4763,6 +5355,10 @@ int totemsrp_member_remove (
 	return (res);
 }
 
+/**
+ * @brief totemsrp_threaded_mode_enable
+ * @param context
+ */
 void totemsrp_threaded_mode_enable (void *context)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)context;
@@ -4770,6 +5366,10 @@ void totemsrp_threaded_mode_enable (void *context)
 	instance->threaded_mode_enabled = 1;
 }
 
+/**
+ * @brief totemsrp_trans_ack
+ * @param context
+ */
 void totemsrp_trans_ack (void *context)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)context;

--- a/exec/totemudp.c
+++ b/exec/totemudp.c
@@ -88,6 +88,9 @@
 
 #define MESSAGE_TYPE_MEMB_JOIN	3
 
+/**
+ * @brief The totemudp_socket struct
+ */
 struct totemudp_socket {
 	int mcast_recv;
 	int mcast_send;
@@ -101,6 +104,9 @@ struct totemudp_socket {
 	int local_mcast_loop[2];
 };
 
+/**
+ * @brief The totemudp_instance struct
+ */
 struct totemudp_instance {
 	qb_loop_t *totemudp_poll_handle;
 
@@ -191,12 +197,24 @@ struct totemudp_instance {
 	struct totem_ip_address token_target;
 };
 
+/**
+ * @brief The work_item struct
+ */
 struct work_item {
 	const void *msg;
 	unsigned int msg_len;
 	struct totemudp_instance *instance;
 };
 
+/**
+ * @brief totemudp_build_sockets
+ * @param instance
+ * @param bindnet_address
+ * @param mcastaddress
+ * @param sockets
+ * @param bound_to
+ * @return
+ */
 static int totemudp_build_sockets (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *bindnet_address,
@@ -206,6 +224,10 @@ static int totemudp_build_sockets (
 
 static struct totem_ip_address localhost;
 
+/**
+ * @brief totemudp_instance_initialize
+ * @param instance
+ */
 static void totemudp_instance_initialize (struct totemudp_instance *instance)
 {
 	memset (instance, 0, sizeof (struct totemudp_instance));
@@ -243,6 +265,13 @@ do {												\
 		fmt ": %s (%d)\n", ##args, _error_ptr, err_num);				\
 	} while(0)
 
+/**
+ * @brief totemudp_crypto_set
+ * @param udp_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemudp_crypto_set (
 	void *udp_context,
 	const char *cipher_type,
@@ -253,6 +282,13 @@ int totemudp_crypto_set (
 }
 
 
+/**
+ * @brief ucast_sendmsg
+ * @param instance
+ * @param system_to
+ * @param msg
+ * @param msg_len
+ */
 static inline void ucast_sendmsg (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *system_to,
@@ -307,6 +343,12 @@ static inline void ucast_sendmsg (
 	}
 }
 
+/**
+ * @brief mcast_sendmsg
+ * @param instance
+ * @param msg
+ * @param msg_len
+ */
 static inline void mcast_sendmsg (
 	struct totemudp_instance *instance,
 	const void *msg,
@@ -377,6 +419,11 @@ static inline void mcast_sendmsg (
 }
 
 
+/**
+ * @brief totemudp_finalize
+ * @param udp_context
+ * @return
+ */
 int totemudp_finalize (
 	void *udp_context)
 {
@@ -410,6 +457,13 @@ int totemudp_finalize (
  * Only designed to work with a message with one iov
  */
 
+/**
+ * @brief net_deliver_fn
+ * @param fd
+ * @param revents
+ * @param data
+ * @return
+ */
 static int net_deliver_fn (
 	int fd,
 	int revents,
@@ -483,6 +537,15 @@ static int net_deliver_fn (
 	return (0);
 }
 
+/**
+ * @brief netif_determine
+ * @param instance
+ * @param bindnet
+ * @param bound_to
+ * @param interface_up
+ * @param interface_num
+ * @return
+ */
 static int netif_determine (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *bindnet,
@@ -504,6 +567,10 @@ static int netif_determine (
 /*
  * If the interface is up, the sockets for totem are built.  If the interface is down
  * this function is requeued in the timer list to retry building the sockets later.
+ */
+/**
+ * @brief timer_function_netif_check_timeout
+ * @param data
  */
 static void timer_function_netif_check_timeout (
 	void *data)
@@ -652,6 +719,12 @@ static void timer_function_netif_check_timeout (
 
 /* Set the socket priority to INTERACTIVE to ensure
    that our messages don't get queued behind anything else */
+
+/**
+ * @brief totemudp_traffic_control_set
+ * @param instance
+ * @param sock
+ */
 static void totemudp_traffic_control_set(struct totemudp_instance *instance, int sock)
 {
 #ifdef SO_PRIORITY
@@ -663,6 +736,16 @@ static void totemudp_traffic_control_set(struct totemudp_instance *instance, int
 #endif
 }
 
+/**
+ * @brief totemudp_build_sockets_ip
+ * @param instance
+ * @param mcast_address
+ * @param bindnet_address
+ * @param sockets
+ * @param bound_to
+ * @param interface_num
+ * @return
+ */
 static int totemudp_build_sockets_ip (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *mcast_address,
@@ -1014,6 +1097,15 @@ static int totemudp_build_sockets_ip (
 	return 0;
 }
 
+/**
+ * @brief totemudp_build_sockets
+ * @param instance
+ * @param mcast_address
+ * @param bindnet_address
+ * @param sockets
+ * @param bound_to
+ * @return
+ */
 static int totemudp_build_sockets (
 	struct totemudp_instance *instance,
 	struct totem_ip_address *mcast_address,
@@ -1140,16 +1232,30 @@ int totemudp_initialize (
 	return (0);
 }
 
+/**
+ * @brief totemudp_buffer_alloc
+ * @return
+ */
 void *totemudp_buffer_alloc (void)
 {
 	return malloc (FRAME_SIZE_MAX);
 }
 
+/**
+ * @brief totemudp_buffer_release
+ * @param ptr
+ */
 void totemudp_buffer_release (void *ptr)
 {
 	return free (ptr);
 }
 
+/**
+ * @brief totemudp_processor_count_set
+ * @param udp_context
+ * @param processor_count
+ * @return
+ */
 int totemudp_processor_count_set (
 	void *udp_context,
 	int processor_count)
@@ -1172,6 +1278,11 @@ int totemudp_processor_count_set (
 	return (res);
 }
 
+/**
+ * @brief totemudp_recv_flush
+ * @param udp_context
+ * @return
+ */
 int totemudp_recv_flush (void *udp_context)
 {
 	struct totemudp_instance *instance = (struct totemudp_instance *)udp_context;
@@ -1208,11 +1319,23 @@ int totemudp_recv_flush (void *udp_context)
 	return (res);
 }
 
+/**
+ * @brief totemudp_send_flush
+ * @param udp_context
+ * @return
+ */
 int totemudp_send_flush (void *udp_context)
 {
 	return 0;
 }
 
+/**
+ * @brief totemudp_token_send
+ * @param udp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudp_token_send (
 	void *udp_context,
 	const void *msg,
@@ -1225,6 +1348,14 @@ int totemudp_token_send (
 
 	return (res);
 }
+
+/**
+ * @brief totemudp_mcast_flush_send
+ * @param udp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudp_mcast_flush_send (
 	void *udp_context,
 	const void *msg,
@@ -1238,6 +1369,13 @@ int totemudp_mcast_flush_send (
 	return (res);
 }
 
+/**
+ * @brief totemudp_mcast_noflush_send
+ * @param udp_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudp_mcast_noflush_send (
 	void *udp_context,
 	const void *msg,
@@ -1251,6 +1389,11 @@ int totemudp_mcast_noflush_send (
 	return (res);
 }
 
+/**
+ * @brief totemudp_iface_check
+ * @param udp_context
+ * @return
+ */
 extern int totemudp_iface_check (void *udp_context)
 {
 	struct totemudp_instance *instance = (struct totemudp_instance *)udp_context;
@@ -1261,6 +1404,13 @@ extern int totemudp_iface_check (void *udp_context)
 	return (res);
 }
 
+/**
+ * @brief totemudp_ifaces_get
+ * @param net_context
+ * @param status
+ * @param iface_count
+ * @return
+ */
 int totemudp_ifaces_get (
 	void *net_context,
 	char ***status,
@@ -1276,6 +1426,11 @@ int totemudp_ifaces_get (
 	return (0);
 }
 
+/**
+ * @brief totemudp_net_mtu_adjust
+ * @param udp_context
+ * @param totem_config
+ */
 extern void totemudp_net_mtu_adjust (void *udp_context, struct totem_config *totem_config)
 {
 
@@ -1284,6 +1439,12 @@ extern void totemudp_net_mtu_adjust (void *udp_context, struct totem_config *tot
 	totem_config->net_mtu -= totemip_udpip_header_size(totem_config->interfaces[0].bindnet.family);
 }
 
+/**
+ * @brief totemudp_token_target_set
+ * @param udp_context
+ * @param token_target
+ * @return
+ */
 int totemudp_token_target_set (
 	void *udp_context,
 	const struct totem_ip_address *token_target)
@@ -1299,6 +1460,11 @@ int totemudp_token_target_set (
 	return (res);
 }
 
+/**
+ * @brief totemudp_recv_mcast_empty
+ * @param udp_context
+ * @return
+ */
 extern int totemudp_recv_mcast_empty (
 	void *udp_context)
 {

--- a/exec/totemudpu.c
+++ b/exec/totemudpu.c
@@ -212,6 +212,10 @@ static void totemudpu_stop_merge_detect_timeout(
 
 static struct totem_ip_address localhost;
 
+/**
+ * @brief totemudpu_instance_initialize
+ * @param instance
+ */
 static void totemudpu_instance_initialize (struct totemudpu_instance *instance)
 {
 	memset (instance, 0, sizeof (struct totemudpu_instance));
@@ -247,6 +251,13 @@ do {												\
 		fmt ": %s (%d)", ##args, _error_ptr, err_num);				\
 	} while(0)
 
+/**
+ * @brief totemudpu_crypto_set
+ * @param udpu_context
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 int totemudpu_crypto_set (
 	void *udpu_context,
 	const char *cipher_type,
@@ -256,7 +267,13 @@ int totemudpu_crypto_set (
 	return (0);
 }
 
-
+/**
+ * @brief ucast_sendmsg
+ * @param instance
+ * @param system_to
+ * @param msg
+ * @param msg_len
+ */
 static inline void ucast_sendmsg (
 	struct totemudpu_instance *instance,
 	struct totem_ip_address *system_to,
@@ -310,6 +327,13 @@ static inline void ucast_sendmsg (
 	}
 }
 
+/**
+ * @brief mcast_sendmsg
+ * @param instance
+ * @param msg
+ * @param msg_len
+ * @param only_active
+ */
 static inline void mcast_sendmsg (
 	struct totemudpu_instance *instance,
 	const void *msg,
@@ -385,6 +409,11 @@ static inline void mcast_sendmsg (
 	}
 }
 
+/**
+ * @brief totemudpu_finalize
+ * @param udpu_context
+ * @return
+ */
 int totemudpu_finalize (
 	void *udpu_context)
 {
@@ -402,6 +431,13 @@ int totemudpu_finalize (
 	return (res);
 }
 
+/**
+ * @brief net_deliver_fn
+ * @param fd
+ * @param revents
+ * @param data
+ * @return
+ */
 static int net_deliver_fn (
 	int fd,
 	int revents,
@@ -459,6 +495,16 @@ static int net_deliver_fn (
 	return (0);
 }
 
+
+/**
+ * @brief netif_determine
+ * @param instance
+ * @param bindnet
+ * @param bound_to
+ * @param interface_up
+ * @param interface_num
+ * @return
+ */
 static int netif_determine (
 	struct totemudpu_instance *instance,
 	struct totem_ip_address *bindnet,
@@ -480,6 +526,11 @@ static int netif_determine (
 /*
  * If the interface is up, the sockets for totem are built.  If the interface is down
  * this function is requeued in the timer list to retry building the sockets later.
+ */
+
+/**
+ * @brief timer_function_netif_check_timeout
+ * @param data
  */
 static void timer_function_netif_check_timeout (
 	void *data)
@@ -599,6 +650,12 @@ static void timer_function_netif_check_timeout (
 
 /* Set the socket priority to INTERACTIVE to ensure
    that our messages don't get queued behind anything else */
+
+/**
+ * @brief totemudpu_traffic_control_set
+ * @param instance
+ * @param sock
+ */
 static void totemudpu_traffic_control_set(struct totemudpu_instance *instance, int sock)
 {
 #ifdef SO_PRIORITY
@@ -611,6 +668,14 @@ static void totemudpu_traffic_control_set(struct totemudpu_instance *instance, i
 #endif
 }
 
+/**
+ * @brief totemudpu_build_sockets_ip
+ * @param instance
+ * @param bindnet_address
+ * @param bound_to
+ * @param interface_num
+ * @return
+ */
 static int totemudpu_build_sockets_ip (
 	struct totemudpu_instance *instance,
 	struct totem_ip_address *bindnet_address,
@@ -683,7 +748,13 @@ int totemudpu_ifaces_get (
 	return (0);
 }
 
-
+/**
+ * @brief totemudpu_build_sockets
+ * @param instance
+ * @param bindnet_address
+ * @param bound_to
+ * @return
+ */
 static int totemudpu_build_sockets (
 	struct totemudpu_instance *instance,
 	struct totem_ip_address *bindnet_address,
@@ -729,6 +800,17 @@ static int totemudpu_build_sockets (
 
 /*
  * Create an instance
+ */
+
+/**
+ * @brief totemudpu_initialize
+ * @param poll_handle
+ * @param udpu_context
+ * @param totem_config
+ * @param stats
+ * @param interface_no
+ * @param context
+ * @return
  */
 int totemudpu_initialize (
 	qb_loop_t *poll_handle,
@@ -814,16 +896,30 @@ int totemudpu_initialize (
 	return (0);
 }
 
+/**
+ * @brief totemudpu_buffer_alloc
+ * @return
+ */
 void *totemudpu_buffer_alloc (void)
 {
 	return malloc (UDPU_FRAME_SIZE_MAX);
 }
 
+/**
+ * @brief totemudpu_buffer_release
+ * @param ptr
+ */
 void totemudpu_buffer_release (void *ptr)
 {
 	return free (ptr);
 }
 
+/**
+ * @brief totemudpu_processor_count_set
+ * @param udpu_context
+ * @param processor_count
+ * @return
+ */
 int totemudpu_processor_count_set (
 	void *udpu_context,
 	int processor_count)
@@ -846,6 +942,11 @@ int totemudpu_processor_count_set (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_recv_flush
+ * @param udpu_context
+ * @return
+ */
 int totemudpu_recv_flush (void *udpu_context)
 {
 	int res = 0;
@@ -853,6 +954,11 @@ int totemudpu_recv_flush (void *udpu_context)
 	return (res);
 }
 
+/**
+ * @brief totemudpu_send_flush
+ * @param udpu_context
+ * @return
+ */
 int totemudpu_send_flush (void *udpu_context)
 {
 	int res = 0;
@@ -860,6 +966,13 @@ int totemudpu_send_flush (void *udpu_context)
 	return (res);
 }
 
+/**
+ * @brief totemudpu_token_send
+ * @param udpu_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudpu_token_send (
 	void *udpu_context,
 	const void *msg,
@@ -872,6 +985,14 @@ int totemudpu_token_send (
 
 	return (res);
 }
+
+/**
+ * @brief totemudpu_mcast_flush_send
+ * @param udpu_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudpu_mcast_flush_send (
 	void *udpu_context,
 	const void *msg,
@@ -885,6 +1006,13 @@ int totemudpu_mcast_flush_send (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_mcast_noflush_send
+ * @param udpu_context
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 int totemudpu_mcast_noflush_send (
 	void *udpu_context,
 	const void *msg,
@@ -898,6 +1026,11 @@ int totemudpu_mcast_noflush_send (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_iface_check
+ * @param udpu_context
+ * @return
+ */
 extern int totemudpu_iface_check (void *udpu_context)
 {
 	struct totemudpu_instance *instance = (struct totemudpu_instance *)udpu_context;
@@ -908,6 +1041,11 @@ extern int totemudpu_iface_check (void *udpu_context)
 	return (res);
 }
 
+/**
+ * @brief totemudpu_net_mtu_adjust
+ * @param udpu_context
+ * @param totem_config
+ */
 extern void totemudpu_net_mtu_adjust (void *udpu_context, struct totem_config *totem_config)
 {
 
@@ -916,7 +1054,12 @@ extern void totemudpu_net_mtu_adjust (void *udpu_context, struct totem_config *t
 	totem_config->net_mtu -= totemip_udpip_header_size(totem_config->interfaces[0].bindnet.family);
 }
 
-
+/**
+ * @brief totemudpu_token_target_set
+ * @param udpu_context
+ * @param token_target
+ * @return
+ */
 int totemudpu_token_target_set (
 	void *udpu_context,
 	const struct totem_ip_address *token_target)
@@ -932,6 +1075,11 @@ int totemudpu_token_target_set (
 	return (res);
 }
 
+/**
+ * @brief totemudpu_recv_mcast_empty
+ * @param udpu_context
+ * @return
+ */
 extern int totemudpu_recv_mcast_empty (
 	void *udpu_context)
 {
@@ -983,6 +1131,12 @@ extern int totemudpu_recv_mcast_empty (
 	return (msg_processed);
 }
 
+/**
+ * @brief totemudpu_create_sending_socket
+ * @param udpu_context
+ * @param member
+ * @return
+ */
 static int totemudpu_create_sending_socket(
 	void *udpu_context,
 	const struct totem_ip_address *member)
@@ -1042,6 +1196,12 @@ error_close_fd:
 	return (-1);
 }
 
+/**
+ * @brief totemudpu_member_add
+ * @param udpu_context
+ * @param member
+ * @return
+ */
 int totemudpu_member_add (
 	void *udpu_context,
 	const struct totem_ip_address *local,
@@ -1070,6 +1230,12 @@ int totemudpu_member_add (
 	return (0);
 }
 
+/**
+ * @brief totemudpu_member_remove
+ * @param udpu_context
+ * @param token_target
+ * @return
+ */
 int totemudpu_member_remove (
 	void *udpu_context,
 	const struct totem_ip_address *token_target,
@@ -1118,6 +1284,11 @@ int totemudpu_member_remove (
 	return (0);
 }
 
+/**
+ * @brief totemudpu_member_list_rebind_ip
+ * @param udpu_context
+ * @return
+ */
 int totemudpu_member_list_rebind_ip (
 	void *udpu_context)
 {
@@ -1142,6 +1313,10 @@ int totemudpu_member_list_rebind_ip (
 }
 
 
+/**
+ * @brief timer_function_merge_detect_timeout
+ * @param data
+ */
 static void timer_function_merge_detect_timeout (
 	void *data)
 {
@@ -1156,6 +1331,10 @@ static void timer_function_merge_detect_timeout (
 	totemudpu_start_merge_detect_timeout(instance);
 }
 
+/**
+ * @brief totemudpu_start_merge_detect_timeout
+ * @param udpu_context
+ */
 static void totemudpu_start_merge_detect_timeout(
 	void *udpu_context)
 {
@@ -1170,6 +1349,10 @@ static void totemudpu_start_merge_detect_timeout(
 
 }
 
+/**
+ * @brief totemudpu_stop_merge_detect_timeout
+ * @param udpu_context
+ */
 static void totemudpu_stop_merge_detect_timeout(
 	void *udpu_context)
 {

--- a/exec/util.c
+++ b/exec/util.c
@@ -68,6 +68,13 @@ static struct service_names servicenames[] =
 	{ NULL, -1 }
 };
 
+/**
+ * @brief short_service_name_get
+ * @param service_id
+ * @param buf
+ * @param buf_size
+ * @return
+ */
 const char * short_service_name_get(uint32_t service_id,
 	char *buf, size_t buf_size)
 {
@@ -113,15 +120,31 @@ cs_time_t clust_time_now(void)
 }
 
 void _corosync_out_of_memory_error (void) __attribute__((noreturn));
+
+/**
+ * @brief _corosync_out_of_memory_error
+ */
 void _corosync_out_of_memory_error (void)
 {
 	assert (0==1);
 	exit (EXIT_FAILURE);
 }
 
+/**
+ * @brief _corosync_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 void _corosync_exit_error (
 	enum e_corosync_done err, const char *file, unsigned int line)  __attribute__((noreturn));
 
+/**
+ * @brief _corosync_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 void _corosync_exit_error (
 	enum e_corosync_done err, const char *file, unsigned int line)
 {
@@ -138,6 +161,11 @@ void _corosync_exit_error (
 
 #define min(a,b) ((a) < (b) ? (a) : (b))
 
+/**
+ * @brief getcs_name_t
+ * @param name
+ * @return
+ */
 char *getcs_name_t (cs_name_t *name)
 {
 	static char ret_name[CS_MAX_NAME_LENGTH];
@@ -151,6 +179,11 @@ char *getcs_name_t (cs_name_t *name)
 	return ((char *)name->value);
 }
 
+/**
+ * @brief setcs_name_t
+ * @param name
+ * @param str
+ */
 void setcs_name_t (cs_name_t *name, char *str) {
 	strncpy ((char *)name->value, str, sizeof (name->value));
 	((char *)name->value)[sizeof (name->value) - 1] = '\0';
@@ -161,6 +194,12 @@ void setcs_name_t (cs_name_t *name, char *str) {
 	}
 }
 
+/**
+ * @brief cs_name_tisEqual
+ * @param str1
+ * @param str2
+ * @return
+ */
 int cs_name_tisEqual (cs_name_t *str1, char *str2) {
 	if (str1->length == strlen (str2)) {
 		return ((strncmp ((char *)str1->value, (char *)str2,
@@ -170,6 +209,10 @@ int cs_name_tisEqual (cs_name_t *str1, char *str2) {
 	}
 }
 
+/**
+ * @brief get_run_dir
+ * @return
+ */
 const char *get_run_dir(void)
 {
 	static char path[PATH_MAX] = {'\0'};

--- a/exec/util.h
+++ b/exec/util.h
@@ -68,12 +68,43 @@ enum e_corosync_done {
  */
 extern int name_match(cs_name_t *name1, cs_name_t *name2);
 #define corosync_exit_error(err) _corosync_exit_error ((err), __FILE__, __LINE__)
+
+/**
+ * @brief _corosync_exit_error
+ * @param err
+ * @param file
+ * @param line
+ */
 extern void _corosync_exit_error (enum e_corosync_done err, const char *file,
 				  unsigned int line) __attribute__((noreturn));
+
+/**
+ * @brief _corosync_out_of_memory_error
+ */
 void _corosync_out_of_memory_error (void) __attribute__((noreturn));
+
+/**
+ * @brief getcs_name_t
+ * @param name
+ * @return
+ */
 extern char *getcs_name_t (cs_name_t *name);
+
+/**
+ * @brief setcs_name_t
+ * @param name
+ * @param str
+ */
 extern void setcs_name_t (cs_name_t *name, char *str);
+
+/**
+ * @brief cs_name_tisEqual
+ * @param str1
+ * @param str2
+ * @return
+ */
 extern int cs_name_tisEqual (cs_name_t *str1, char *str2);
+
 /**
  * Get the short name of a service from the service_id.
  */

--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -347,6 +347,9 @@ static void message_handler_req_lib_votequorum_qdevice_poll (void *conn,
 static void message_handler_req_lib_votequorum_qdevice_master_wins (void *conn,
 							     const void *message);
 
+/**
+ *
+ */
 static struct corosync_lib_handler quorum_lib_service[] =
 {
 	{ /* 0 */
@@ -391,6 +394,9 @@ static struct corosync_lib_handler quorum_lib_service[] =
 	}
 };
 
+/**
+ *
+ */
 static struct corosync_service_engine votequorum_service_engine = {
 	.name				= "corosync vote quorum service v1.0",
 	.id				= VOTEQUORUM_SERVICE,
@@ -412,11 +418,18 @@ static struct corosync_service_engine votequorum_service_engine = {
 	.sync_abort			= votequorum_sync_abort
 };
 
+/**
+ * @brief votequorum_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *votequorum_get_service_engine_ver0 (void)
 {
 	return (&votequorum_service_engine);
 }
 
+/**
+ *
+ */
 static struct default_service votequorum_service[] = {
 	{
 		.name		= "corosync_votequorum",
@@ -431,6 +444,10 @@ static struct default_service votequorum_service[] = {
 
 #define max(a,b) (((a) > (b)) ? (a) : (b))
 
+/**
+ * @brief node_add_ordered
+ * @param newnode
+ */
 static void node_add_ordered(struct cluster_node *newnode)
 {
 	struct cluster_node *node = NULL;
@@ -454,6 +471,11 @@ static void node_add_ordered(struct cluster_node *newnode)
 	LEAVE();
 }
 
+/**
+ * @brief allocate_node
+ * @param nodeid
+ * @return
+ */
 static struct cluster_node *allocate_node(unsigned int nodeid)
 {
 	struct cluster_node *cl = NULL;
@@ -493,6 +515,11 @@ out:
 	return cl;
 }
 
+/**
+ * @brief find_node_by_nodeid
+ * @param nodeid
+ * @return
+ */
 static struct cluster_node *find_node_by_nodeid(unsigned int nodeid)
 {
 	struct cluster_node *node;
@@ -522,6 +549,9 @@ static struct cluster_node *find_node_by_nodeid(unsigned int nodeid)
 	return NULL;
 }
 
+/**
+ * @brief get_lowest_node_id
+ */
 static void get_lowest_node_id(void)
 {
 	struct cluster_node *node = NULL;
@@ -544,6 +574,9 @@ static void get_lowest_node_id(void)
 	LEAVE();
 }
 
+/**
+ * @brief get_highest_node_id
+ */
 static void get_highest_node_id(void)
 {
 	struct cluster_node *node = NULL;
@@ -566,6 +599,10 @@ static void get_highest_node_id(void)
 	LEAVE();
 }
 
+/**
+ * @brief check_low_node_id_partition
+ * @return
+ */
 static int check_low_node_id_partition(void)
 {
 	struct cluster_node *node = NULL;
@@ -586,6 +623,10 @@ static int check_low_node_id_partition(void)
 	return found;
 }
 
+/**
+ * @brief check_high_node_id_partition
+ * @return
+ */
 static int check_high_node_id_partition(void)
 {
 	struct cluster_node *node = NULL;
@@ -606,6 +647,13 @@ static int check_high_node_id_partition(void)
 	return found;
 }
 
+/**
+ * @brief is_in_nodelist
+ * @param nodeid
+ * @param members
+ * @param entries
+ * @return
+ */
 static int is_in_nodelist(int nodeid, unsigned int *members, int entries)
 {
 	int i;
@@ -633,6 +681,10 @@ static int is_in_nodelist(int nodeid, unsigned int *members, int entries)
  * partition then we are quorate.
  *
  * Special cases lowest nodeid, and highest nodeid are handled separately.
+ */
+/**
+ * @brief check_auto_tie_breaker
+ * @return
  */
 static int check_auto_tie_breaker(void)
 {
@@ -690,6 +742,11 @@ static int check_auto_tie_breaker(void)
  *   'highest'
  *   a list of nodeids
  */
+
+/**
+ * @brief parse_atb_string
+ * @param atb_string
+ */
 static void parse_atb_string(char *atb_string)
 {
 	char *ptr;
@@ -731,6 +788,10 @@ static void parse_atb_string(char *atb_string)
 	LEAVE();
 }
 
+/**
+ * @brief check_qdevice_master
+ * @return
+ */
 static int check_qdevice_master(void)
 {
 	struct cluster_node *node = NULL;
@@ -752,6 +813,10 @@ static int check_qdevice_master(void)
 	return found;
 }
 
+/**
+ * @brief decode_flags
+ * @param flags
+ */
 static void decode_flags(uint32_t flags)
 {
 	ENTER();
@@ -772,6 +837,10 @@ static void decode_flags(uint32_t flags)
 
 /*
  * load/save are copied almost pristine from totemsrp,c
+ */
+/**
+ * @brief load_ev_tracking_barrier
+ * @return
  */
 static int load_ev_tracking_barrier(void)
 {
@@ -813,6 +882,10 @@ static int load_ev_tracking_barrier(void)
 	return -1;
 }
 
+/**
+ * @brief update_wait_for_all_status
+ * @param wfa_status
+ */
 static void update_wait_for_all_status(uint8_t wfa_status)
 {
 	ENTER();
@@ -829,6 +902,9 @@ static void update_wait_for_all_status(uint8_t wfa_status)
 	LEAVE();
 }
 
+/**
+ * @brief update_two_node
+ */
 static void update_two_node(void)
 {
 	ENTER();
@@ -838,6 +914,10 @@ static void update_two_node(void)
 	LEAVE();
 }
 
+/**
+ * @brief update_ev_barrier
+ * @param expected_votes
+ */
 static void update_ev_barrier(uint32_t expected_votes)
 {
 	ENTER();
@@ -848,6 +928,10 @@ static void update_ev_barrier(uint32_t expected_votes)
 	LEAVE();
 }
 
+/**
+ * @brief update_qdevice_can_operate
+ * @param status
+ */
 static void update_qdevice_can_operate(uint8_t status)
 {
 	ENTER();
@@ -858,6 +942,10 @@ static void update_qdevice_can_operate(uint8_t status)
 	LEAVE();
 }
 
+/**
+ * @brief update_qdevice_master_wins
+ * @param allow
+ */
 static void update_qdevice_master_wins(uint8_t allow)
 {
 	ENTER();
@@ -868,6 +956,10 @@ static void update_qdevice_master_wins(uint8_t allow)
 	LEAVE();
 }
 
+/**
+ * @brief update_ev_tracking_barrier
+ * @param ev_t_barrier
+ */
 static void update_ev_tracking_barrier(uint32_t ev_t_barrier)
 {
 	int res;
@@ -902,6 +994,13 @@ static void update_ev_tracking_barrier(uint32_t ev_t_barrier)
  * quorum calculation core bits
  */
 
+/**
+ * @brief calculate_quorum
+ * @param allow_decrease
+ * @param max_expected
+ * @param ret_total_votes
+ * @return
+ */
 static int calculate_quorum(int allow_decrease, unsigned int max_expected, unsigned int *ret_total_votes)
 {
 	struct qb_list_head *nodelist;
@@ -991,6 +1090,10 @@ static void update_node_expected_votes(int new_expected_votes)
 	}
 }
 
+/**
+ * @brief are_we_quorate
+ * @param total_votes
+ */
 static void are_we_quorate(unsigned int total_votes)
 {
 	int quorate;
@@ -1072,6 +1175,11 @@ static void are_we_quorate(unsigned int total_votes)
 	LEAVE();
 }
 
+/**
+ * @brief get_total_votes
+ * @param totalvotes
+ * @param current_members
+ */
 static void get_total_votes(unsigned int *totalvotes, unsigned int *current_members)
 {
 	unsigned int total_votes = 0;
@@ -1102,6 +1210,11 @@ static void get_total_votes(unsigned int *totalvotes, unsigned int *current_memb
 
 /*
  * Recalculate cluster quorum, set quorate and notify changes
+ */
+/**
+ * @brief recalculate_quorum
+ * @param allow_decrease
+ * @param by_current_nodes
  */
 static void recalculate_quorum(int allow_decrease, int by_current_nodes)
 {
@@ -1142,6 +1255,13 @@ static void recalculate_quorum(int allow_decrease, int by_current_nodes)
  * configuration bits and pieces
  */
 
+/**
+ * @brief votequorum_read_nodelist_configuration
+ * @param votes
+ * @param nodes
+ * @param expected_votes
+ * @return
+ */
 static int votequorum_read_nodelist_configuration(uint32_t *votes,
 						  uint32_t *nodes,
 						  uint32_t *expected_votes)
@@ -1200,6 +1320,11 @@ static int votequorum_read_nodelist_configuration(uint32_t *votes,
 	return 1;
 }
 
+/**
+ * @brief votequorum_qdevice_is_configured
+ * @param qdevice_votes
+ * @return
+ */
 static int votequorum_qdevice_is_configured(uint32_t *qdevice_votes)
 {
 	char *qdevice_model = NULL;
@@ -1233,6 +1358,11 @@ static int votequorum_qdevice_is_configured(uint32_t *qdevice_votes)
 #define VOTEQUORUM_READCONFIG_STARTUP 0
 #define VOTEQUORUM_READCONFIG_RUNTIME 1
 
+/**
+ * @brief votequorum_readconfig
+ * @param runtime
+ * @return
+ */
 static char *votequorum_readconfig(int runtime)
 {
 	uint32_t node_votes = 0, qdevice_votes = 0;
@@ -1533,6 +1663,14 @@ out:
 	return error;
 }
 
+/**
+ * @brief votequorum_refresh_config
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void votequorum_refresh_config(
 	int32_t event,
 	const char *key_name,
@@ -1588,6 +1726,9 @@ static void votequorum_refresh_config(
 	LEAVE();
 }
 
+/**
+ * @brief votequorum_exec_add_config_notification
+ */
 static void votequorum_exec_add_config_notification(void)
 {
 	icmap_track_t icmap_track_nodelist = NULL;
@@ -1621,6 +1762,13 @@ static void votequorum_exec_add_config_notification(void)
  * votequorum_exec core
  */
 
+/**
+ * @brief votequorum_exec_send_reconfigure
+ * @param param
+ * @param nodeid
+ * @param value
+ * @return
+ */
 static int votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, uint32_t value)
 {
 	struct req_exec_quorum_reconfigure req_exec_quorum_reconfigure;
@@ -1648,6 +1796,11 @@ static int votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, 
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_send_nodeinfo
+ * @param nodeid
+ * @return
+ */
 static int votequorum_exec_send_nodeinfo(uint32_t nodeid)
 {
 	struct req_exec_quorum_nodeinfo req_exec_quorum_nodeinfo;
@@ -1682,6 +1835,12 @@ static int votequorum_exec_send_nodeinfo(uint32_t nodeid)
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_send_qdevice_reconfigure
+ * @param oldname
+ * @param newname
+ * @return
+ */
 static int votequorum_exec_send_qdevice_reconfigure(const char *oldname, const char *newname)
 {
 	struct req_exec_quorum_qdevice_reconfigure req_exec_quorum_qdevice_reconfigure;
@@ -1704,6 +1863,12 @@ static int votequorum_exec_send_qdevice_reconfigure(const char *oldname, const c
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_send_qdevice_reg
+ * @param operation
+ * @param qdevice_name_req
+ * @return
+ */
 static int votequorum_exec_send_qdevice_reg(uint32_t operation, const char *qdevice_name_req)
 {
 	struct req_exec_quorum_qdevice_reg req_exec_quorum_qdevice_reg;
@@ -1726,6 +1891,12 @@ static int votequorum_exec_send_qdevice_reg(uint32_t operation, const char *qdev
 	return ret;
 }
 
+/**
+ * @brief votequorum_exec_send_quorum_notification
+ * @param conn
+ * @param context
+ * @return
+ */
 static int votequorum_exec_send_quorum_notification(void *conn, uint64_t context)
 {
 	struct res_lib_votequorum_quorum_notification *res_lib_votequorum_notification;
@@ -1837,6 +2008,9 @@ static int votequorum_exec_send_nodelist_notification(void *conn, uint64_t conte
 	return 0;
 }
 
+/**
+ * @brief votequorum_exec_send_expectedvotes_notification
+ */
 static void votequorum_exec_send_expectedvotes_notification(void)
 {
 	struct res_lib_votequorum_expectedvotes_notification res_lib_votequorum_expectedvotes_notification;
@@ -1862,6 +2036,10 @@ static void votequorum_exec_send_expectedvotes_notification(void)
 	LEAVE();
 }
 
+/**
+ * @brief exec_votequorum_qdevice_reconfigure_endian_convert
+ * @param message
+ */
 static void exec_votequorum_qdevice_reconfigure_endian_convert (void *message)
 {
 	ENTER();
@@ -1869,6 +2047,11 @@ static void exec_votequorum_qdevice_reconfigure_endian_convert (void *message)
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_votequorum_qdevice_reconfigure
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_votequorum_qdevice_reconfigure (
 	const void *message,
 	unsigned int nodeid)
@@ -1896,6 +2079,10 @@ static void message_handler_req_exec_votequorum_qdevice_reconfigure (
 	LEAVE();
 }
 
+/**
+ * @brief exec_votequorum_qdevice_reg_endian_convert
+ * @param message
+ */
 static void exec_votequorum_qdevice_reg_endian_convert (void *message)
 {
 	struct req_exec_quorum_qdevice_reg *req_exec_quorum_qdevice_reg = message;
@@ -1907,6 +2094,11 @@ static void exec_votequorum_qdevice_reg_endian_convert (void *message)
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_votequorum_qdevice_reg
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_votequorum_qdevice_reg (
 	const void *message,
 	unsigned int nodeid)
@@ -2001,6 +2193,10 @@ static void message_handler_req_exec_votequorum_qdevice_reg (
 	LEAVE();
 }
 
+/**
+ * @brief exec_votequorum_nodeinfo_endian_convert
+ * @param message
+ */
 static void exec_votequorum_nodeinfo_endian_convert (void *message)
 {
 	struct req_exec_quorum_nodeinfo *nodeinfo = message;
@@ -2015,6 +2211,11 @@ static void exec_votequorum_nodeinfo_endian_convert (void *message)
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_votequorum_nodeinfo
+ * @param message
+ * @param sender_nodeid
+ */
 static void message_handler_req_exec_votequorum_nodeinfo (
 	const void *message,
 	unsigned int sender_nodeid)
@@ -2133,6 +2334,10 @@ recalculate:
 	LEAVE();
 }
 
+/**
+ * @brief exec_votequorum_reconfigure_endian_convert
+ * @param message
+ */
 static void exec_votequorum_reconfigure_endian_convert (void *message)
 {
 	struct req_exec_quorum_reconfigure *reconfigure = message;
@@ -2145,6 +2350,11 @@ static void exec_votequorum_reconfigure_endian_convert (void *message)
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_exec_votequorum_reconfigure
+ * @param message
+ * @param nodeid
+ */
 static void message_handler_req_exec_votequorum_reconfigure (
 	const void *message,
 	unsigned int nodeid)
@@ -2192,6 +2402,10 @@ static void message_handler_req_exec_votequorum_reconfigure (
 	LEAVE();
 }
 
+/**
+ * @brief votequorum_exec_exit_fn
+ * @return
+ */
 static int votequorum_exec_exit_fn (void)
 {
 	int ret = 0;
@@ -2227,6 +2441,11 @@ static void votequorum_set_icmap_ro_keys(void)
 	icmap_set_ro_access("quorum.auto_tie_breaker_node", CS_FALSE, CS_TRUE);
 }
 
+/**
+ * @brief votequorum_exec_init_fn
+ * @param api
+ * @return
+ */
 static char *votequorum_exec_init_fn (struct corosync_api_v1 *api)
 {
 	char *error = NULL;
@@ -2298,6 +2517,10 @@ static char *votequorum_exec_init_fn (struct corosync_api_v1 *api)
  * votequorum service core
  */
 
+/**
+ * @brief votequorum_last_man_standing_timer_fn
+ * @param arg
+ */
 static void votequorum_last_man_standing_timer_fn(void *arg)
 {
 	ENTER();
@@ -2310,6 +2533,14 @@ static void votequorum_last_man_standing_timer_fn(void *arg)
 	LEAVE();
 }
 
+/**
+ * @brief votequorum_sync_init
+ * @param trans_list
+ * @param trans_list_entries
+ * @param member_list
+ * @param member_list_entries
+ * @param ring_id
+ */
 static void votequorum_sync_init (
 	const unsigned int *trans_list, size_t trans_list_entries,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -2393,6 +2624,10 @@ static void votequorum_sync_init (
 	LEAVE();
 }
 
+/**
+ * @brief votequorum_sync_process
+ * @return
+ */
 static int votequorum_sync_process (void)
 {
 	if (!sync_nodeinfo_sent) {
@@ -2417,6 +2652,9 @@ static int votequorum_sync_process (void)
 	return 0;
 }
 
+/**
+ * @brief votequorum_sync_activate
+ */
 static void votequorum_sync_activate (void)
 {
 	recalculate_quorum(0, 0);
@@ -2427,11 +2665,20 @@ static void votequorum_sync_activate (void)
 	sync_in_progress = 0;
 }
 
+/**
+ * @brief votequorum_sync_abort
+ */
 static void votequorum_sync_abort (void)
 {
 
 }
 
+/**
+ * @brief votequorum_init
+ * @param api
+ * @param q_set_quorate_fn
+ * @return
+ */
 char *votequorum_init(struct corosync_api_v1 *api,
 	quorum_set_quorate_fn_t q_set_quorate_fn)
 {
@@ -2461,6 +2708,11 @@ char *votequorum_init(struct corosync_api_v1 *api,
  * Library Handler init/fini
  */
 
+/**
+ * @brief quorum_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int quorum_lib_init_fn (void *conn)
 {
 	struct quorum_pd *pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
@@ -2474,6 +2726,11 @@ static int quorum_lib_init_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief quorum_lib_exit_fn
+ * @param conn
+ * @return
+ */
 static int quorum_lib_exit_fn (void *conn)
 {
 	struct quorum_pd *quorum_pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
@@ -2494,6 +2751,10 @@ static int quorum_lib_exit_fn (void *conn)
  * library internal functions
  */
 
+/**
+ * @brief qdevice_timer_fn
+ * @param arg
+ */
 static void qdevice_timer_fn(void *arg)
 {
 	ENTER();
@@ -2519,6 +2780,11 @@ static void qdevice_timer_fn(void *arg)
  * Library Handler Functions
  */
 
+/**
+ * @brief message_handler_req_lib_votequorum_getinfo
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_getinfo (void *conn, const void *message)
 {
 	const struct req_lib_votequorum_getinfo *req_lib_votequorum_getinfo = message;
@@ -2628,6 +2894,11 @@ static void message_handler_req_lib_votequorum_getinfo (void *conn, const void *
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_setexpected
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_setexpected (void *conn, const void *message)
 {
 	const struct req_lib_votequorum_setexpected *req_lib_votequorum_setexpected = message;
@@ -2666,6 +2937,11 @@ error_exit:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_setvotes
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_setvotes (void *conn, const void *message)
 {
 	const struct req_lib_votequorum_setvotes *req_lib_votequorum_setvotes = message;
@@ -2713,6 +2989,11 @@ error_exit:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_trackstart
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_trackstart (void *conn,
 							   const void *message)
 {
@@ -2761,6 +3042,11 @@ response_send:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_trackstop
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_trackstop (void *conn,
 							  const void *message)
 {
@@ -2787,6 +3073,11 @@ static void message_handler_req_lib_votequorum_trackstop (void *conn,
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_register
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_register (void *conn,
 								 const void *message)
 {
@@ -2843,6 +3134,11 @@ out:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_unregister
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_unregister (void *conn,
 								   const void *message)
 {
@@ -2882,6 +3178,11 @@ out:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_update
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_update (void *conn,
 							       const void *message)
 {
@@ -2911,6 +3212,11 @@ out:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_poll
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_poll (void *conn,
 							     const void *message)
 {
@@ -2977,6 +3283,11 @@ out:
 	LEAVE();
 }
 
+/**
+ * @brief message_handler_req_lib_votequorum_qdevice_master_wins
+ * @param conn
+ * @param message
+ */
 static void message_handler_req_lib_votequorum_qdevice_master_wins (void *conn,
 							     const void *message)
 {

--- a/exec/votequorum.h
+++ b/exec/votequorum.h
@@ -38,6 +38,12 @@
 #include <corosync/logsys.h>
 #include <corosync/coroapi.h>
 
+/**
+ * @brief votequorum_init
+ * @param api
+ * @param q_set_quorate_fn
+ * @return
+ */
 char *votequorum_init(struct corosync_api_v1 *api,
 	quorum_set_quorate_fn_t q_set_quorate_fn);
 

--- a/exec/vsf.h
+++ b/exec/vsf.h
@@ -39,6 +39,9 @@ struct corosync_vsf_iface_ver0 {
 
 	/**
 	 * Executes a callback whenever component changes
+         * @param api
+         * @param primary_callback_fn
+         * @returns ???
 	 */
 	int (*init) (
 	    struct corosync_api_v1 *api,
@@ -49,8 +52,10 @@ struct corosync_vsf_iface_ver0 {
 		struct memb_ring_id *ring_id));
 
 	/**
-	 * @retval 1 if we are primary component
-	 * @retval 0 if not primary component
+         * Call to determine if we are the primary component.
+         *
+         * @returns 1 if we are primary component
+         * @returns 0 if not primary component
 	 */
 	int (*primary) (void);
 };

--- a/exec/vsf_quorum.c
+++ b/exec/vsf_quorum.c
@@ -72,6 +72,9 @@
 
 LOGSYS_DECLARE_SUBSYS ("QUORUM");
 
+/**
+ * @brief The quorum_pd struct
+ */
 struct quorum_pd {
 	unsigned char track_flags;
 	int tracking_enabled;
@@ -79,6 +82,9 @@ struct quorum_pd {
 	void *conn;
 };
 
+/**
+ * @brief The internal_callback_pd struct
+ */
 struct internal_callback_pd {
 	struct qb_list_head list;
 	quorum_callback_fn_t callback;
@@ -110,6 +116,11 @@ static int quorum_view_list[PROCESSOR_COUNT_MAX];
 struct quorum_services_api_ver1 *quorum_iface = NULL;
 static char view_buf[64];
 
+/**
+ * @brief log_view_list
+ * @param view_list
+ * @param view_list_entries
+ */
 static void log_view_list(const unsigned int *view_list, size_t view_list_entries)
 {
 	int total = (int)view_list_entries;
@@ -136,6 +147,13 @@ static void log_view_list(const unsigned int *view_list, size_t view_list_entrie
 }
 
 /* Internal quorum API function */
+/**
+ * @brief quorum_api_set_quorum
+ * @param view_list
+ * @param view_list_entries
+ * @param quorum
+ * @param ring_id
+ */
 static void quorum_api_set_quorum(const unsigned int *view_list,
 				  size_t view_list_entries,
 				  int quorum, struct memb_ring_id *ring_id)
@@ -162,6 +180,9 @@ static void quorum_api_set_quorum(const unsigned int *view_list,
 	send_library_notification(NULL);
 }
 
+/**
+ *
+ */
 static struct corosync_lib_handler quorum_lib_service[] =
 {
 	{ /* 0 */
@@ -182,6 +203,9 @@ static struct corosync_lib_handler quorum_lib_service[] =
 	}
 };
 
+/**
+ *
+ */
 static struct corosync_service_engine quorum_service_handler = {
 	.name				        = "corosync cluster quorum service v0.1",
 	.id					= QUORUM_SERVICE,
@@ -196,6 +220,10 @@ static struct corosync_service_engine quorum_service_handler = {
 	.lib_engine_count			= sizeof (quorum_lib_service) / sizeof (struct corosync_lib_handler)
 };
 
+/**
+ * @brief vsf_quorum_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *vsf_quorum_get_service_engine_ver0 (void)
 {
 	return (&quorum_service_handler);
@@ -208,12 +236,21 @@ struct corosync_service_engine *vsf_quorum_get_service_engine_ver0 (void)
  * Internal API functions for corosync
  */
 
+/**
+ * @brief quorum_quorate
+ * @return
+ */
 static int quorum_quorate(void)
 {
 	return primary_designated;
 }
 
-
+/**
+ * @brief quorum_register_callback
+ * @param function
+ * @param context
+ * @return
+ */
 static int quorum_register_callback(quorum_callback_fn_t function, void *context)
 {
 	struct internal_callback_pd *pd = malloc(sizeof(struct internal_callback_pd));
@@ -227,6 +264,12 @@ static int quorum_register_callback(quorum_callback_fn_t function, void *context
 	return 0;
 }
 
+/**
+ * @brief quorum_unregister_callback
+ * @param function
+ * @param context
+ * @return
+ */
 static int quorum_unregister_callback(quorum_callback_fn_t function, void *context)
 {
 	struct internal_callback_pd *pd;
@@ -243,14 +286,20 @@ static int quorum_unregister_callback(quorum_callback_fn_t function, void *conte
 	return -1;
 }
 
+/**
+ *
+ */
 static struct quorum_callin_functions callins = {
 	.quorate = quorum_quorate,
 	.register_callback = quorum_register_callback,
 	.unregister_callback = quorum_unregister_callback
 };
 
-/* --------------------------------------------------------------------- */
-
+/**
+ * @brief quorum_exec_init_fn
+ * @param api
+ * @return
+ */
 static char *quorum_exec_init_fn (struct corosync_api_v1 *api)
 {
 	char *quorum_module = NULL;
@@ -308,6 +357,11 @@ static char *quorum_exec_init_fn (struct corosync_api_v1 *api)
 	return (NULL);
 }
 
+/**
+ * @brief quorum_lib_init_fn
+ * @param conn
+ * @return
+ */
 static int quorum_lib_init_fn (void *conn)
 {
 	struct quorum_pd *pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
@@ -320,6 +374,11 @@ static int quorum_lib_init_fn (void *conn)
 	return (0);
 }
 
+/**
+ * @brief quorum_lib_exit_fn
+ * @param conn
+ * @return
+ */
 static int quorum_lib_exit_fn (void *conn)
 {
 	struct quorum_pd *quorum_pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
@@ -333,7 +392,9 @@ static int quorum_lib_exit_fn (void *conn)
 	return (0);
 }
 
-
+/**
+ * @brief send_internal_notification
+ */
 static void send_internal_notification(void)
 {
 	struct qb_list_head *tmp;
@@ -346,6 +407,10 @@ static void send_internal_notification(void)
 	}
 }
 
+/**
+ * @brief send_library_notification
+ * @param conn
+ */
 static void send_library_notification(void *conn)
 {
 	int size = sizeof(struct res_lib_quorum_notification) + sizeof(unsigned int)*quorum_view_list_entries;
@@ -384,6 +449,11 @@ static void send_library_notification(void *conn)
 	return;
 }
 
+/**
+ * @brief message_handler_req_lib_quorum_getquorate
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_quorum_getquorate (void *conn,
 						       const void *msg)
 {
@@ -399,6 +469,11 @@ static void message_handler_req_lib_quorum_getquorate (void *conn,
 	corosync_api->ipc_response_send(conn, &res_lib_quorum_getquorate, sizeof(res_lib_quorum_getquorate));
 }
 
+/**
+ * @brief message_handler_req_lib_quorum_trackstart
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_quorum_trackstart (void *conn,
 						       const void *msg)
 {
@@ -444,6 +519,11 @@ response_send:
 	corosync_api->ipc_response_send(conn, &res, sizeof(struct qb_ipc_response_header));
 }
 
+/**
+ * @brief message_handler_req_lib_quorum_trackstop
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_quorum_trackstop (void *conn, const void *msg)
 {
 	struct qb_ipc_response_header res;
@@ -467,6 +547,11 @@ static void message_handler_req_lib_quorum_trackstop (void *conn, const void *ms
 	corosync_api->ipc_response_send(conn, &res, sizeof(struct qb_ipc_response_header));
 }
 
+/**
+ * @brief message_handler_req_lib_quorum_gettype
+ * @param conn
+ * @param msg
+ */
 static void message_handler_req_lib_quorum_gettype (void *conn,
 						       const void *msg)
 {

--- a/exec/vsf_ykd.c
+++ b/exec/vsf_ykd.c
@@ -70,26 +70,41 @@ LOGSYS_DECLARE_SUBSYS ("YKD");
 
 #define YKD_PROCESSOR_COUNT_MAX 32
 
+/**
+ * @brief The ykd_header_values enum
+ */
 enum ykd_header_values {
 	YKD_HEADER_SENDSTATE = 0,
 	YKD_HEADER_ATTEMPT = 1
 };
 
+/**
+ * @brief The ykd_mode enum
+ */
 enum ykd_mode {
 	YKD_MODE_SENDSTATE = 0,
 	YKD_MODE_ATTEMPT = 1
 };
 
+/**
+ * @brief The ykd_header struct
+ */
 struct ykd_header {
 	int id;
 };
 
+/**
+ * @brief The ykd_session struct
+ */
 struct ykd_session {
 	unsigned int member_list[YKD_PROCESSOR_COUNT_MAX];
 	int member_list_entries;
 	int session_id;
 };
 
+/**
+ * @brief The ykd_state struct
+ */
 struct ykd_state {
 	struct ykd_session last_primary;
 
@@ -104,6 +119,9 @@ struct ykd_state {
 	int session_id;
 };
 
+/**
+ * @brief The state_received struct
+ */
 struct state_received {
 	unsigned int nodeid;
 	int received;
@@ -146,12 +164,18 @@ hdb_handle_t schedwrk_state_send_callback_handle;
 
 static struct corosync_api_v1 *api;
 
+/**
+ *
+ */
 static void (*ykd_primary_callback_fn) (
 	const unsigned int *view_list,
 	size_t view_list_entries,
 	int primary_designated,
 	struct memb_ring_id *ring_id) = NULL;
 
+/**
+ * @brief ykd_state_init
+ */
 static void ykd_state_init (void)
 {
 	ykd_state.session_id = 0;
@@ -161,6 +185,11 @@ static void ykd_state_init (void)
 	ykd_state.last_primary.member_list_entries = 0;
 }
 
+/**
+ * @brief ykd_state_send_msg
+ * @param context
+ * @return
+ */
 static int ykd_state_send_msg (const void *context)
 {
 	struct iovec iovec[2];
@@ -180,6 +209,9 @@ static int ykd_state_send_msg (const void *context)
 	return (res);
 }
 
+/**
+ * @brief ykd_state_send
+ */
 static void ykd_state_send (void)
 {
 	api->schedwrk_create (
@@ -188,6 +220,11 @@ static void ykd_state_send (void)
                 NULL);
 }
 
+/**
+ * @brief ykd_attempt_send_msg
+ * @param context
+ * @return
+ */
 static int ykd_attempt_send_msg (const void *context)
 {
 	struct iovec iovec;
@@ -205,6 +242,9 @@ static int ykd_attempt_send_msg (const void *context)
 	return (res);
 }
 
+/**
+ * @brief ykd_attempt_send
+ */
 static void ykd_attempt_send (void)
 {
 	api->schedwrk_create (
@@ -213,6 +253,9 @@ static void ykd_attempt_send (void)
                 NULL);
 }
 
+/**
+ * @brief compute
+ */
 static void compute (void)
 {
 	int i;
@@ -251,6 +294,13 @@ static void compute (void)
 	}
 }
 
+/**
+ * @brief subquorum
+ * @param member_list
+ * @param member_list_entries
+ * @param session
+ * @return
+ */
 static int subquorum (
 	unsigned int *member_list,
 	int member_list_entries,
@@ -284,6 +334,10 @@ static int subquorum (
 	return (0);
 }
 
+/**
+ * @brief decide
+ * @return
+ */
 static int decide (void)
 {
 	int i;
@@ -304,6 +358,10 @@ static int decide (void)
 	return (1);
 }
 
+/**
+ * @brief ykd_session_endian_convert
+ * @param ykd_session
+ */
 static void ykd_session_endian_convert (struct ykd_session *ykd_session)
 {
 	int i;
@@ -317,6 +375,10 @@ static void ykd_session_endian_convert (struct ykd_session *ykd_session)
 	}
 }
 
+/**
+ * @brief ykd_state_endian_convert
+ * @param state
+ */
 static void ykd_state_endian_convert (struct ykd_state *state)
 {
 	int i;
@@ -335,6 +397,13 @@ static void ykd_state_endian_convert (struct ykd_state *state)
 	}
 }
 
+/**
+ * @brief ykd_deliver_fn
+ * @param nodeid
+ * @param msg
+ * @param msg_len
+ * @param endian_conversion_required
+ */
 static void ykd_deliver_fn (
 	unsigned int nodeid,
 	const void *msg,
@@ -453,7 +522,22 @@ static void ykd_deliver_fn (
 	}
 }
 
+/**
+ * @brief first_run
+ */
 int first_run = 1;
+
+/**
+ * @brief ykd_confchg_fn
+ * @param configuration_type
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ * @param ring_id
+ */
 static void ykd_confchg_fn (
 	enum totem_configuration_type configuration_type,
 	const unsigned int *member_list, size_t member_list_entries,
@@ -503,11 +587,20 @@ static void ykd_confchg_fn (
 	ykd_state_send ();
 }
 
+/**
+ *
+ */
 struct corosync_tpg_group ykd_group = {
 	.group		= "ykd",
 	.group_len	= 3
 };
 
+/**
+ * @brief ykd_init
+ * @param corosync_api
+ * @param set_primary
+ * @return
+ */
 char *ykd_init (
 	struct corosync_api_v1 *corosync_api,
 	quorum_set_quorate_fn_t set_primary)

--- a/exec/vsf_ykd.h
+++ b/exec/vsf_ykd.h
@@ -38,6 +38,12 @@
 #include <corosync/logsys.h>
 #include <corosync/coroapi.h>
 
+/**
+ * @brief ykd_init
+ * @param api
+ * @param set_primary
+ * @return
+ */
 char *ykd_init(struct corosync_api_v1 *api,
 	quorum_set_quorate_fn_t set_primary);
 

--- a/exec/wd.c
+++ b/exec/wd.c
@@ -51,6 +51,9 @@
 
 #include "service.h"
 
+/**
+ *
+ */
 typedef enum {
 	WD_RESOURCE_GOOD,
 	WD_RESOURCE_FAILED,
@@ -58,6 +61,9 @@ typedef enum {
 	WD_RESOURCE_NOT_MONITORED
 } wd_resource_state_t;
 
+/**
+ * @brief The resource struct
+ */
 struct resource {
 	char res_path[ICMAP_KEYNAME_MAXLEN];
 	char *recovery;
@@ -91,6 +97,9 @@ static corosync_timer_handle_t wd_timer;
 static int watchdog_ok = 1;
 static char *watchdog_device = "/dev/watchdog";
 
+/**
+ *
+ */
 struct corosync_service_engine wd_service_engine = {
 	.name			= "corosync watchdog service",
 	.id			= WD_SERVICE,
@@ -117,23 +126,32 @@ static QB_LIST_DECLARE (confchg_notify);
 static void wd_config_changed (struct cs_fsm* fsm, int32_t event, void * data);
 static void wd_resource_failed (struct cs_fsm* fsm, int32_t event, void * data);
 
+/**
+ * @brief The wd_resource_state enum
+ */
 enum wd_resource_state {
 	WD_S_RUNNING,
 	WD_S_FAILED,
 	WD_S_STOPPED
 };
 
+/**
+ * @brief The wd_resource_event enum
+ */
 enum wd_resource_event {
 	WD_E_FAILURE,
 	WD_E_CONFIG_CHANGED
 };
 
-const char * wd_running_str		= "running";
-const char * wd_failed_str		= "failed";
-const char * wd_failure_str		= "failure";
-const char * wd_stopped_str		= "stopped";
-const char * wd_config_changed_str	= "config_changed";
+const char * wd_running_str		= "running";          ///<
+const char * wd_failed_str		= "failed";           ///<
+const char * wd_failure_str		= "failure";          ///<
+const char * wd_stopped_str		= "stopped";          ///<
+const char * wd_config_changed_str	= "config_changed";   ///<
 
+/**
+ *
+ */
 struct cs_fsm_entry wd_fsm_table[] = {
 	{ WD_S_STOPPED,	WD_E_CONFIG_CHANGED,	wd_config_changed,	{WD_S_STOPPED, WD_S_RUNNING, -1} },
 	{ WD_S_STOPPED,	WD_E_FAILURE,		NULL,			{-1} },
@@ -143,11 +161,21 @@ struct cs_fsm_entry wd_fsm_table[] = {
 	{ WD_S_FAILED,	WD_E_FAILURE,		NULL,			{-1} },
 };
 
+/**
+ * @brief wd_get_service_engine_ver0
+ * @return
+ */
 struct corosync_service_engine *wd_get_service_engine_ver0 (void)
 {
 	return (&wd_service_engine);
 }
 
+/**
+ * @brief wd_res_state_to_str
+ * @param fsm
+ * @param state
+ * @return
+ */
 static const char * wd_res_state_to_str(struct cs_fsm* fsm,
 	int32_t state)
 {
@@ -165,6 +193,12 @@ static const char * wd_res_state_to_str(struct cs_fsm* fsm,
 	return NULL;
 }
 
+/**
+ * @brief wd_res_event_to_str
+ * @param fsm
+ * @param event
+ * @return
+ */
 static const char * wd_res_event_to_str(struct cs_fsm* fsm,
 	int32_t event)
 {
@@ -179,6 +213,15 @@ static const char * wd_res_event_to_str(struct cs_fsm* fsm,
 	return NULL;
 }
 
+/**
+ * @brief wd_fsm_cb
+ * @param fsm
+ * @param cb_event
+ * @param curr_state
+ * @param next_state
+ * @param fsm_event
+ * @param data
+ */
 static void wd_fsm_cb (struct cs_fsm *fsm, int cb_event, int32_t curr_state,
 	int32_t next_state, int32_t fsm_event, void *data)
 {
@@ -210,8 +253,10 @@ static void wd_fsm_cb (struct cs_fsm *fsm, int cb_event, int32_t curr_state,
 	}
 }
 
-/*
- * returns (CS_TRUE == OK, CS_FALSE == failed)
+/**
+ * @brief wd_resource_state_is_ok
+ * @param ref
+ * @return (CS_TRUE == OK, CS_FALSE == failed)
  */
 static int32_t wd_resource_state_is_ok (struct resource *ref)
 {
@@ -269,6 +314,12 @@ static int32_t wd_resource_state_is_ok (struct resource *ref)
 	return CS_TRUE;
 }
 
+/**
+ * @brief wd_config_changed
+ * @param fsm
+ * @param event
+ * @param data
+ */
 static void wd_config_changed (struct cs_fsm* fsm, int32_t event, void * data)
 {
 	char *state;
@@ -332,6 +383,12 @@ static void wd_config_changed (struct cs_fsm* fsm, int32_t event, void * data)
 	free(state);
 }
 
+/**
+ * @brief wd_resource_failed
+ * @param fsm
+ * @param event
+ * @param data
+ */
 static void wd_resource_failed (struct cs_fsm* fsm, int32_t event, void * data)
 {
 	struct resource* ref = (struct resource*)data;
@@ -356,6 +413,14 @@ static void wd_resource_failed (struct cs_fsm* fsm, int32_t event, void * data)
 	cs_fsm_state_set(fsm, WD_S_FAILED, data, wd_fsm_cb);
 }
 
+/**
+ * @brief wd_key_changed
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void wd_key_changed(
 	int32_t event,
 	const char *key_name,
@@ -402,6 +467,10 @@ static void wd_key_changed(
 	}
 }
 
+/**
+ * @brief wd_resource_check_fn
+ * @param resource_ref
+ */
 static void wd_resource_check_fn (void* resource_ref)
 {
 	struct resource* ref = (struct resource*)resource_ref;
@@ -414,9 +483,12 @@ static void wd_resource_check_fn (void* resource_ref)
 		ref, wd_resource_check_fn, &ref->check_timer);
 }
 
-/*
- * return 0   - fully configured
- * return -1  - partially configured
+/**
+ * @brief wd_resource_create
+ * @param res_path
+ * @param res_name
+ * @return 0   - fully configured
+ *         -1  - partially configured
  */
 static int32_t wd_resource_create (char *res_path, char *res_name)
 {
@@ -494,7 +566,10 @@ static int32_t wd_resource_create (char *res_path, char *res_name)
 	return 0;
 }
 
-
+/**
+ * @brief wd_tickle_fn
+ * @param arg
+ */
 static void wd_tickle_fn (void* arg)
 {
 	ENTER();
@@ -512,6 +587,14 @@ static void wd_tickle_fn (void* arg)
 
 }
 
+/**
+ * @brief wd_resource_created_cb
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void wd_resource_created_cb(
 	int32_t event,
 	const char *key_name,
@@ -541,6 +624,9 @@ static void wd_resource_created_cb(
 	wd_resource_create (tmp_key, res_name);
 }
 
+/**
+ * @brief wd_scan_resources
+ */
 static void wd_scan_resources (void)
 {
 	int res_count = 0;
@@ -582,7 +668,10 @@ static void wd_scan_resources (void)
 	}
 }
 
-
+/**
+ * @brief watchdog_timeout_apply
+ * @param new
+ */
 static void watchdog_timeout_apply (uint32_t new)
 {
 	struct watchdog_info ident;
@@ -627,6 +716,10 @@ static void watchdog_timeout_apply (uint32_t new)
 
 }
 
+/**
+ * @brief setup_watchdog
+ * @return
+ */
 static int setup_watchdog(void)
 {
 	struct watchdog_info ident;
@@ -676,6 +769,14 @@ static int setup_watchdog(void)
 	return 0;
 }
 
+/**
+ * @brief wd_top_level_key_changed
+ * @param event
+ * @param key_name
+ * @param new_val
+ * @param old_val
+ * @param user_data
+ */
 static void wd_top_level_key_changed(
 	int32_t event,
 	const char *key_name,
@@ -699,6 +800,9 @@ static void wd_top_level_key_changed(
 	icmap_set_uint32("resources.watchdog_timeout", watchdog_timeout);
 }
 
+/**
+ * @brief watchdog_timeout_get_initial
+ */
 static void watchdog_timeout_get_initial (void)
 {
 	uint32_t tmp_value_32;
@@ -730,6 +834,11 @@ static void watchdog_timeout_get_initial (void)
 
 }
 
+/**
+ * @brief wd_exec_init_fn
+ * @param corosync_api
+ * @return
+ */
 static char *wd_exec_init_fn (struct corosync_api_v1 *corosync_api)
 {
 
@@ -746,6 +855,10 @@ static char *wd_exec_init_fn (struct corosync_api_v1 *corosync_api)
 	return NULL;
 }
 
+/**
+ * @brief wd_exec_exit_fn
+ * @return
+ */
 static int wd_exec_exit_fn (void)
 {
 	char magic = 'V';

--- a/include/corosync/ipc_votequorum.h
+++ b/include/corosync/ipc_votequorum.h
@@ -219,6 +219,9 @@ struct res_lib_votequorum_quorum_notification {
 	struct votequorum_node node_list[] __attribute__((aligned(8)));
 };
 
+/**
+ * @brief The res_lib_votequorum_nodelist_notification struct
+ */
 struct res_lib_votequorum_nodelist_notification {
 	struct qb_ipc_response_header header __attribute__((aligned(8)));
 	mar_uint64_t context __attribute__((aligned(8)));

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -106,9 +106,19 @@ struct totem_message_header {
 	unsigned int target_nodeid;
 } __attribute__((packed));
 
+/**
+ *
+ */
 enum { TOTEM_PRIVATE_KEY_LEN = 4096 };
+
+/**
+ *
+ */
 enum { TOTEM_LINK_MODE_BYTES = 64 };
 
+/**
+ * @brief totem_transport_t enum
+ */
 typedef enum {
 	TOTEM_TRANSPORT_UDP = 0,
 	TOTEM_TRANSPORT_UDPU = 1,
@@ -116,11 +126,17 @@ typedef enum {
 } totem_transport_t;
 
 #define MEMB_RING_ID
+/**
+ * @brief The memb_ring_id struct
+ */
 struct memb_ring_id {
 	struct totem_ip_address rep;
 	unsigned long long seq;
 } __attribute__((packed));
 
+/**
+ * @brief The totem_config struct
+ */
 struct totem_config {
 	int version;
 
@@ -204,39 +220,67 @@ struct totem_config {
 	    const struct totem_ip_address *addr);
 };
 
+/**
+ * @brief TOTEM_CONFIGURATION_TYPE
+ */
 #define TOTEM_CONFIGURATION_TYPE
+/**
+ * @brief The totem_configuration_type enum
+ */
 enum totem_configuration_type {
 	TOTEM_CONFIGURATION_REGULAR,
 	TOTEM_CONFIGURATION_TRANSITIONAL
 };
 
+/**
+ * @brief TOTEM_CALLBACK_TOKEN_TYPE
+ */
 #define TOTEM_CALLBACK_TOKEN_TYPE
+
+/**
+ * @brief The totem_callback_token_type enum
+ */
 enum totem_callback_token_type {
 	TOTEM_CALLBACK_TOKEN_RECEIVED = 1,
 	TOTEM_CALLBACK_TOKEN_SENT = 2
 };
 
+/**
+ * @brief The totem_event_type enum
+ */
 enum totem_event_type {
 	TOTEM_EVENT_DELIVERY_CONGESTED,
 	TOTEM_EVENT_NEW_MSG,
 };
 
+/**
+ * @brief totem_stats_header_t struct
+ */
 typedef struct {
 	int is_dirty;
 	time_t last_updated;
 } totem_stats_header_t;
 
+/**
+ * @brief totemnet_stats_t struct
+ */
 typedef struct {
 	totem_stats_header_t hdr;
 	uint32_t iface_changes;
 } totemnet_stats_t;
 
+/**
+ * @brief totemsrp_token_stats_t struct
+ */
 typedef struct {
 	uint32_t rx;
 	uint32_t tx;
 	int backlog_calc;
 } totemsrp_token_stats_t;
 
+/**
+ * @brief totemsrp_stats_t struct
+ */
 typedef struct {
 	totem_stats_header_t hdr;
 	uint64_t orf_token_tx;
@@ -272,9 +316,14 @@ typedef struct {
 
 } totemsrp_stats_t;
 
- 
+/**
+ * @brief TOTEM_CONFIGURATION_TYPE
+ */
  #define TOTEM_CONFIGURATION_TYPE
 
+/**
+ * @brief totempg_stats_t
+ */
 typedef struct {
 	totem_stats_header_t hdr;
 	totemsrp_stats_t *srp;

--- a/include/corosync/totem/totemip.h
+++ b/include/corosync/totem/totemip.h
@@ -56,10 +56,17 @@ void totemip_nosigpipe(int s);
 #define totemip_nosigpipe(s)
 #endif
 
+/**
+ * @brief TOTEMIP_ADDRLEN
+ */
 #define TOTEMIP_ADDRLEN (sizeof(struct in6_addr))
 
 /* These are the things that get passed around */
 #define TOTEM_IP_ADDRESS
+
+/**
+ * @brief The totem_ip_address struct
+ */
 struct totem_ip_address
 {
 	unsigned int   nodeid;
@@ -67,6 +74,9 @@ struct totem_ip_address
 	unsigned char  addr[TOTEMIP_ADDRLEN];
 } __attribute__((packed));
 
+/**
+ * @brief The totem_ip_if_address struct
+ */
 struct totem_ip_if_address
 {
 	struct totem_ip_address ip_addr;
@@ -77,43 +87,148 @@ struct totem_ip_if_address
 	struct qb_list_head list;
 };
 
+/**
+ * @brief totemip_equal
+ * @param addr1
+ * @param addr2
+ * @return
+ */
 extern int totemip_equal(const struct totem_ip_address *addr1,
 			 const struct totem_ip_address *addr2);
+
+/**
+ * @brief totemip_compare
+ * @param a
+ * @param b
+ * @return
+ */
 extern int totemip_compare(const void *a, const void *b);
+
+/**
+ * @brief totemip_is_mcast
+ * @param addr
+ * @return
+ */
 extern int totemip_is_mcast(struct totem_ip_address *addr);
+
+/**
+ * @brief totemip_copy
+ * @param addr1
+ * @param addr2
+ */
 extern void totemip_copy(struct totem_ip_address *addr1,
 			 const struct totem_ip_address *addr2);
+
+/**
+ * @brief totemip_copy_endian_convert
+ * @param addr1
+ * @param addr2
+ */
 extern void totemip_copy_endian_convert(struct totem_ip_address *addr1,
 					const struct totem_ip_address *addr2);
+
+/**
+ * @brief totemip_localhost
+ * @param family
+ * @param localhost
+ * @return
+ */
 int totemip_localhost(int family, struct totem_ip_address *localhost);
+
+/**
+ * @brief totemip_localhost_check
+ * @param addr
+ * @return
+ */
 extern int totemip_localhost_check(const struct totem_ip_address *addr);
+
+/**
+ * @brief totemip_print
+ * @param addr
+ * @return
+ */
 extern const char *totemip_print(const struct totem_ip_address *addr);
+
+/**
+ * @brief totemip_sockaddr_to_totemip_convert
+ * @param saddr
+ * @param ip_addr
+ * @return
+ */
 extern int totemip_sockaddr_to_totemip_convert(const struct sockaddr_storage *saddr,
 					       struct totem_ip_address *ip_addr);
+/**
+ * @brief totemip_totemip_to_sockaddr_convert
+ * @param ip_addr
+ * @param port
+ * @param saddr
+ * @param addrlen
+ * @return
+ */
 extern int totemip_totemip_to_sockaddr_convert(struct totem_ip_address *ip_addr,
 					       uint16_t port, struct sockaddr_storage *saddr, int *addrlen);
+
+/**
+ * @brief totemip_parse
+ * @param totemip
+ * @param addr
+ * @param family
+ * @return
+ */
 extern int totemip_parse(struct totem_ip_address *totemip, const char *addr,
 			 int family);
+/**
+ * @brief totemip_iface_check
+ * @param bindnet
+ * @param boundto
+ * @param interface_up
+ * @param interface_num
+ * @param mask_high_bit
+ * @return
+ */
 extern int totemip_iface_check(struct totem_ip_address *bindnet,
 			       struct totem_ip_address *boundto,
 			       int *interface_up,
 			       int *interface_num,
 			       int mask_high_bit);
 
+/**
+ * @brief totemip_getifaddrs
+ * @param addrs
+ * @return
+ */
 extern int totemip_getifaddrs(struct qb_list_head *addrs);
 
+/**
+ * @brief totemip_freeifaddrs
+ * @param addrs
+ */
 extern void totemip_freeifaddrs(struct qb_list_head *addrs);
 
-/* These two simulate a zero in_addr by clearing the family field */
+/**
+ * @brief totemip_zero_set These two simulate a zero in_addr by clearing the family field
+ * @param addr
+ */
 static inline void totemip_zero_set(struct totem_ip_address *addr)
 {
 	addr->family = 0;
 }
+
+/**
+ * @brief totemip_zero_check These two simulate a zero in_addr by clearing the family field
+ * @param addr
+ * @return
+ */
 static inline int totemip_zero_check(const struct totem_ip_address *addr)
 {
 	return (addr->family == 0);
 }
 
+/**
+ * @brief totemip_udpip_header_size
+ * @param family
+ * @return
+ */
 extern size_t totemip_udpip_header_size(int family);
 
 #ifdef __cplusplus

--- a/include/corosync/totem/totempg.h
+++ b/include/corosync/totem/totempg.h
@@ -52,6 +52,9 @@ extern "C" {
 #include "totem.h"
 #include <qb/qbloop.h>
 
+/**
+ * @brief The totempg_group struct
+ */
 struct totempg_group {
 	const void *group;
 	size_t group_len;
@@ -68,18 +71,35 @@ extern int totempg_initialize (
 	struct totem_config *totem_config
 );
 
+/**
+ * @brief totempg_finalize
+ */
 extern void totempg_finalize (void);
 
+/**
+ * @brief totempg_callback_token_create
+ * @param handle_out
+ * @param totem_callback_token_type
+ * @param delete
+ * @param callback_fn
+ * @param data
+ */
 extern int totempg_callback_token_create (void **handle_out,
 	enum totem_callback_token_type type,
 	int delete,
 	int (*callback_fn) (enum totem_callback_token_type type, const void *),
 	const void *data);
 
+/**
+ * @brief totempg_callback_token_destroy
+ * @param handle
+ */
 extern void totempg_callback_token_destroy (void *handle);
 
 /**
- * Initialize a groups instance
+ * @brief Initialize a groups instance
+ * @param instance
+ * @return
  */
 extern int totempg_groups_initialize (
 	void **instance,
@@ -97,32 +117,81 @@ extern int totempg_groups_initialize (
 		const unsigned int *joined_list, size_t joined_list_entries,
 		const struct memb_ring_id *ring_id));
 
+/**
+ * @brief totempg_groups_finalize
+ * @param instance
+ * @return
+ */
 extern int totempg_groups_finalize (void *instance);
 
+/**
+ * @brief totempg_groups_join
+ * @param instance
+ * @param groups
+ * @param group_cnt
+ * @return
+ */
 extern int totempg_groups_join (
 	void *instance,
 	const struct totempg_group *groups,
 	size_t group_cnt);
 
+/**
+ * @brief totempg_groups_leave
+ * @param instance
+ * @param groups
+ * @param group_cnt
+ * @return
+ */
 extern int totempg_groups_leave (
 	void *instance,
 	const struct totempg_group *groups,
 	size_t group_cnt);
 
+/**
+ * @brief totempg_groups_mcast_joined
+ * @param instance
+ * @param iovec
+ * @param iov_len
+ * @param guarantee
+ * @return
+ */
 extern int totempg_groups_mcast_joined (
 	void *instance,
 	const struct iovec *iovec,
 	unsigned int iov_len,
 	int guarantee);
 
+/**
+ * @brief totempg_groups_joined_reserve
+ * @param instance
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 extern int totempg_groups_joined_reserve (
 	void *instance,
 	const struct iovec *iovec,
 	unsigned int iov_len);
 
+/**
+ * @brief totempg_groups_joined_release
+ * @param msg_count
+ * @return
+ */
 extern int totempg_groups_joined_release (
 	int msg_count);
 
+/**
+ * @brief totempg_groups_mcast_groups
+ * @param instance
+ * @param guarantee
+ * @param groups
+ * @param groups_cnt
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 extern int totempg_groups_mcast_groups (
 	void *instance,
 	int guarantee,
@@ -131,6 +200,15 @@ extern int totempg_groups_mcast_groups (
 	const struct iovec *iovec,
 	unsigned int iov_len);
 
+/**
+ * @brief totempg_groups_send_ok_groups
+ * @param instance
+ * @param groups
+ * @param groups_cnt
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 extern int totempg_groups_send_ok_groups (
 	void *instance,
 	const struct totempg_group *groups,
@@ -138,6 +216,15 @@ extern int totempg_groups_send_ok_groups (
 	const struct iovec *iovec,
 	unsigned int iov_len);
 
+/**
+ * @brief totempg_ifaces_get
+ * @param nodeid
+ * @param interfaces
+ * @param interfaces_size
+ * @param status
+ * @param iface_count
+ * @return
+ */
 extern int totempg_ifaces_get (
 	unsigned int nodeid,
         struct totem_ip_address *interfaces,
@@ -145,31 +232,81 @@ extern int totempg_ifaces_get (
 	char ***status,
         unsigned int *iface_count);
 
+/**
+ * @brief totempg_get_stats
+ * @return
+ */
 extern void* totempg_get_stats (void);
 
+/**
+ * @brief totempg_event_signal
+ * @param type
+ * @param value
+ */
 void totempg_event_signal (enum totem_event_type type, int value);
 
+/**
+ * @brief totempg_ifaces_print
+ * @param nodeid
+ * @return
+ */
 extern const char *totempg_ifaces_print (unsigned int nodeid);
 
+/**
+ * @brief totempg_my_nodeid_get
+ * @return
+ */
 extern unsigned int totempg_my_nodeid_get (void);
 
+/**
+ * @brief totempg_my_family_get
+ * @return
+ */
 extern int totempg_my_family_get (void);
 
+/**
+ * @brief totempg_crypto_set
+ * @param cipher_type
+ * @param hash_type
+ * @return
+ */
 extern int totempg_crypto_set (const char *cipher_type, const char *hash_type);
 
+/**
+ * @brief totempg_ring_reenable
+ * @return
+ */
 extern int totempg_ring_reenable (void);
 
+/**
+ * @brief totempg_service_ready_register
+ */
 extern void totempg_service_ready_register (
 	void (*totem_service_ready) (void));
 
+/**
+ * @brief totempg_member_add
+ * @param member
+ * @param ring_no
+ * @return
+ */
 extern int totempg_member_add (
 	const struct totem_ip_address *member,
 	int ring_no);
 
+/**
+ * @brief totempg_member_remove
+ * @param member
+ * @param ring_no
+ * @return
+ */
 extern int totempg_member_remove (
 	const struct totem_ip_address *member,
 	int ring_no);
 
+/**
+ * @brief The totem_q_level enum
+ */
 enum totem_q_level {
 	TOTEM_Q_LEVEL_LOW,
 	TOTEM_Q_LEVEL_GOOD,
@@ -177,13 +314,30 @@ enum totem_q_level {
 	TOTEM_Q_LEVEL_CRITICAL
 };
 
+/**
+ * @brief totempg_check_q_level
+ * @param instance
+ */
 void totempg_check_q_level(void *instance);
 
+/**
+ * @brief totem_queue_level_changed_fn
+ */
 typedef void (*totem_queue_level_changed_fn) (enum totem_q_level level);
+
+/**
+ * @brief totempg_queue_level_register_callback
+ */
 extern void totempg_queue_level_register_callback (totem_queue_level_changed_fn);
 
+/**
+ * @brief totempg_threaded_mode_enable
+ */
 extern void totempg_threaded_mode_enable (void);
 
+/**
+ * @brief totempg_trans_ack
+ */
 extern void totempg_trans_ack (void);
 
 #ifdef __cplusplus

--- a/include/corosync/votequorum.h
+++ b/include/corosync/votequorum.h
@@ -111,6 +111,9 @@ typedef void (*votequorum_quorum_notification_fn_t) (
 	uint32_t node_list_entries,
 	votequorum_node_t node_list[]);
 
+/**
+ * @brief The votequorum_nodelist_notification_fn_t callback
+ */
 typedef void (*votequorum_nodelist_notification_fn_t) (
 	votequorum_handle_t handle,
 	uint64_t context,

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -62,6 +62,9 @@
 /*
  * Data structure for instance data
  */
+/**
+ * @brief The cfg_inst struct
+ */
 struct cfg_inst {
 	qb_ipcc_connection_t *c;
 	corosync_cfg_callbacks_t callbacks;
@@ -81,6 +84,12 @@ DECLARE_HDB_DATABASE (cfg_hdb, cfg_inst_free);
  * Implementation
  */
 
+/**
+ * @brief corosync_cfg_initialize
+ * @param cfg_handle
+ * @param cfg_callbacks
+ * @return
+ */
 cs_error_t
 corosync_cfg_initialize (
 	corosync_cfg_handle_t *cfg_handle,
@@ -122,6 +131,12 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_fd_get
+ * @param cfg_handle
+ * @param selection_fd
+ * @return
+ */
 cs_error_t
 corosync_cfg_fd_get (
 	corosync_cfg_handle_t cfg_handle,
@@ -141,6 +156,12 @@ corosync_cfg_fd_get (
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_dispatch
+ * @param cfg_handle
+ * @param dispatch_flags
+ * @return
+ */
 cs_error_t
 corosync_cfg_dispatch (
 	corosync_cfg_handle_t cfg_handle,
@@ -244,12 +265,21 @@ error_nounlock:
 	return (error);
 }
 
+/**
+ * @brief cfg_inst_free
+ * @param inst
+ */
 static void cfg_inst_free (void *inst)
 {
 	struct cfg_inst *cfg_inst = (struct cfg_inst *)inst;
 	qb_ipcc_disconnect(cfg_inst->c);
 }
 
+/**
+ * @brief corosync_cfg_finalize
+ * @param cfg_handle
+ * @return
+ */
 cs_error_t
 corosync_cfg_finalize (
 	corosync_cfg_handle_t cfg_handle)
@@ -279,6 +309,14 @@ corosync_cfg_finalize (
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_ring_status_get
+ * @param cfg_handle
+ * @param interface_names
+ * @param status
+ * @param interface_count
+ * @return
+ */
 cs_error_t
 corosync_cfg_ring_status_get (
 	corosync_cfg_handle_t cfg_handle,
@@ -367,6 +405,11 @@ exit_handle_put:
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_ring_reenable
+ * @param cfg_handle
+ * @return
+ */
 cs_error_t
 corosync_cfg_ring_reenable (
 	corosync_cfg_handle_t cfg_handle)
@@ -399,6 +442,13 @@ corosync_cfg_ring_reenable (
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_kill_node
+ * @param cfg_handle
+ * @param nodeid
+ * @param reason
+ * @return
+ */
 cs_error_t
 corosync_cfg_kill_node (
 	corosync_cfg_handle_t cfg_handle,
@@ -442,6 +492,12 @@ corosync_cfg_kill_node (
         return (error == CS_OK ? res_lib_cfg_killnode.header.error : error);
 }
 
+/**
+ * @brief corosync_cfg_try_shutdown
+ * @param cfg_handle
+ * @param flags
+ * @return
+ */
 cs_error_t
 corosync_cfg_try_shutdown (
 	corosync_cfg_handle_t cfg_handle,
@@ -477,6 +533,12 @@ corosync_cfg_try_shutdown (
         return (error == CS_OK ? res_lib_cfg_tryshutdown.header.error : error);
 }
 
+/**
+ * @brief corosync_cfg_replyto_shutdown
+ * @param cfg_handle
+ * @param response
+ * @return
+ */
 cs_error_t
 corosync_cfg_replyto_shutdown (
 	corosync_cfg_handle_t cfg_handle,
@@ -510,6 +572,15 @@ corosync_cfg_replyto_shutdown (
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_get_node_addrs
+ * @param cfg_handle
+ * @param nodeid
+ * @param max_addrs
+ * @param num_addrs
+ * @param addrs
+ * @return
+ */
 cs_error_t corosync_cfg_get_node_addrs (
 	corosync_cfg_handle_t cfg_handle,
 	int nodeid,
@@ -583,6 +654,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_local_get
+ * @param handle
+ * @param local_nodeid
+ * @return
+ */
 cs_error_t corosync_cfg_local_get (
 	corosync_cfg_handle_t handle,
 	unsigned int *local_nodeid)
@@ -625,6 +702,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief corosync_cfg_reload_config
+ * @param handle
+ * @return
+ */
 cs_error_t corosync_cfg_reload_config (
 	corosync_cfg_handle_t handle)
 {

--- a/lib/cmap.c
+++ b/lib/cmap.c
@@ -74,6 +74,16 @@ DECLARE_HDB_DATABASE(cmap_track_handle_t_db,NULL);
 /*
  * Function prototypes
  */
+
+/**
+ * @brief cmap_get_int
+ * @param handle
+ * @param key_name
+ * @param value
+ * @param value_size
+ * @param type
+ * @return
+ */
 static cs_error_t cmap_get_int(
 	cmap_handle_t handle,
 	const char *key_name,
@@ -85,6 +95,11 @@ static cs_error_t cmap_adjust_int(cmap_handle_t handle, const char *key_name, in
 
 /*
  * Function implementations
+ */
+/**
+ * @brief cmap_initialize
+ * @param handle
+ * @return
  */
 cs_error_t cmap_initialize (cmap_handle_t *handle)
 {
@@ -121,12 +136,21 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief cmap_inst_free
+ * @param inst
+ */
 static void cmap_inst_free (void *inst)
 {
 	struct cmap_inst *cmap_inst = (struct cmap_inst *)inst;
 	qb_ipcc_disconnect(cmap_inst->c);
 }
 
+/**
+ * @brief cmap_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t cmap_finalize(cmap_handle_t handle)
 {
 	struct cmap_inst *cmap_inst;
@@ -166,6 +190,12 @@ cs_error_t cmap_finalize(cmap_handle_t handle)
 	return (CS_OK);
 }
 
+/**
+ * @brief cmap_fd_get
+ * @param handle
+ * @param fd
+ * @return
+ */
 cs_error_t cmap_fd_get(cmap_handle_t handle, int *fd)
 {
 	cs_error_t error;
@@ -183,6 +213,12 @@ cs_error_t cmap_fd_get(cmap_handle_t handle, int *fd)
 	return (error);
 }
 
+/**
+ * @brief cmap_dispatch
+ * @param handle
+ * @param dispatch_types
+ * @return
+ */
 cs_error_t cmap_dispatch (
 	cmap_handle_t handle,
         cs_dispatch_flags_t dispatch_types)
@@ -306,6 +342,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief cmap_context_get
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t cmap_context_get (
 	cmap_handle_t handle,
 	const void **context)
@@ -325,6 +367,12 @@ cs_error_t cmap_context_get (
 	return (CS_OK);
 }
 
+/**
+ * @brief cmap_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t cmap_context_set (
 	cmap_handle_t handle,
 	const void *context)
@@ -344,6 +392,15 @@ cs_error_t cmap_context_set (
 	return (CS_OK);
 }
 
+/**
+ * @brief cmap_set
+ * @param handle
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t cmap_set (
 	cmap_handle_t handle,
 	const char *key_name,
@@ -401,56 +458,133 @@ cs_error_t cmap_set (
 	return (error);
 }
 
+/**
+ * @brief cmap_set_int8
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_int8(cmap_handle_t handle, const char *key_name, int8_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_INT8));
 }
 
+/**
+ * @brief cmap_set_uint8
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_uint8(cmap_handle_t handle, const char *key_name, uint8_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_UINT8));
 }
 
+/**
+ * @brief cmap_set_int16
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_int16(cmap_handle_t handle, const char *key_name, int16_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_INT16));
 }
 
+/**
+ * @brief cmap_set_uint16
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_uint16(cmap_handle_t handle, const char *key_name, uint16_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_UINT16));
 }
 
+/**
+ * @brief cmap_set_int32
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_int32(cmap_handle_t handle, const char *key_name, int32_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_INT32));
 }
 
+/**
+ * @brief cmap_set_uint32
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_uint32(cmap_handle_t handle, const char *key_name, uint32_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_UINT32));
 }
 
+/**
+ * @brief cmap_set_int64
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_int64(cmap_handle_t handle, const char *key_name, int64_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_INT64));
 }
 
+/**
+ * @brief cmap_set_uint64
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_uint64(cmap_handle_t handle, const char *key_name, uint64_t value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_UINT64));
 }
 
+/**
+ * @brief cmap_set_float
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_float(cmap_handle_t handle, const char *key_name, float value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_FLOAT));
 }
 
+/**
+ * @brief cmap_set_double
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_double(cmap_handle_t handle, const char *key_name, double value)
 {
 	return (cmap_set(handle, key_name, &value, sizeof(value), CMAP_VALUETYPE_DOUBLE));
 }
 
+/**
+ * @brief cmap_set_string
+ * @param handle
+ * @param key_name
+ * @param value
+ * @return
+ */
 cs_error_t cmap_set_string(cmap_handle_t handle, const char *key_name, const char *value)
 {
 
@@ -461,6 +595,12 @@ cs_error_t cmap_set_string(cmap_handle_t handle, const char *key_name, const cha
 	return (cmap_set(handle, key_name, value, strlen(value), CMAP_VALUETYPE_STRING));
 }
 
+/**
+ * @brief cmap_delete
+ * @param handle
+ * @param key_name
+ * @return
+ */
 cs_error_t cmap_delete(cmap_handle_t handle, const char *key_name)
 {
 	cs_error_t error;
@@ -507,6 +647,15 @@ cs_error_t cmap_delete(cmap_handle_t handle, const char *key_name)
 	return (error);
 }
 
+/**
+ * @brief cmap_get
+ * @param handle
+ * @param key_name
+ * @param value
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t cmap_get(
 		cmap_handle_t handle,
 		const char *key_name,
@@ -592,6 +741,15 @@ cs_error_t cmap_get(
 	return (error);
 }
 
+/**
+ * @brief cmap_get_int
+ * @param handle
+ * @param key_name
+ * @param value
+ * @param value_size
+ * @param type
+ * @return
+ */
 static cs_error_t cmap_get_int(
 	cmap_handle_t handle,
 	const char *key_name,
@@ -621,66 +779,143 @@ static cs_error_t cmap_get_int(
 	return (CS_OK);
 }
 
+/**
+ * @brief cmap_get_int8
+ * @param handle
+ * @param key_name
+ * @param i8
+ * @return
+ */
 cs_error_t cmap_get_int8(cmap_handle_t handle, const char *key_name, int8_t *i8)
 {
 
 	return (cmap_get_int(handle, key_name, i8, sizeof(*i8), CMAP_VALUETYPE_INT8));
 }
 
+/**
+ * @brief cmap_get_uint8
+ * @param handle
+ * @param key_name
+ * @param u8
+ * @return
+ */
 cs_error_t cmap_get_uint8(cmap_handle_t handle, const char *key_name, uint8_t *u8)
 {
 
 	return (cmap_get_int(handle, key_name, u8, sizeof(*u8), CMAP_VALUETYPE_UINT8));
 }
 
+/**
+ * @brief cmap_get_int16
+ * @param handle
+ * @param key_name
+ * @param i16
+ * @return
+ */
 cs_error_t cmap_get_int16(cmap_handle_t handle, const char *key_name, int16_t *i16)
 {
 
 	return (cmap_get_int(handle, key_name, i16, sizeof(*i16), CMAP_VALUETYPE_INT16));
 }
 
+/**
+ * @brief cmap_get_uint16
+ * @param handle
+ * @param key_name
+ * @param u16
+ * @return
+ */
 cs_error_t cmap_get_uint16(cmap_handle_t handle, const char *key_name, uint16_t *u16)
 {
 
 	return (cmap_get_int(handle, key_name, u16, sizeof(*u16), CMAP_VALUETYPE_UINT16));
 }
 
+/**
+ * @brief cmap_get_int32
+ * @param handle
+ * @param key_name
+ * @param i32
+ * @return
+ */
 cs_error_t cmap_get_int32(cmap_handle_t handle, const char *key_name, int32_t *i32)
 {
 
 	return (cmap_get_int(handle, key_name, i32, sizeof(*i32), CMAP_VALUETYPE_INT32));
 }
 
+/**
+ * @brief cmap_get_uint32
+ * @param handle
+ * @param key_name
+ * @param u32
+ * @return
+ */
 cs_error_t cmap_get_uint32(cmap_handle_t handle, const char *key_name, uint32_t *u32)
 {
 
 	return (cmap_get_int(handle, key_name, u32, sizeof(*u32), CMAP_VALUETYPE_UINT32));
 }
 
+/**
+ * @brief cmap_get_int64
+ * @param handle
+ * @param key_name
+ * @param i64
+ * @return
+ */
 cs_error_t cmap_get_int64(cmap_handle_t handle, const char *key_name, int64_t *i64)
 {
 
 	return (cmap_get_int(handle, key_name, i64, sizeof(*i64), CMAP_VALUETYPE_INT64));
 }
 
+/**
+ * @brief cmap_get_uint64
+ * @param handle
+ * @param key_name
+ * @param u64
+ * @return
+ */
 cs_error_t cmap_get_uint64(cmap_handle_t handle, const char *key_name, uint64_t *u64)
 {
 
 	return (cmap_get_int(handle, key_name, u64, sizeof(*u64), CMAP_VALUETYPE_UINT64));
 }
 
+/**
+ * @brief cmap_get_float
+ * @param handle
+ * @param key_name
+ * @param flt
+ * @return
+ */
 cs_error_t cmap_get_float(cmap_handle_t handle, const char *key_name, float *flt)
 {
 
 	return (cmap_get_int(handle, key_name, flt, sizeof(*flt), CMAP_VALUETYPE_FLOAT));
 }
 
+/**
+ * @brief cmap_get_double
+ * @param handle
+ * @param key_name
+ * @param dbl
+ * @return
+ */
 cs_error_t cmap_get_double(cmap_handle_t handle, const char *key_name, double *dbl)
 {
 
 	return (cmap_get_int(handle, key_name, dbl, sizeof(*dbl), CMAP_VALUETYPE_DOUBLE));
 }
 
+/**
+ * @brief cmap_get_string
+ * @param handle
+ * @param key_name
+ * @param str
+ * @return
+ */
 cs_error_t cmap_get_string(cmap_handle_t handle, const char *key_name, char **str)
 {
 	cs_error_t res;
@@ -717,6 +952,13 @@ return_error:
 	return (res);
 }
 
+/**
+ * @brief cmap_adjust_int
+ * @param handle
+ * @param key_name
+ * @param step
+ * @return
+ */
 static cs_error_t cmap_adjust_int(cmap_handle_t handle, const char *key_name, int32_t step)
 {
 	cs_error_t error;
@@ -765,18 +1007,37 @@ static cs_error_t cmap_adjust_int(cmap_handle_t handle, const char *key_name, in
 	return (error);
 }
 
+/**
+ * @brief cmap_inc
+ * @param handle
+ * @param key_name
+ * @return
+ */
 cs_error_t cmap_inc(cmap_handle_t handle, const char *key_name)
 {
 
 	return (cmap_adjust_int(handle, key_name, 1));
 }
 
+/**
+ * @brief cmap_dec
+ * @param handle
+ * @param key_name
+ * @return
+ */
 cs_error_t cmap_dec(cmap_handle_t handle, const char *key_name)
 {
 
 	return (cmap_adjust_int(handle, key_name, -1));
 }
 
+/**
+ * @brief cmap_iter_init
+ * @param handle
+ * @param prefix
+ * @param cmap_iter_handle
+ * @return
+ */
 cs_error_t cmap_iter_init(
 		cmap_handle_t handle,
 		const char *prefix,
@@ -832,6 +1093,15 @@ cs_error_t cmap_iter_init(
 	return (error);
 }
 
+/**
+ * @brief cmap_iter_next
+ * @param handle
+ * @param iter_handle
+ * @param key_name
+ * @param value_len
+ * @param type
+ * @return
+ */
 cs_error_t cmap_iter_next(
 		cmap_handle_t handle,
 		cmap_iter_handle_t iter_handle,
@@ -890,6 +1160,12 @@ cs_error_t cmap_iter_next(
 	return (error);
 }
 
+/**
+ * @brief cmap_iter_finalize
+ * @param handle
+ * @param iter_handle
+ * @return
+ */
 cs_error_t cmap_iter_finalize(
 		cmap_handle_t handle,
 		cmap_iter_handle_t iter_handle)
@@ -929,6 +1205,16 @@ cs_error_t cmap_iter_finalize(
 	return (error);
 }
 
+/**
+ * @brief cmap_track_add
+ * @param handle
+ * @param key_name
+ * @param track_type
+ * @param notify_fn
+ * @param user_data
+ * @param cmap_track_handle
+ * @return
+ */
 cs_error_t cmap_track_add(
 	cmap_handle_t handle,
 	const char *key_name,
@@ -1020,6 +1306,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief cmap_track_delete
+ * @param handle
+ * @param track_handle
+ * @return
+ */
 cs_error_t cmap_track_delete(
 		cmap_handle_t handle,
 		cmap_track_handle_t track_handle)

--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -80,6 +80,9 @@
  */
 #define CPG_MEMORY_MAP_UMASK		077
 
+/**
+ * @brief The cpg_inst struct
+ */
 struct cpg_inst {
 	qb_ipcc_connection_t *c;
 	int finalize;
@@ -102,6 +105,9 @@ static void cpg_inst_free (void *inst);
 
 DECLARE_HDB_DATABASE(cpg_handle_t_db, cpg_inst_free);
 
+/**
+ * @brief The cpg_iteration_instance_t struct
+ */
 struct cpg_iteration_instance_t {
 	cpg_iteration_handle_t cpg_iteration_handle;
 	qb_ipcc_connection_t *conn;
@@ -116,6 +122,15 @@ DECLARE_HDB_DATABASE(cpg_iteration_handle_t_db,NULL);
  * Internal (not visible by API) functions
  */
 
+/**
+ * @brief coroipcc_msg_send_reply_receive
+ * @param c
+ * @param iov
+ * @param iov_len
+ * @param res_msg
+ * @param res_len
+ * @return
+ */
 static cs_error_t
 coroipcc_msg_send_reply_receive (
 	qb_ipcc_connection_t *c,
@@ -128,18 +143,31 @@ coroipcc_msg_send_reply_receive (
 				CS_IPC_TIMEOUT_MS));
 }
 
+/**
+ * @brief cpg_iteration_instance_finalize
+ * @param cpg_iteration_instance
+ */
 static void cpg_iteration_instance_finalize (struct cpg_iteration_instance_t *cpg_iteration_instance)
 {
 	qb_list_del (&cpg_iteration_instance->list);
 	hdb_handle_destroy (&cpg_iteration_handle_t_db, cpg_iteration_instance->cpg_iteration_handle);
 }
 
+/**
+ * @brief cpg_inst_free
+ * @param inst
+ */
 static void cpg_inst_free (void *inst)
 {
 	struct cpg_inst *cpg_inst = (struct cpg_inst *)inst;
 	qb_ipcc_disconnect(cpg_inst->c);
 }
 
+/**
+ * @brief cpg_inst_finalize
+ * @param cpg_inst
+ * @param handle
+ */
 static void cpg_inst_finalize (struct cpg_inst *cpg_inst, hdb_handle_t handle)
 {
 	struct qb_list_head *iter, *tmp_iter;
@@ -163,6 +191,12 @@ static void cpg_inst_finalize (struct cpg_inst *cpg_inst, hdb_handle_t handle)
  * @{
  */
 
+/**
+ * @brief cpg_initialize
+ * @param handle
+ * @param callbacks
+ * @return
+ */
 cs_error_t cpg_initialize (
 	cpg_handle_t *handle,
 	cpg_callbacks_t *callbacks)
@@ -179,6 +213,14 @@ cs_error_t cpg_initialize (
 	return (cpg_model_initialize (handle, CPG_MODEL_V1, (cpg_model_data_t *)&model_v1_data, NULL));
 }
 
+/**
+ * @brief cpg_model_initialize
+ * @param handle
+ * @param model
+ * @param model_data
+ * @param context
+ * @return
+ */
 cs_error_t cpg_model_initialize (
 	cpg_handle_t *handle,
 	cpg_model_t model,
@@ -241,6 +283,11 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief cpg_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t cpg_finalize (
 	cpg_handle_t handle)
 {
@@ -286,6 +333,12 @@ cs_error_t cpg_finalize (
 	return (error);
 }
 
+/**
+ * @brief cpg_fd_get
+ * @param handle
+ * @param fd
+ * @return
+ */
 cs_error_t cpg_fd_get (
 	cpg_handle_t handle,
 	int *fd)
@@ -305,6 +358,12 @@ cs_error_t cpg_fd_get (
 	return (error);
 }
 
+/**
+ * @brief cpg_max_atomic_msgsize_get
+ * @param handle
+ * @param size
+ * @return
+ */
 cs_error_t cpg_max_atomic_msgsize_get (
 	cpg_handle_t handle,
 	uint32_t *size)
@@ -324,6 +383,12 @@ cs_error_t cpg_max_atomic_msgsize_get (
 	return (error);
 }
 
+/**
+ * @brief cpg_context_get
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t cpg_context_get (
 	cpg_handle_t handle,
 	void **context)
@@ -343,6 +408,12 @@ cs_error_t cpg_context_get (
 	return (CS_OK);
 }
 
+/**
+ * @brief cpg_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t cpg_context_set (
 	cpg_handle_t handle,
 	void *context)
@@ -362,6 +433,12 @@ cs_error_t cpg_context_set (
 	return (CS_OK);
 }
 
+/**
+ * @brief cpg_dispatch
+ * @param handle
+ * @param dispatch_types
+ * @return
+ */
 cs_error_t cpg_dispatch (
 	cpg_handle_t handle,
 	cs_dispatch_flags_t dispatch_types)
@@ -584,6 +661,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief cpg_join
+ * @param handle
+ * @param group
+ * @return
+ */
 cs_error_t cpg_join (
     cpg_handle_t handle,
     const struct cpg_name *group)
@@ -638,6 +721,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_leave
+ * @param handle
+ * @param group
+ * @return
+ */
 cs_error_t cpg_leave (
     cpg_handle_t handle,
     const struct cpg_name *group)
@@ -683,6 +772,14 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_membership_get
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @return
+ */
 cs_error_t cpg_membership_get (
 	cpg_handle_t handle,
 	struct cpg_name *group_name,
@@ -746,6 +843,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_local_get
+ * @param handle
+ * @param local_nodeid
+ * @return
+ */
 cs_error_t cpg_local_get (
 	cpg_handle_t handle,
 	unsigned int *local_nodeid)
@@ -784,6 +887,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_flow_control_state_get
+ * @param handle
+ * @param flow_control_state
+ * @return
+ */
 cs_error_t cpg_flow_control_state_get (
 	cpg_handle_t handle,
 	cpg_flow_control_state_t *flow_control_state)
@@ -803,6 +912,14 @@ cs_error_t cpg_flow_control_state_get (
 	return (error);
 }
 
+/**
+ * @brief memory_map
+ * @param path
+ * @param file
+ * @param buf
+ * @param bytes
+ * @return
+ */
 static int
 memory_map (char *path, const char *file, void **buf, size_t bytes)
 {
@@ -884,6 +1001,13 @@ error_close_unlink:
 	return -1;
 }
 
+/**
+ * @brief cpg_zcb_alloc
+ * @param handle
+ * @param size
+ * @param buffer
+ * @return
+ */
 cs_error_t cpg_zcb_alloc (
 	cpg_handle_t handle,
 	size_t size,
@@ -941,6 +1065,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_zcb_free
+ * @param handle
+ * @param buffer
+ * @return
+ */
 cs_error_t cpg_zcb_free (
 	cpg_handle_t handle,
 	void *buffer)
@@ -990,6 +1120,14 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_zcb_mcast_joined
+ * @param handle
+ * @param guarantee
+ * @param msg
+ * @param msg_len
+ * @return
+ */
 cs_error_t cpg_zcb_mcast_joined (
 	cpg_handle_t handle,
 	cpg_guarantee_t guarantee,
@@ -1050,6 +1188,15 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief send_fragments
+ * @param cpg_inst
+ * @param guarantee
+ * @param msg_len
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 static cs_error_t send_fragments (
 	struct cpg_inst *cpg_inst,
 	cpg_guarantee_t guarantee,
@@ -1132,6 +1279,14 @@ error_exit:
 }
 
 
+/**
+ * @brief cpg_mcast_joined
+ * @param handle
+ * @param guarantee
+ * @param iovec
+ * @param iov_len
+ * @return
+ */
 cs_error_t cpg_mcast_joined (
 	cpg_handle_t handle,
 	cpg_guarantee_t guarantee,
@@ -1180,6 +1335,14 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_iteration_initialize
+ * @param handle
+ * @param iteration_type
+ * @param group
+ * @param cpg_iteration_handle
+ * @return
+ */
 cs_error_t cpg_iteration_initialize(
 	cpg_handle_t handle,
 	cpg_iteration_type_t iteration_type,
@@ -1273,6 +1436,12 @@ error_put_cpg_db:
 	return (error);
 }
 
+/**
+ * @brief cpg_iteration_next
+ * @param handle
+ * @param description
+ * @return
+ */
 cs_error_t cpg_iteration_next(
 	cpg_iteration_handle_t handle,
 	struct cpg_iteration_description_t *description)
@@ -1323,6 +1492,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief cpg_iteration_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t cpg_iteration_finalize (
 	cpg_iteration_handle_t handle)
 {

--- a/lib/quorum.c
+++ b/lib/quorum.c
@@ -55,6 +55,9 @@
 
 #include "util.h"
 
+/**
+ * @brief The quorum_inst struct
+ */
 struct quorum_inst {
 	qb_ipcc_connection_t *c;
 	int finalize;
@@ -66,6 +69,13 @@ static void quorum_inst_free (void *inst);
 
 DECLARE_HDB_DATABASE(quorum_handle_t_db, quorum_inst_free);
 
+/**
+ * @brief quorum_initialize
+ * @param handle
+ * @param callbacks
+ * @param quorum_type
+ * @return
+ */
 cs_error_t quorum_initialize (
 	quorum_handle_t *handle,
 	quorum_callbacks_t *callbacks,
@@ -133,12 +143,21 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief quorum_inst_free
+ * @param inst
+ */
 static void quorum_inst_free (void *inst)
 {
 	struct quorum_inst *quorum_inst = (struct quorum_inst *)inst;
 	qb_ipcc_disconnect(quorum_inst->c);
 }
 
+/**
+ * @brief quorum_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t quorum_finalize (
 	quorum_handle_t handle)
 {
@@ -167,6 +186,12 @@ cs_error_t quorum_finalize (
 	return (CS_OK);
 }
 
+/**
+ * @brief quorum_getquorate
+ * @param handle
+ * @param quorate
+ * @return
+ */
 cs_error_t quorum_getquorate (
 	quorum_handle_t handle,
 	int *quorate)
@@ -209,6 +234,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief quorum_fd_get
+ * @param handle
+ * @param fd
+ * @return
+ */
 cs_error_t quorum_fd_get (
 	quorum_handle_t handle,
 	int *fd)
@@ -229,6 +260,12 @@ cs_error_t quorum_fd_get (
 }
 
 
+/**
+ * @brief quorum_context_get
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t quorum_context_get (
 	quorum_handle_t handle,
 	const void **context)
@@ -248,6 +285,12 @@ cs_error_t quorum_context_get (
 	return (CS_OK);
 }
 
+/**
+ * @brief quorum_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t quorum_context_set (
 	quorum_handle_t handle,
 	const void *context)
@@ -268,6 +311,12 @@ cs_error_t quorum_context_set (
 }
 
 
+/**
+ * @brief quorum_trackstart
+ * @param handle
+ * @param flags
+ * @return
+ */
 cs_error_t quorum_trackstart (
 	quorum_handle_t handle,
 	unsigned int flags )
@@ -309,6 +358,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief quorum_trackstop
+ * @param handle
+ * @return
+ */
 cs_error_t quorum_trackstop (
 	quorum_handle_t handle)
 {
@@ -348,6 +402,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief quorum_dispatch
+ * @param handle
+ * @param dispatch_types
+ * @return
+ */
 cs_error_t quorum_dispatch (
 	quorum_handle_t handle,
 	cs_dispatch_flags_t dispatch_types)

--- a/lib/sam.c
+++ b/lib/sam.c
@@ -72,6 +72,9 @@
 #define SAM_RP_MASK_C(pol)	(pol & (~SAM_RECOVERY_POLICY_CMAP))
 #define SAM_RP_MASK(pol)	(pol & (~(SAM_RECOVERY_POLICY_QUORUM | SAM_RECOVERY_POLICY_CMAP)))
 
+/**
+ * @brief The sam_internal_status_t enum
+ */
 enum sam_internal_status_t {
 	SAM_INTERNAL_STATUS_NOT_INITIALIZED = 0,
 	SAM_INTERNAL_STATUS_INITIALIZED,
@@ -80,6 +83,9 @@ enum sam_internal_status_t {
 	SAM_INTERNAL_STATUS_FINALIZED
 };
 
+/**
+ * @brief The sam_command_t enum
+ */
 enum sam_command_t {
 	SAM_COMMAND_START,
 	SAM_COMMAND_STOP,
@@ -89,11 +95,17 @@ enum sam_command_t {
 	SAM_COMMAND_MARK_FAILED,
 };
 
+/**
+ * @brief The sam_reply_t enum
+ */
 enum sam_reply_t {
 	SAM_REPLY_OK,
 	SAM_REPLY_ERROR,
 };
 
+/**
+ * @brief The sam_parent_action_t enum
+ */
 enum sam_parent_action_t {
 	SAM_PARENT_ACTION_ERROR,
 	SAM_PARENT_ACTION_RECOVERY,
@@ -101,6 +113,9 @@ enum sam_parent_action_t {
 	SAM_PARENT_ACTION_CONTINUE
 };
 
+/**
+ * @brief The sam_cmap_key_t enum
+ */
 enum sam_cmap_key_t {
 	SAM_CMAP_KEY_RECOVERY,
 	SAM_CMAP_KEY_HC_PERIOD,
@@ -108,6 +123,9 @@ enum sam_cmap_key_t {
 	SAM_CMAP_KEY_STATE,
 };
 
+/**
+ * @brief sam_internal_data
+ */
 static struct {
 	int time_interval;
 	sam_recovery_policy_t recovery_policy;
@@ -140,6 +158,12 @@ static struct {
 
 extern const char *__progname;
 
+/**
+ * @brief sam_cmap_update_key
+ * @param key
+ * @param value
+ * @return
+ */
 static cs_error_t sam_cmap_update_key (enum sam_cmap_key_t key, const char *value)
 {
 	cs_error_t err;
@@ -192,6 +216,10 @@ exit_error:
 	return (err);
 }
 
+/**
+ * @brief sam_cmap_destroy_pid_path
+ * @return
+ */
 static cs_error_t sam_cmap_destroy_pid_path (void)
 {
 	cmap_iter_handle_t iter;
@@ -213,6 +241,10 @@ error_exit:
 	return (err);
 }
 
+/**
+ * @brief sam_cmap_register
+ * @return
+ */
 static cs_error_t sam_cmap_register (void)
 {
 	cs_error_t err;
@@ -242,6 +274,14 @@ destroy_finalize_error:
 	return (err);
 }
 
+/**
+ * @brief quorum_notification_fn
+ * @param handle
+ * @param quorate
+ * @param ring_id
+ * @param view_list_entries
+ * @param view_list
+ */
 static void quorum_notification_fn (
         quorum_handle_t handle,
         uint32_t quorate,
@@ -252,6 +292,12 @@ static void quorum_notification_fn (
 	sam_internal_data.quorate = quorate;
 }
 
+/**
+ * @brief sam_initialize
+ * @param time_interval
+ * @param recovery_policy
+ * @return
+ */
 cs_error_t sam_initialize (
 	int time_interval,
 	sam_recovery_policy_t recovery_policy)
@@ -320,6 +366,13 @@ exit_error:
 /*
  * Wrapper on top of write(2) function. It handles EAGAIN and EINTR states and sends whole buffer if possible.
  */
+/**
+ * @brief sam_safe_write
+ * @param d
+ * @param buf
+ * @param nbyte
+ * @return
+ */
 static size_t sam_safe_write (
 	int d,
 	const void *buf,
@@ -348,6 +401,13 @@ static size_t sam_safe_write (
 /*
  * Wrapper on top of read(2) function. It handles EAGAIN and EINTR states and reads whole buffer if possible.
  */
+/**
+ * @brief sam_safe_read
+ * @param d
+ * @param buf
+ * @param nbyte
+ * @return
+ */
 static size_t sam_safe_read (
 	int d,
 	void *buf,
@@ -374,6 +434,11 @@ static size_t sam_safe_read (
 	return (bytes_read);
 }
 
+/**
+ * @brief sam_read_reply
+ * @param child_fd_in
+ * @return
+ */
 static cs_error_t sam_read_reply (
 	int child_fd_in)
 {
@@ -408,6 +473,11 @@ static cs_error_t sam_read_reply (
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_data_getsize
+ * @param size
+ * @return
+ */
 cs_error_t sam_data_getsize (size_t *size)
 {
 	if (size == NULL) {
@@ -430,6 +500,12 @@ cs_error_t sam_data_getsize (size_t *size)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_data_restore
+ * @param data
+ * @param size
+ * @return
+ */
 cs_error_t sam_data_restore (
 	void *data,
 	size_t size)
@@ -475,6 +551,12 @@ error_unlock:
 	return (err);
 }
 
+/**
+ * @brief sam_data_store
+ * @param data
+ * @param size
+ * @return
+ */
 cs_error_t sam_data_store (
 	const void *data,
 	size_t size)
@@ -564,6 +646,10 @@ error_unlock:
 	return (err);
 }
 
+/**
+ * @brief sam_start
+ * @return
+ */
 cs_error_t sam_start (void)
 {
 	char command;
@@ -612,6 +698,10 @@ cs_error_t sam_start (void)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_stop
+ * @return
+ */
 cs_error_t sam_stop (void)
 {
 	char command;
@@ -657,6 +747,10 @@ cs_error_t sam_stop (void)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_hc_send
+ * @return
+ */
 cs_error_t sam_hc_send (void)
 {
 	char command;
@@ -673,6 +767,10 @@ cs_error_t sam_hc_send (void)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_finalize
+ * @return
+ */
 cs_error_t sam_finalize (void)
 {
 	cs_error_t error;
@@ -697,6 +795,10 @@ exit_error:
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_mark_failed
+ * @return
+ */
 cs_error_t sam_mark_failed (void)
 {
 	char command;
@@ -718,6 +820,11 @@ cs_error_t sam_mark_failed (void)
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_warn_signal_set
+ * @param warn_signal
+ * @return
+ */
 cs_error_t sam_warn_signal_set (int warn_signal)
 {
 	char command;
@@ -772,6 +879,13 @@ error_unlock:
 	return (err);
 }
 
+/**
+ * @brief sam_parent_reply_send
+ * @param err
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @return
+ */
 static cs_error_t sam_parent_reply_send (
 	cs_error_t err,
 	int parent_fd_in,
@@ -803,6 +917,12 @@ error_reply:
 }
 
 
+/**
+ * @brief sam_parent_warn_signal_set
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @return
+ */
 static cs_error_t sam_parent_warn_signal_set (
 	int parent_fd_in,
 	int parent_fd_out)
@@ -829,6 +949,12 @@ error_reply:
 	return (sam_parent_reply_send (err, parent_fd_in, parent_fd_out));
 }
 
+/**
+ * @brief sam_parent_wait_for_quorum
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @return
+ */
 static cs_error_t sam_parent_wait_for_quorum (
 	int parent_fd_in,
 	int parent_fd_out)
@@ -907,6 +1033,13 @@ error_reply:
 	return (sam_parent_reply_send (err, parent_fd_in, parent_fd_out));
 }
 
+/**
+ * @brief sam_parent_cmap_state_set
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @param state
+ * @return
+ */
 static cs_error_t sam_parent_cmap_state_set (
 	int parent_fd_in,
 	int parent_fd_out,
@@ -931,6 +1064,12 @@ error_reply:
 	return (sam_parent_reply_send (err, parent_fd_in, parent_fd_out));
 }
 
+/**
+ * @brief sam_parent_kill_child
+ * @param action
+ * @param child_pid
+ * @return
+ */
 static cs_error_t sam_parent_kill_child (
 	int *action,
 	pid_t child_pid)
@@ -956,6 +1095,12 @@ static cs_error_t sam_parent_kill_child (
 	return (CS_OK);
 }
 
+/**
+ * @brief sam_parent_mark_child_failed
+ * @param action
+ * @param child_pid
+ * @return
+ */
 static cs_error_t sam_parent_mark_child_failed (
 	int *action,
 	pid_t child_pid)
@@ -972,6 +1117,12 @@ static cs_error_t sam_parent_mark_child_failed (
 	return (sam_parent_kill_child (action, child_pid));
 }
 
+/**
+ * @brief sam_parent_data_store
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @return
+ */
 static cs_error_t sam_parent_data_store (
 	int parent_fd_in,
 	int parent_fd_out)
@@ -1016,6 +1167,13 @@ error_reply:
 	return (sam_parent_reply_send (err, parent_fd_in, parent_fd_out));
 }
 
+/**
+ * @brief sam_parent_handler
+ * @param parent_fd_in
+ * @param parent_fd_out
+ * @param child_pid
+ * @return
+ */
 static enum sam_parent_action_t sam_parent_handler (
 	int parent_fd_in,
 	int parent_fd_out,
@@ -1180,6 +1338,11 @@ action_exit:
 	return action;
 }
 
+/**
+ * @brief sam_register
+ * @param instance_id
+ * @return
+ */
 cs_error_t sam_register (
 	unsigned int *instance_id)
 {
@@ -1321,6 +1484,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief hc_callback_thread
+ * @param unused_param
+ * @return
+ */
 static void *hc_callback_thread (void *unused_param)
 {
 	int poll_error;
@@ -1383,6 +1551,11 @@ static void *hc_callback_thread (void *unused_param)
 	return (unused_param);
 }
 
+/**
+ * @brief sam_hc_callback_register
+ * @param cb
+ * @return
+ */
 cs_error_t sam_hc_callback_register (sam_hc_callback_t cb)
 {
 	cs_error_t error = CS_OK;

--- a/lib/util.h
+++ b/lib/util.h
@@ -39,6 +39,11 @@
 
 #include <corosync/corotypes.h>
 
+/**
+ * @brief hdb_error_to_cs
+ * @param res
+ * @return
+ */
 cs_error_t hdb_error_to_cs (int res);
 
 #ifdef HAVE_SMALL_MEMORY_FOOTPRINT

--- a/lib/votequorum.c
+++ b/lib/votequorum.c
@@ -58,6 +58,9 @@
 
 #include "util.h"
 
+/**
+ * @brief The votequorum_inst struct
+ */
 struct votequorum_inst {
 	qb_ipcc_connection_t *c;
 	int finalize;
@@ -69,6 +72,12 @@ static void votequorum_inst_free (void *inst);
 
 DECLARE_HDB_DATABASE(votequorum_handle_t_db, votequorum_inst_free);
 
+/**
+ * @brief votequorum_initialize
+ * @param handle
+ * @param callbacks
+ * @return
+ */
 cs_error_t votequorum_initialize (
 	votequorum_handle_t *handle,
 	votequorum_callbacks_t *callbacks)
@@ -110,12 +119,21 @@ error_no_destroy:
 	return (error);
 }
 
+/**
+ * @brief votequorum_inst_free
+ * @param inst
+ */
 static void votequorum_inst_free (void *inst)
 {
 	struct votequorum_inst *vq_inst = (struct votequorum_inst *)inst;
 	qb_ipcc_disconnect(vq_inst->c);
 }
 
+/**
+ * @brief votequorum_finalize
+ * @param handle
+ * @return
+ */
 cs_error_t votequorum_finalize (
 	votequorum_handle_t handle)
 {
@@ -145,6 +163,13 @@ cs_error_t votequorum_finalize (
 }
 
 
+/**
+ * @brief votequorum_getinfo
+ * @param handle
+ * @param nodeid
+ * @param info
+ * @return
+ */
 cs_error_t votequorum_getinfo (
 	votequorum_handle_t handle,
 	unsigned int nodeid,
@@ -199,6 +224,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_setexpected
+ * @param handle
+ * @param expected_votes
+ * @return
+ */
 cs_error_t votequorum_setexpected (
 	votequorum_handle_t handle,
 	unsigned int expected_votes)
@@ -241,6 +272,13 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_setvotes
+ * @param handle
+ * @param nodeid
+ * @param votes
+ * @return
+ */
 cs_error_t votequorum_setvotes (
 	votequorum_handle_t handle,
 	unsigned int nodeid,
@@ -284,6 +322,13 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_trackstart
+ * @param handle
+ * @param context
+ * @param flags
+ * @return
+ */
 cs_error_t votequorum_trackstart (
 	votequorum_handle_t handle,
 	uint64_t context,
@@ -327,6 +372,11 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_trackstop
+ * @param handle
+ * @return
+ */
 cs_error_t votequorum_trackstop (
 	votequorum_handle_t handle)
 {
@@ -367,6 +417,12 @@ error_exit:
 }
 
 
+/**
+ * @brief votequorum_context_get
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t votequorum_context_get (
 	votequorum_handle_t handle,
 	void **context)
@@ -386,6 +442,12 @@ cs_error_t votequorum_context_get (
 	return (CS_OK);
 }
 
+/**
+ * @brief votequorum_context_set
+ * @param handle
+ * @param context
+ * @return
+ */
 cs_error_t votequorum_context_set (
 	votequorum_handle_t handle,
 	void *context)
@@ -406,6 +468,12 @@ cs_error_t votequorum_context_set (
 }
 
 
+/**
+ * @brief votequorum_fd_get
+ * @param handle
+ * @param fd
+ * @return
+ */
 cs_error_t votequorum_fd_get (
         votequorum_handle_t handle,
         int *fd)
@@ -425,6 +493,12 @@ cs_error_t votequorum_fd_get (
 	return (error);
 }
 
+/**
+ * @brief votequorum_dispatch
+ * @param handle
+ * @param dispatch_types
+ * @return
+ */
 cs_error_t votequorum_dispatch (
 	votequorum_handle_t handle,
 	cs_dispatch_flags_t dispatch_types)
@@ -569,6 +643,12 @@ error_put:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_register
+ * @param handle
+ * @param name
+ * @return
+ */
 cs_error_t votequorum_qdevice_register (
 	votequorum_handle_t handle,
 	const char *name)
@@ -616,6 +696,14 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_poll
+ * @param handle
+ * @param name
+ * @param cast_vote
+ * @param ring_id
+ * @return
+ */
 cs_error_t votequorum_qdevice_poll (
 	votequorum_handle_t handle,
 	const char *name,
@@ -666,6 +754,13 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_master_wins
+ * @param handle
+ * @param name
+ * @param allow
+ * @return
+ */
 cs_error_t votequorum_qdevice_master_wins (
 	votequorum_handle_t handle,
 	const char *name,
@@ -714,6 +809,13 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_update
+ * @param handle
+ * @param oldname
+ * @param newname
+ * @return
+ */
 cs_error_t votequorum_qdevice_update (
 	votequorum_handle_t handle,
 	const char *oldname,
@@ -764,6 +866,12 @@ error_exit:
 	return (error);
 }
 
+/**
+ * @brief votequorum_qdevice_unregister
+ * @param handle
+ * @param name
+ * @return
+ */
 cs_error_t votequorum_qdevice_unregister (
 	votequorum_handle_t handle,
 	const char *name)

--- a/test/cpgbench.c
+++ b/test/cpgbench.c
@@ -57,8 +57,14 @@
 #include <corosync/corotypes.h>
 #include <corosync/cpg.h>
 
+/**
+ * @brief handle
+ */
 static cpg_handle_t handle;
 
+/**
+ * @brief thread
+ */
 static pthread_t thread;
 
 #ifndef timersub
@@ -73,8 +79,22 @@ static pthread_t thread;
 	} while (0)
 #endif /* timersub */
 
+/**
+ * @brief alarm_notice
+ */
 static int alarm_notice;
 
+/**
+ * @brief cpg_bm_confchg_fn
+ * @param handle_in
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_bm_confchg_fn (
 	cpg_handle_t handle_in,
 	const struct cpg_name *group_name,
@@ -84,8 +104,20 @@ static void cpg_bm_confchg_fn (
 {
 }
 
+/**
+ * @brief write_count
+ */
 static unsigned int write_count;
 
+/**
+ * @brief cpg_bm_deliver_fn
+ * @param handle_in
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void cpg_bm_deliver_fn (
         cpg_handle_t handle_in,
         const struct cpg_name *group_name,
@@ -97,14 +129,26 @@ static void cpg_bm_deliver_fn (
 	write_count++;
 }
 
+/**
+ * @brief callbacks
+ */
 static cpg_callbacks_t callbacks = {
 	.cpg_deliver_fn 	= cpg_bm_deliver_fn,
 	.cpg_confchg_fn		= cpg_bm_confchg_fn
 };
 
 #define ONE_MEG 1048576
+
+/**
+ * @brief data
+ */
 static char data[ONE_MEG];
 
+/**
+ * @brief cpg_benchmark
+ * @param handle_in
+ * @param write_size
+ */
 static void cpg_benchmark (
 	cpg_handle_t handle_in,
 	int write_size)
@@ -137,22 +181,38 @@ static void cpg_benchmark (
 		((float)write_count) * ((float)write_size) /  ((tv_elapsed.tv_sec + (tv_elapsed.tv_usec / 1000000.0)) * 1000000.0));
 }
 
+/**
+ * @brief sigalrm_handler
+ * @param num
+ */
 static void sigalrm_handler (int num)
 {
 	alarm_notice = 1;
 }
 
+/**
+ * @brief group_name
+ */
 static struct cpg_name group_name = {
 	.value = "cpg_bm",
 	.length = 6
 };
 
+/**
+ * @brief dispatch_thread
+ * @param arg
+ * @return
+ */
 static void* dispatch_thread (void *arg)
 {
 	cpg_dispatch (handle, CS_DISPATCH_BLOCKING);
 	return NULL;
 }
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void) {
 	unsigned int size;
 	int i;

--- a/test/cpgbenchzc.c
+++ b/test/cpgbenchzc.c
@@ -65,8 +65,22 @@
     } while (0)
 #endif
 
+/**
+ * @brief alarm_notice
+ */
 static int alarm_notice;
 
+/**
+ * @brief cpg_bm_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_bm_confchg_fn (
 	cpg_handle_t handle,
 	const struct cpg_name *group_name,
@@ -76,8 +90,20 @@ static void cpg_bm_confchg_fn (
 {
 }
 
+/**
+ * @brief write_count
+ */
 static unsigned int write_count;
 
+/**
+ * @brief cpg_bm_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void cpg_bm_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -89,14 +115,25 @@ static void cpg_bm_deliver_fn (
 	write_count++;
 }
 
+/**
+ * @brief callbacks
+ */
 static cpg_callbacks_t callbacks = {
 	.cpg_deliver_fn 	= cpg_bm_deliver_fn,
 	.cpg_confchg_fn		= cpg_bm_confchg_fn
 };
 
 
+/**
+ * @brief data
+ */
 void *data;
 
+/**
+ * @brief cpg_benchmark
+ * @param handle
+ * @param write_size
+ */
 static void cpg_benchmark (
 	cpg_handle_t handle,
 	int write_size)
@@ -142,16 +179,27 @@ retry:
 		((float)write_count) * ((float)write_size) /  ((tv_elapsed.tv_sec + (tv_elapsed.tv_usec / 1000000.0)) * 1000000.0));
 }
 
+/**
+ * @brief sigalrm_handler
+ * @param num
+ */
 static void sigalrm_handler (int num)
 {
 	alarm_notice = 1;
 }
 
+/**
+ *  @brief group_name
+ */
 static struct cpg_name group_name = {
 	.value = "cpg_bm",
 	.length = 6
 };
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void) {
 	cpg_handle_t handle;
 	unsigned int size;

--- a/test/cpgbound.c
+++ b/test/cpgbound.c
@@ -45,6 +45,15 @@
 #include <corosync/corotypes.h>
 #include <corosync/cpg.h>
 
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -55,6 +64,17 @@ static void cpg_deliver_fn (
 {
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -64,18 +84,32 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ * @brief callbacks
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ * @brief group_name
+ */
 static struct cpg_name group_name = {
         .value = "cpg_bm",
         .length = 6
 };
 
 
+/**
+ * @brief buffer
+ */
 static unsigned char buffer[2000000];
+
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	cpg_handle_t handle;

--- a/test/cpghum.c
+++ b/test/cpghum.c
@@ -102,6 +102,9 @@ static unsigned long avg_rtt=0;
 static unsigned long max_rtt=0;
 static unsigned long min_rtt=LONG_MAX;
 
+/**
+ * @brief cpghum_header
+ */
 struct cpghum_header {
 	unsigned int counter;
 	unsigned int crc;
@@ -109,6 +112,17 @@ struct cpghum_header {
 	struct timeval timestamp;
 };
 
+/**
+ * @brief cpg_bm_confchg_fn
+ * @param handle_in
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_bm_confchg_fn (
 	cpg_handle_t handle_in,
 	const struct cpg_name *group_name,
@@ -133,6 +147,13 @@ typedef enum
 	CPGH_LOG_ERR   = 16
 } log_type_t;
 
+/**
+ * @brief cpgh_print_message
+ * @param syslog_level
+ * @param facility_name
+ * @param format
+ * @param ap
+ */
 static void cpgh_print_message(int syslog_level, const char *facility_name, const char *format, va_list ap)
 {
 	char msg[1024];
@@ -155,6 +176,11 @@ static void cpgh_print_message(int syslog_level, const char *facility_name, cons
 	}
 }
 
+/**
+ * @brief cpgh_log_printf
+ * @param type
+ * @param format
+ */
 static void cpgh_log_printf(log_type_t type, const char *format, ...)
 {
 	va_list ap;
@@ -188,6 +214,15 @@ static void cpgh_log_printf(log_type_t type, const char *format, ...)
 	va_end(ap);
 }
 
+/**
+ * @brief cpg_bm_deliver_fn
+ * @param handle_in
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void cpg_bm_deliver_fn (
 	cpg_handle_t handle_in,
 	const struct cpg_name *group_name,
@@ -298,21 +333,35 @@ static void cpg_bm_deliver_fn (
 
 }
 
+/**
+ * @brief model1_data
+ */
 static cpg_model_v1_data_t model1_data = {
 	.cpg_deliver_fn		= cpg_bm_deliver_fn,
 	.cpg_confchg_fn		= cpg_bm_confchg_fn,
 };
 
+/**
+ * @brief callbacks
+ */
 static cpg_callbacks_t callbacks = {
 	.cpg_deliver_fn		= cpg_bm_deliver_fn,
 	.cpg_confchg_fn		= cpg_bm_confchg_fn
 };
 
+/**
+ * @brief group_name
+ */
 static struct cpg_name group_name = {
 	.value = "cpghum",
 	.length = 7
 };
 
+/**
+ * @brief set_packet
+ * @param write_size
+ * @param counter
+ */
 static void set_packet(int write_size, int counter)
 {
 	struct cpghum_header *header = (struct cpghum_header *)data;
@@ -334,7 +383,11 @@ static void set_packet(int write_size, int counter)
 	memcpy(&header->timestamp, &tv1, sizeof(struct timeval));
 }
 
-/* Basically this is cpgbench.c */
+/**
+ * @brief cpg_flood -- Basically this is cpgbench.c
+ * @param handle_in
+ * @param write_size
+ */
 static void cpg_flood (
 	cpg_handle_t handle_in,
 	int write_size)
@@ -394,6 +447,13 @@ static void cpg_flood (
 	}
 }
 
+/**
+ * @brief cpg_test
+ * @param handle_in
+ * @param write_size
+ * @param delay_time
+ * @param print_time
+ */
 static void cpg_test (
 	cpg_handle_t handle_in,
 	int write_size,
@@ -447,22 +507,39 @@ static void cpg_test (
 
 }
 
+/**
+ * @brief sigalrm_handler
+ * @param num
+ */
 static void sigalrm_handler (int num)
 {
 	alarm_notice = 1;
 }
 
+/**
+ * @brief sigint_handler
+ * @param num
+ */
 static void sigint_handler (int num)
 {
 	stopped = 1;
 }
 
+/**
+ * @brief dispatch_thread
+ * @param arg
+ * @return
+ */
 static void* dispatch_thread (void *arg)
 {
 	cpg_dispatch (handle, CS_DISPATCH_BLOCKING);
 	return NULL;
 }
 
+/**
+ * @brief usage
+ * @param cmd
+ */
 static void usage(char *cmd)
 {
 	fprintf(stderr, "%s [OPTIONS]\n", cmd);
@@ -503,6 +580,12 @@ static void usage(char *cmd)
 	fprintf(stderr, "\n");
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	int i;
 	unsigned int res;

--- a/test/cpgverify.c
+++ b/test/cpgverify.c
@@ -49,15 +49,30 @@
 #include <nss.h>
 #include <pk11pub.h>
 
+/**
+ * @brief The my_msg struct
+ */
 struct my_msg {
 	unsigned int msg_size;
 	unsigned char sha1[20];
 	unsigned char buffer[0];
 };
 
+/**
+ * @brief deliveries
+ */
 static int deliveries = 0;
 PK11Context* sha1_context;
 
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -87,6 +102,17 @@ printf ("\n");
 	deliveries++;
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -96,17 +122,26 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ *
+ */
 static struct cpg_name group_name = {
         .value = "cpg_bm",
         .length = 6
 };
 
 
+/**
+ * @brief buffer
+ */
 static unsigned char buffer[200000];
 int main (int argc, char *argv[])
 {

--- a/test/stress_cpgcontext.c
+++ b/test/stress_cpgcontext.c
@@ -45,12 +45,24 @@
 #include <corosync/cpg.h>
 #include <signal.h>
 
+/**
+ * @brief The my_msg struct
+ */
 struct my_msg {
 	unsigned int msg_size;
 	unsigned char sha1[20];
 	unsigned char buffer[0];
 };
 
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -61,6 +73,17 @@ static void cpg_deliver_fn (
 {
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -70,11 +93,18 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ * @brief sigintr_handler
+ * @param num
+ */
 static void sigintr_handler (int num)
 {
 	exit (1);
@@ -84,6 +114,10 @@ static void sigintr_handler (int num)
 
 #define INSTANCES 100
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	cpg_handle_t handle[INSTANCES];

--- a/test/stress_cpgfdget.c
+++ b/test/stress_cpgfdget.c
@@ -45,12 +45,24 @@
 #include <corosync/cpg.h>
 #include <signal.h>
 
+/**
+ * @brief The my_msg struct
+ */
 struct my_msg {
 	unsigned int msg_size;
 	unsigned char sha1[20];
 	unsigned char buffer[0];
 };
 
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -61,6 +73,17 @@ static void cpg_deliver_fn (
 {
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -70,11 +93,18 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ * @brief callbacks
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ * @brief sigintr_handler
+ * @param num
+ */
 static void sigintr_handler (int num)
 {
 	exit (1);
@@ -83,6 +113,10 @@ static void sigintr_handler (int num)
 
 #define ITERATIONS (1000*2000)
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	cpg_handle_t handle;

--- a/test/stress_cpgzc.c
+++ b/test/stress_cpgzc.c
@@ -46,13 +46,29 @@
 #include <signal.h>
 #include <assert.h>
 
+/**
+ * @brief The my_msg struct
+ */
 struct my_msg {
 	unsigned int msg_size;
 	unsigned char sha1[20];
 	unsigned char buffer[0];
 };
 
+/**
+ * @brief deliveries
+ */
 static int deliveries = 0;
+
+/**
+ * @brief cpg_deliver_fn
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param m
+ * @param msg_len
+ */
 static void cpg_deliver_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -64,6 +80,17 @@ static void cpg_deliver_fn (
 	deliveries++;
 }
 
+/**
+ * @brief cpg_confchg_fn
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void cpg_confchg_fn (
         cpg_handle_t handle,
         const struct cpg_name *group_name,
@@ -73,11 +100,18 @@ static void cpg_confchg_fn (
 {
 }
 
+/**
+ * callbacks
+ */
 static cpg_callbacks_t callbacks = {
 	cpg_deliver_fn,
 	cpg_confchg_fn
 };
 
+/**
+ * @brief sigintr_handler
+ * @param num
+ */
 static void sigintr_handler (int num)
 {
 	exit (1);
@@ -86,6 +120,11 @@ static void sigintr_handler (int num)
 #define ITERATIONS 100
 #define ALLOCATIONS 2000
 #define MAX_SIZE 100000
+
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	cs_error_t res;

--- a/test/testcpg.c
+++ b/test/testcpg.c
@@ -71,6 +71,10 @@ static uint32_t nodeidStart = 0;
 
 static void print_localnodeid(cpg_handle_t handle);
 
+/**
+ * @brief print_cpgname
+ * @param name
+ */
 static void print_cpgname (const struct cpg_name *name)
 {
 	unsigned int i;
@@ -80,6 +84,12 @@ static void print_cpgname (const struct cpg_name *name)
 	}
 }
 
+/**
+ * @brief node_pid_format
+ * @param nodeid
+ * @param pid
+ * @return
+ */
 static char * node_pid_format(unsigned int nodeid, unsigned int pid) {
 	static char buffer[100];
 	if (show_ip) {
@@ -97,6 +107,9 @@ static char * node_pid_format(unsigned int nodeid, unsigned int pid) {
 	return buffer;
 }
 
+/**
+ * @brief print_time
+ */
 static void
 print_time(void)
 {
@@ -129,6 +142,15 @@ print_time(void)
 }
 
 
+/**
+ * @brief DeliverCallback
+ * @param handle
+ * @param groupName
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void DeliverCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -143,6 +165,17 @@ static void DeliverCallback (
 		       (const char *)msg);
 }
 
+/**
+ * @brief ConfchgCallback
+ * @param handle
+ * @param groupName
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void ConfchgCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -209,6 +242,13 @@ static void ConfchgCallback (
 	}
 }
 
+/**
+ * @brief TotemConfchgCallback
+ * @param handle
+ * @param ring_id
+ * @param member_list_entries
+ * @param member_list
+ */
 static void TotemConfchgCallback (
 	cpg_handle_t handle,
         struct cpg_ring_id ring_id,
@@ -230,6 +270,9 @@ static void TotemConfchgCallback (
 	printf ("\n");
 }
 
+/**
+ *
+ */
 static cpg_model_v1_data_t model_data = {
 	.cpg_deliver_fn =            DeliverCallback,
 	.cpg_confchg_fn =            ConfchgCallback,
@@ -237,8 +280,14 @@ static cpg_model_v1_data_t model_data = {
 	.flags =                     CPG_MODEL_V1_DELIVER_INITIAL_TOTEM_CONF,
 };
 
+/**
+ * @brief group_name
+ */
 static struct cpg_name group_name;
 
+/**
+ * @brief retrybackoff
+ */
 #define retrybackoff(counter) {    \
 		counter++;                    \
 		printf("Restart operation after %ds\n", counter); \
@@ -247,6 +296,9 @@ static struct cpg_name group_name;
 		continue;			\
 }
 
+/**
+ * @brief cs_repeat_init
+ */
 #define cs_repeat_init(counter, max, code) do {    \
 	code;                                 \
 	if (result == CS_ERR_TRY_AGAIN || result == CS_ERR_QUEUE_FULL || result == CS_ERR_LIBRARY) {  \
@@ -258,6 +310,9 @@ static struct cpg_name group_name;
 	}                                     \
 } while (counter < max)
 
+/**
+ * @brief cs_repeat
+ */
 #define cs_repeat(counter, max, code) do {    \
 	code;                                 \
 	if (result == CS_ERR_TRY_AGAIN || result == CS_ERR_QUEUE_FULL) {  \
@@ -269,6 +324,10 @@ static struct cpg_name group_name;
 	}                                     \
 } while (counter < max)
 
+/**
+ * @brief print_localnodeid
+ * @param handle
+ */
 static void print_localnodeid(cpg_handle_t handle)
 {
 	char addrStr[128];
@@ -293,6 +352,12 @@ static void print_localnodeid(cpg_handle_t handle)
 	}
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	cpg_handle_t handle;
 	fd_set read_fds;

--- a/test/testcpg2.c
+++ b/test/testcpg2.c
@@ -44,6 +44,15 @@
 #include <corosync/corotypes.h>
 #include <corosync/cpg.h>
 
+/**
+ * @brief deliver
+ * @param handle
+ * @param group_name
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void deliver(
 	cpg_handle_t handle,
 	const struct cpg_name *group_name,
@@ -55,6 +64,17 @@ static void deliver(
     printf("self delivered nodeid: %x\n", nodeid);
 }
 
+/**
+ * @brief confch
+ * @param handle
+ * @param group_name
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void confch(
 	cpg_handle_t handle,
 	const struct cpg_name *group_name,
@@ -65,6 +85,12 @@ static void confch(
 	printf("confchg nodeid %x\n", member_list[0].nodeid);
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char** argv) {
 	cpg_handle_t handle=0;
 	cpg_callbacks_t cb={&deliver,&confch};

--- a/test/testcpgzc.c
+++ b/test/testcpgzc.c
@@ -55,6 +55,10 @@
 static int quit = 0;
 static int show_ip = 0;
 
+/**
+ * @brief print_cpgname
+ * @param name
+ */
 static void print_cpgname (const struct cpg_name *name)
 {
 	int i;
@@ -64,6 +68,15 @@ static void print_cpgname (const struct cpg_name *name)
 	}
 }
 
+/**
+ * @brief DeliverCallback
+ * @param handle
+ * @param groupName
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void DeliverCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -86,6 +99,17 @@ static void DeliverCallback (
 	}
 }
 
+/**
+ * @brief ConfchgCallback
+ * @param handle
+ * @param groupName
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void ConfchgCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -156,6 +180,12 @@ static cpg_callbacks_t callbacks = {
 
 static struct cpg_name group_name;
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	cpg_handle_t handle;
 	fd_set read_fds;

--- a/test/testparse.c
+++ b/test/testparse.c
@@ -40,6 +40,10 @@
 #include "../exec/parse.h"
 #include "../exec/print.h"
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 #ifdef CODE_COVERAGE_COMPILE_OUT

--- a/test/testquorum.c
+++ b/test/testquorum.c
@@ -10,6 +10,14 @@
 
 static quorum_handle_t g_handle;
 
+/**
+ * @brief quorum_notification_fn
+ * @param handle
+ * @param quorate
+ * @param ring_id
+ * @param view_list_entries
+ * @param view_list
+ */
 static void quorum_notification_fn(
 	quorum_handle_t handle,
 	uint32_t quorate,
@@ -31,6 +39,12 @@ static void quorum_notification_fn(
 }
 
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	int quorate;

--- a/test/testsam.c
+++ b/test/testsam.c
@@ -67,6 +67,11 @@ static int test6_sig_delivered = 0;
  * twice. One should succeed, second should fail. After this, we will call every function
  * (none should succeed).
  */
+
+/**
+ * @brief test1
+ * @return
+ */
 static int test1 (void)
 {
 	cs_error_t error;
@@ -176,6 +181,10 @@ static int test1 (void)
 }
 
 
+/**
+ * @brief test2_signal
+ * @param sig
+ */
 static void test2_signal (int sig) {
 	printf ("%s\n", __FUNCTION__);
 
@@ -184,6 +193,10 @@ static void test2_signal (int sig) {
 
 /*
  * This tests recovery policy quit and callback.
+ */
+/**
+ * @brief test2
+ * @return
  */
 static int test2 (void) {
 	cs_error_t error;
@@ -241,6 +254,10 @@ static int test2 (void) {
  * Smoke test. Better to turn off coredump ;) This has no time limit, just restart process
  * when it dies.
  */
+/**
+ * @brief test3
+ * @return
+ */
 static int test3 (void) {
 	cs_error_t error;
 	unsigned int instance_id;
@@ -277,6 +294,10 @@ static int test3 (void) {
 
 /*
  * Test sam_data_store, sam_data_restore and sam_data_getsize
+ */
+/**
+ * @brief test4
+ * @return
  */
 static int test4 (void)
 {
@@ -524,6 +545,10 @@ static int test4 (void)
 	return (0);
 }
 
+/**
+ * @brief test5_hc_cb
+ * @return
+ */
 static int test5_hc_cb (void)
 {
 	cs_error_t res;
@@ -538,8 +563,13 @@ static int test5_hc_cb (void)
 
 	return 0;
 }
+
 /*
  * Test event driven healtchecking.
+ */
+/**
+ * @brief test5
+ * @return
  */
 static int test5 (void)
 {
@@ -601,6 +631,10 @@ static int test5 (void)
 	return 1;
 }
 
+/**
+ * @brief test6_signal
+ * @param sig
+ */
 static void test6_signal (int sig) {
 	cs_error_t error;
 
@@ -614,6 +648,10 @@ static void test6_signal (int sig) {
 
 /*
  * Test warn signal set.
+ */
+/**
+ * @brief test6
+ * @return
  */
 static int test6 (void) {
 	cs_error_t error;
@@ -748,6 +786,10 @@ static void *test7_thread (void *arg)
 /*
  * Test quorum
  */
+/**
+ * @brief test7
+ * @return
+ */
 static int test7 (void) {
 	cmap_handle_t cmap_handle;
 	cs_error_t err;
@@ -855,6 +897,13 @@ static int test7 (void) {
 
 /*
  * Test cmap integration + quit policy
+ */
+/**
+ * @brief test8
+ * @param pid
+ * @param old_pid
+ * @param test_n
+ * @return
  */
 static int test8 (pid_t pid, pid_t old_pid, int test_n) {
 	cmap_handle_t cmap_handle;
@@ -1102,6 +1151,13 @@ static int test8 (pid_t pid, pid_t old_pid, int test_n) {
 /*
  * Test cmap integration + restart policy
  */
+/**
+ * @brief test9
+ * @param pid
+ * @param old_pid
+ * @param test_n
+ * @return
+ */
 static int test9 (pid_t pid, pid_t old_pid, int test_n) {
 	cs_error_t err;
 	cmap_handle_t cmap_handle;
@@ -1231,6 +1287,12 @@ static int test9 (pid_t pid, pid_t old_pid, int test_n) {
 	return (2);
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	pid_t pid, old_pid;

--- a/test/testtimer.c
+++ b/test/testtimer.c
@@ -41,11 +41,19 @@
 
 #include "../exec/timer.h"
 
+/**
+ * @brief timer_function
+ * @param data
+ */
 void timer_function (void *data)
 {
 	printf ("timer %p\n", data);
 }
 
+/**
+ * @brief main
+ * @return
+ */
 int main (void)
 {
 	int msec;

--- a/test/testvotequorum1.c
+++ b/test/testvotequorum1.c
@@ -46,6 +46,11 @@
 
 static votequorum_handle_t g_handle;
 
+/**
+ * @brief node_state
+ * @param state
+ * @return
+ */
 static const char *node_state(int state)
 {
 	switch (state) {
@@ -65,6 +70,12 @@ static const char *node_state(int state)
 }
 
 
+/**
+ * @brief votequorum_expectedvotes_notification_fn
+ * @param handle
+ * @param context
+ * @param expected_votes
+ */
 static void votequorum_expectedvotes_notification_fn(
 	votequorum_handle_t handle,
 	uint64_t context,
@@ -76,6 +87,14 @@ static void votequorum_expectedvotes_notification_fn(
 }
 
 
+/**
+ * @brief votequorum_quorum_notification_fn
+ * @param handle
+ * @param context
+ * @param quorate
+ * @param node_list_entries
+ * @param node_list
+ */
 static void votequorum_quorum_notification_fn(
 	votequorum_handle_t handle,
 	uint64_t context,
@@ -96,6 +115,15 @@ static void votequorum_quorum_notification_fn(
 
 }
 
+/**
+ * @brief votequorum_nodelist_notification_fn
+ * @param handle
+ * @param context
+ * @param quorate
+ * @param ring_id
+ * @param node_list_entries
+ * @param node_list
+ */
 static void votequorum_nodelist_notification_fn(
 	votequorum_handle_t handle,
 	uint64_t context,
@@ -118,6 +146,12 @@ static void votequorum_nodelist_notification_fn(
 }
 
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	struct votequorum_info info;

--- a/test/testvotequorum2.c
+++ b/test/testvotequorum2.c
@@ -50,6 +50,11 @@ static votequorum_ring_id_t last_received_ring_id;
 static votequorum_ring_id_t ring_id_to_send;
 static int no_sent_old_ringid = 0;
 
+/**
+ * @brief print_info
+ * @param ok_to_fail
+ * @return
+ */
 static int print_info(int ok_to_fail)
 {
 	struct votequorum_info info;
@@ -76,6 +81,15 @@ static int print_info(int ok_to_fail)
 	return 0;
 }
 
+/**
+ * @brief votequorum_nodelist_notification_fn
+ * @param vq_handle
+ * @param context
+ * @param quorate
+ * @param ring_id
+ * @param node_list_entries
+ * @param node_list
+ */
 static void votequorum_nodelist_notification_fn(
 	votequorum_handle_t vq_handle,
 	uint64_t context,
@@ -92,6 +106,10 @@ static void votequorum_nodelist_notification_fn(
 	no_sent_old_ringid = 0;
 }
 
+/**
+ * @brief usage
+ * @param command
+ */
 static void usage(const char *command)
 {
   printf("%s [-F <num>] [-p <num>] [-t <time>] [-n <name>] [-c] [-m]\n", command);
@@ -105,6 +123,12 @@ static void usage(const char *command)
         printf("      -1        Print status once and exit\n");
 }
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main(int argc, char *argv[])
 {
 	int ret = 0;

--- a/test/testzcgc.c
+++ b/test/testzcgc.c
@@ -52,6 +52,10 @@
 static int quit = 0;
 static int show_ip = 0;
 
+/**
+ * @brief print_cpgname
+ * @param name
+ */
 static void print_cpgname (const struct cpg_name *name)
 {
 	int i;
@@ -61,6 +65,15 @@ static void print_cpgname (const struct cpg_name *name)
 	}
 }
 
+/**
+ * @brief DeliverCallback
+ * @param handle
+ * @param groupName
+ * @param nodeid
+ * @param pid
+ * @param msg
+ * @param msg_len
+ */
 static void DeliverCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -83,6 +96,17 @@ static void DeliverCallback (
 	}
 }
 
+/**
+ * @brief ConfchgCallback
+ * @param handle
+ * @param groupName
+ * @param member_list
+ * @param member_list_entries
+ * @param left_list
+ * @param left_list_entries
+ * @param joined_list
+ * @param joined_list_entries
+ */
 static void ConfchgCallback (
 	cpg_handle_t handle,
 	const struct cpg_name *groupName,
@@ -146,6 +170,9 @@ static void ConfchgCallback (
 	}
 }
 
+/**
+ *
+ */
 static cpg_callbacks_t callbacks = {
 	.cpg_deliver_fn =            DeliverCallback,
 	.cpg_confchg_fn =            ConfchgCallback,
@@ -153,6 +180,12 @@ static cpg_callbacks_t callbacks = {
 
 static struct cpg_name group_name;
 
+/**
+ * @brief main
+ * @param argc
+ * @param argv
+ * @return
+ */
 int main (int argc, char *argv[]) {
 	cpg_handle_t handle;
 	int result;


### PR DESCRIPTION
This pull request should be fairly self explanatory.

Corosync still lacks code documentation, and I remain unable to penetrate the intentions of most of the library code.

Here are stubs that will remind people (by being blank) of which functions are in need of documentation from subject matter experts.