### PR TITLE
Modify the return type of several functions from int to bool

### DIFF
--- a/exec/apidef.c
+++ b/exec/apidef.c
@@ -68,7 +68,7 @@ typedef int (*typedef_tpg_leave) (void *,
 	const struct corosync_tpg_group *,
 	size_t);
 
-typedef int (*typedef_tpg_groups_mcast_groups) (
+typedef bool (*typedef_tpg_groups_mcast_groups) (
 	void *, int,
 	const struct corosync_tpg_group *,
 	size_t groups_cnt,

--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -108,9 +108,9 @@ static char *cfg_exec_init_fn (struct corosync_api_v1 *corosync_api_v1);
 
 static struct corosync_api_v1 *api;
 
-static int cfg_lib_init_fn (void *conn);
+static bool cfg_lib_init_fn(void *conn);
 
-static int cfg_lib_exit_fn (void *conn);
+static bool cfg_lib_exit_fn (void *conn);
 
 static void message_handler_req_exec_cfg_ringreenable (
         const void *message,
@@ -286,7 +286,7 @@ static void cfg_confchg_fn (
 /*
  * Tell other nodes we are shutting down
  */
-static int send_shutdown(void)
+static void send_shutdown(void)
 {
 	struct req_exec_cfg_shutdown req_exec_cfg_shutdown;
 	struct iovec iovec;
@@ -300,10 +300,9 @@ static int send_shutdown(void)
 	iovec.iov_base = (char *)&req_exec_cfg_shutdown;
 	iovec.iov_len = sizeof (struct req_exec_cfg_shutdown);
 
-	assert (api->totem_mcast (&iovec, 1, TOTEM_SAFE) == 0);
+        assert(api->totem_mcast (&iovec, 1, TOTEM_SAFE));
 
-	LEAVE();
-	return 0;
+        LEAVE();
 }
 
 static void send_test_shutdown(void *only_conn, void *exclude_conn, int status)
@@ -454,17 +453,17 @@ static void remove_ci_from_shutdown(struct cfg_info *ci)
 }
 
 
-int cfg_lib_exit_fn (void *conn)
+static bool cfg_lib_exit_fn (void *conn)
 {
 	struct cfg_info *ci = (struct cfg_info *)api->ipc_private_data_get (conn);
 
 	ENTER();
 	remove_ci_from_shutdown(ci);
 	LEAVE();
-	return (0);
+        return true;
 }
 
-static int cfg_lib_init_fn (void *conn)
+static bool cfg_lib_init_fn (void *conn)
 {
 	struct cfg_info *ci = (struct cfg_info *)api->ipc_private_data_get (conn);
 
@@ -472,7 +471,7 @@ static int cfg_lib_init_fn (void *conn)
 	qb_list_init(&ci->list);
 	LEAVE();
 
-        return (0);
+        return true;
 }
 
 /*
@@ -820,7 +819,7 @@ static void message_handler_req_lib_cfg_ringreenable (
 	iovec.iov_base = (char *)&req_exec_cfg_ringreenable;
 	iovec.iov_len = sizeof (struct req_exec_cfg_ringreenable);
 
-	assert (api->totem_mcast (&iovec, 1, TOTEM_SAFE) == 0);
+        assert(api->totem_mcast (&iovec, 1, TOTEM_SAFE));
 
 	LEAVE();
 }
@@ -1077,7 +1076,7 @@ static void message_handler_req_lib_cfg_reload_config (void *conn, const void *m
 	iovec.iov_base = (char *)&req_exec_cfg_reload_config;
 	iovec.iov_len = sizeof (struct req_exec_cfg_reload_config);
 
-	assert (api->totem_mcast (&iovec, 1, TOTEM_SAFE) == 0);
+        assert(api->totem_mcast (&iovec, 1, TOTEM_SAFE));
 
 	LEAVE();
 }

--- a/exec/ipc_glue.c
+++ b/exec/ipc_glue.c
@@ -295,7 +295,7 @@ static void cs_ipcs_connection_created(qb_ipcs_connection_t *c)
 
 	qb_ipcs_context_set(c, context);
 
-	if (corosync_service[service]->lib_init_fn(c) != 0) {
+        if ( ! corosync_service[service]->lib_init_fn(c)) {
 		log_printf(LOG_ERR, "lib_init_fn failed, disconnecting");
 		qb_ipcs_disconnect(c);
 		return;
@@ -412,7 +412,6 @@ static void cs_ipcs_connection_destroyed (qb_ipcs_connection_t *c)
 
 static int32_t cs_ipcs_connection_closed (qb_ipcs_connection_t *c)
 {
-	int32_t res = 0;
 	int32_t service = qb_ipcs_service_id_get(c);
 	icmap_iter_t iter;
 	char prefix[ICMAP_KEYNAME_MAXLEN];
@@ -420,8 +419,8 @@ static int32_t cs_ipcs_connection_closed (qb_ipcs_connection_t *c)
 	struct cs_ipcs_conn_context *cnx;
 
 	log_printf(LOG_DEBUG, "%s() ", __func__);
-	res = corosync_service[service]->lib_exit_fn(c);
-	if (res != 0) {
+        bool res = corosync_service[service]->lib_exit_fn(c);
+        if ( ! res) {
 		return res;
 	}
 

--- a/exec/main.c
+++ b/exec/main.c
@@ -621,7 +621,7 @@ static void deliver_fn (
 		(msg, nodeid);
 }
 
-int main_mcast (
+bool main_mcast (
         const struct iovec *iovec,
         unsigned int iov_len,
         unsigned int guarantee)
@@ -637,7 +637,7 @@ int main_mcast (
 		icmap_fast_inc(service_stats_tx[service][fn_id]);
 	}
 
-	return (totempg_groups_mcast_joined (corosync_group_handle, iovec, iov_len, guarantee));
+        return totempg_groups_mcast_joined (corosync_group_handle, iovec, iov_len, guarantee);
 }
 
 static void corosync_ring_id_create_or_load (

--- a/exec/main.h
+++ b/exec/main.h
@@ -53,7 +53,7 @@
 
 extern unsigned long long *(*main_clm_get_by_nodeid) (unsigned int node_id);
 
-extern int main_mcast (
+extern bool main_mcast(
 	const struct iovec *iovec,
 	unsigned int iov_len,
 	unsigned int guarantee);

--- a/exec/pload.c
+++ b/exec/pload.c
@@ -189,11 +189,10 @@ static void pload_send_start (uint32_t count, uint32_t size)
 /*
  * send N empty data messages of size X
  */
-static int pload_send_message (const void *arg)
+static bool pload_send_message (const void *arg)
 {
 	struct req_exec_pload_mcast req_exec_pload_mcast;
-	struct iovec iov[2];
-	unsigned int res;
+        struct iovec iov[2];
 	unsigned int iov_len = 1;
 
 	req_exec_pload_mcast.header.id = SERVICE_ID_MAKE (PLOAD_SERVICE, MESSAGE_REQ_EXEC_PLOAD_MCAST);
@@ -208,19 +207,14 @@ static int pload_send_message (const void *arg)
 	}
 
 	do {
-		res = api->totem_mcast (iov, iov_len, TOTEM_AGREED);
-		if (res == -1) {
+                if ( ! api->totem_mcast (iov, iov_len, TOTEM_AGREED)) {
 			break;
 		} else {
 			msgs_sent++;
 		}
 	} while (msgs_sent < msgs_wanted);
 
-	if (msgs_sent == msgs_wanted) {
-		return (0);
-	} else {
-		return (-1);
-	}
+	return msgs_sent == msgs_wanted;
 }
 
 /*

--- a/exec/schedwrk.h
+++ b/exec/schedwrk.h
@@ -34,18 +34,20 @@
 #ifndef SCHEDWRK_H_DEFINED
 #define SCHEDWRK_H_DEFINED
 
+#include <stdbool.h>
+
 extern void schedwrk_init (
         void (*serialize_lock_fn) (void),
         void (*serialize_unlock_fn) (void));
 
-extern int schedwrk_create (
+extern bool schedwrk_create (
         hdb_handle_t *handle,
-        int (schedwrk_fn) (const void *),
+        bool (schedwrk_fn) (const void *),
         const void *context);
 
-extern int schedwrk_create_nolock (
+extern bool schedwrk_create_nolock (
         hdb_handle_t *handle,
-        int (schedwrk_fn) (const void *),
+        bool (schedwrk_fn) (const void *),
         const void *context);
 
 extern void schedwrk_destroy (hdb_handle_t handle);

--- a/exec/sync.h
+++ b/exec/sync.h
@@ -42,7 +42,7 @@ struct sync_callbacks {
 		const unsigned int *member_list,
 		size_t member_list_entries,
 		const struct memb_ring_id *ring_id);
-	int (*sync_process) (void);
+        bool (*sync_process) (void);
 	void (*sync_activate) (void);
 	void (*sync_abort) (void);
 	const char *name;

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -86,6 +86,8 @@
 #define LOGSYS_UTILS_ONLY 1
 #include <corosync/logsys.h>
 
+#include <stdbool.h>
+
 #include "totemsrp.h"
 #include "totemnet.h"
 
@@ -2422,7 +2424,7 @@ void totemsrp_event_signal (void *srp_context, enum totem_event_type type, int v
 	return;
 }
 
-int totemsrp_mcast (
+bool totemsrp_mcast (
 	void *srp_context,
 	struct iovec *iovec,
 	unsigned int iov_len,
@@ -2453,7 +2455,7 @@ int totemsrp_mcast (
 	 */
 	message_item.mcast = totemsrp_buffer_alloc (instance);
 	if (message_item.mcast == 0) {
-		goto error_mcast;
+                return false;
 	}
 
 	/*
@@ -2482,10 +2484,7 @@ int totemsrp_mcast (
 	instance->stats.mcast_tx++;
 	cs_queue_item_add (queue_use, &message_item);
 
-	return (0);
-
-error_mcast:
-	return (-1);
+        return true;
 }
 
 /*

--- a/exec/totemsrp.h
+++ b/exec/totemsrp.h
@@ -73,8 +73,10 @@ void totemsrp_finalize (void *srp_context);
 
 /**
  * Multicast a message
+ * @return true  - Success
+ *         false - Failure
  */
-int totemsrp_mcast (
+bool totemsrp_mcast (
 	void *srp_context,
 	struct iovec *iovec,
 	unsigned int iov_len,

--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -153,7 +153,7 @@ static int votequorum_exec_send_nodelist_notification(void *conn, uint64_t conte
 #define VOTEQUORUM_RECONFIG_PARAM_NODE_VOTES     2
 #define VOTEQUORUM_RECONFIG_PARAM_CANCEL_WFA     3
 
-static int votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, uint32_t value);
+static void votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, uint32_t value);
 
 /*
  * used by req_exec_quorum_qdevice_reg
@@ -253,7 +253,7 @@ static void votequorum_sync_init (
 	size_t member_list_entries,
 	const struct memb_ring_id *ring_id);
 
-static int votequorum_sync_process (void);
+static bool votequorum_sync_process (void);
 static void votequorum_sync_activate (void);
 static void votequorum_sync_abort (void);
 
@@ -265,7 +265,7 @@ static quorum_set_quorate_fn_t quorum_callback;
 
 static char *votequorum_exec_init_fn (struct corosync_api_v1 *api);
 static int votequorum_exec_exit_fn (void);
-static int votequorum_exec_send_nodeinfo(uint32_t nodeid);
+static bool votequorum_exec_send_nodeinfo(uint32_t nodeid);
 
 static void message_handler_req_exec_votequorum_nodeinfo (
 	const void *message,
@@ -311,9 +311,9 @@ static struct corosync_exec_handler votequorum_exec_engine[] =
  * Library Handler and Functions Definitions
  */
 
-static int quorum_lib_init_fn (void *conn);
+static bool quorum_lib_init_fn (void *conn);
 
-static int quorum_lib_exit_fn (void *conn);
+static bool quorum_lib_exit_fn(void *conn);
 
 static void qdevice_timer_fn(void *arg);
 
@@ -1551,7 +1551,7 @@ static void votequorum_refresh_config(
 	 * can reconfigure it all atomically
 	 */
 	if (icmap_get_uint8("config.totemconfig_reload_in_progress", &reloading) == CS_OK && reloading) {
-		return ;
+                return;
 	}
 
 	icmap_get_uint8("quorum.cancel_wait_for_all", &cancel_wfa);
@@ -1621,11 +1621,10 @@ static void votequorum_exec_add_config_notification(void)
  * votequorum_exec core
  */
 
-static int votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, uint32_t value)
+static void votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, uint32_t value)
 {
 	struct req_exec_quorum_reconfigure req_exec_quorum_reconfigure;
-	struct iovec iov[1];
-	int ret;
+        struct iovec iov[1];
 
 	ENTER();
 
@@ -1642,24 +1641,22 @@ static int votequorum_exec_send_reconfigure(uint8_t param, unsigned int nodeid, 
 	iov[0].iov_base = (void *)&req_exec_quorum_reconfigure;
 	iov[0].iov_len = sizeof(req_exec_quorum_reconfigure);
 
-	ret = corosync_api->totem_mcast (iov, 1, TOTEM_AGREED);
+        corosync_api->totem_mcast (iov, 1, TOTEM_AGREED);
 
-	LEAVE();
-	return ret;
+        LEAVE();
 }
 
-static int votequorum_exec_send_nodeinfo(uint32_t nodeid)
+static bool votequorum_exec_send_nodeinfo(uint32_t nodeid)
 {
 	struct req_exec_quorum_nodeinfo req_exec_quorum_nodeinfo;
 	struct iovec iov[1];
-	struct cluster_node *node;
-	int ret;
+        struct cluster_node *node;
 
 	ENTER();
 
 	node = find_node_by_nodeid(nodeid);
 	if (!node) {
-		return -1;
+                return false;
 	}
 
 	req_exec_quorum_nodeinfo.nodeid = nodeid;
@@ -1676,17 +1673,16 @@ static int votequorum_exec_send_nodeinfo(uint32_t nodeid)
 	iov[0].iov_base = (void *)&req_exec_quorum_nodeinfo;
 	iov[0].iov_len = sizeof(req_exec_quorum_nodeinfo);
 
-	ret = corosync_api->totem_mcast (iov, 1, TOTEM_AGREED);
+        bool ret = corosync_api->totem_mcast (iov, 1, TOTEM_AGREED);
 
 	LEAVE();
 	return ret;
 }
 
-static int votequorum_exec_send_qdevice_reconfigure(const char *oldname, const char *newname)
+static bool votequorum_exec_send_qdevice_reconfigure(const char *oldname, const char *newname)
 {
 	struct req_exec_quorum_qdevice_reconfigure req_exec_quorum_qdevice_reconfigure;
-	struct iovec iov[1];
-	int ret;
+        struct iovec iov[1];
 
 	ENTER();
 
@@ -1698,17 +1694,16 @@ static int votequorum_exec_send_qdevice_reconfigure(const char *oldname, const c
 	iov[0].iov_base = (void *)&req_exec_quorum_qdevice_reconfigure;
 	iov[0].iov_len = sizeof(req_exec_quorum_qdevice_reconfigure);
 
-	ret = corosync_api->totem_mcast (iov, 1, TOTEM_AGREED);
+        bool ret = corosync_api->totem_mcast (iov, 1, TOTEM_AGREED);
 
 	LEAVE();
 	return ret;
 }
 
-static int votequorum_exec_send_qdevice_reg(uint32_t operation, const char *qdevice_name_req)
+static bool votequorum_exec_send_qdevice_reg(uint32_t operation, const char *qdevice_name_req)
 {
 	struct req_exec_quorum_qdevice_reg req_exec_quorum_qdevice_reg;
-	struct iovec iov[1];
-	int ret;
+        struct iovec iov[1];
 
 	ENTER();
 
@@ -1720,7 +1715,7 @@ static int votequorum_exec_send_qdevice_reg(uint32_t operation, const char *qdev
 	iov[0].iov_base = (void *)&req_exec_quorum_qdevice_reg;
 	iov[0].iov_len = sizeof(req_exec_quorum_qdevice_reg);
 
-	ret = corosync_api->totem_mcast (iov, 1, TOTEM_AGREED);
+        bool ret = corosync_api->totem_mcast (iov, 1, TOTEM_AGREED);
 
 	LEAVE();
 	return ret;
@@ -2194,7 +2189,7 @@ static void message_handler_req_exec_votequorum_reconfigure (
 
 static int votequorum_exec_exit_fn (void)
 {
-	int ret = 0;
+        bool ret = true;
 
 	ENTER();
 
@@ -2393,7 +2388,7 @@ static void votequorum_sync_init (
 	LEAVE();
 }
 
-static int votequorum_sync_process (void)
+static bool votequorum_sync_process (void)
 {
 	if (!sync_nodeinfo_sent) {
 		votequorum_exec_send_nodeinfo(us->node_id);
@@ -2411,10 +2406,10 @@ static int votequorum_sync_process (void)
 		 * Waiting for qdevice to poll with new ringid or timeout
 		 */
 
-		return (-1);
+                return false;
 	}
 
-	return 0;
+        return true;
 }
 
 static void votequorum_sync_activate (void)
@@ -2461,7 +2456,7 @@ char *votequorum_init(struct corosync_api_v1 *api,
  * Library Handler init/fini
  */
 
-static int quorum_lib_init_fn (void *conn)
+static bool quorum_lib_init_fn (void *conn)
 {
 	struct quorum_pd *pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
 
@@ -2471,10 +2466,10 @@ static int quorum_lib_init_fn (void *conn)
 	pd->conn = conn;
 
 	LEAVE();
-	return (0);
+        return true;
 }
 
-static int quorum_lib_exit_fn (void *conn)
+static bool quorum_lib_exit_fn (void *conn)
 {
 	struct quorum_pd *quorum_pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
 
@@ -2487,7 +2482,7 @@ static int quorum_lib_exit_fn (void *conn)
 
 	LEAVE();
 
-	return (0);
+        return true;
 }
 
 /*

--- a/exec/vsf_quorum.c
+++ b/exec/vsf_quorum.c
@@ -96,8 +96,8 @@ static void message_handler_req_lib_quorum_gettype (void *conn,
 static void send_library_notification(void *conn);
 static void send_internal_notification(void);
 static char *quorum_exec_init_fn (struct corosync_api_v1 *api);
-static int quorum_lib_init_fn (void *conn);
-static int quorum_lib_exit_fn (void *conn);
+static bool quorum_lib_init_fn (void *conn);
+static bool quorum_lib_exit_fn (void *conn);
 
 static int primary_designated = 0;
 static int quorum_type = 0;
@@ -308,7 +308,7 @@ static char *quorum_exec_init_fn (struct corosync_api_v1 *api)
 	return (NULL);
 }
 
-static int quorum_lib_init_fn (void *conn)
+static bool quorum_lib_init_fn (void *conn)
 {
 	struct quorum_pd *pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
 
@@ -317,10 +317,10 @@ static int quorum_lib_init_fn (void *conn)
 	qb_list_init (&pd->list);
 	pd->conn = conn;
 
-	return (0);
+        return true;
 }
 
-static int quorum_lib_exit_fn (void *conn)
+static bool quorum_lib_exit_fn (void *conn)
 {
 	struct quorum_pd *quorum_pd = (struct quorum_pd *)corosync_api->ipc_private_data_get (conn);
 
@@ -330,7 +330,7 @@ static int quorum_lib_exit_fn (void *conn)
 		qb_list_del (&quorum_pd->list);
 		qb_list_init (&quorum_pd->list);
 	}
-	return (0);
+        return true;
 }
 
 

--- a/exec/vsf_ykd.c
+++ b/exec/vsf_ykd.c
@@ -161,11 +161,10 @@ static void ykd_state_init (void)
 	ykd_state.last_primary.member_list_entries = 0;
 }
 
-static int ykd_state_send_msg (const void *context)
+static bool ykd_state_send_msg (const void *context)
 {
 	struct iovec iovec[2];
-	struct ykd_header header;
-	int res;
+        struct ykd_header header;
 
 	header.id = YKD_HEADER_SENDSTATE;
 
@@ -174,10 +173,7 @@ static int ykd_state_send_msg (const void *context)
 	iovec[1].iov_base = (char *)&ykd_state;
 	iovec[1].iov_len = sizeof (struct ykd_state);
 
-	res = api->tpg_joined_mcast (ykd_group_handle, iovec, 2,
-		TOTEM_AGREED);
-
-	return (res);
+        return api->tpg_joined_mcast (ykd_group_handle, iovec, 2, TOTEM_AGREED);
 }
 
 static void ykd_state_send (void)
@@ -188,21 +184,17 @@ static void ykd_state_send (void)
                 NULL);
 }
 
-static int ykd_attempt_send_msg (const void *context)
+static bool ykd_attempt_send_msg (const void *context)
 {
 	struct iovec iovec;
-	struct ykd_header header;
-	int res;
+        struct ykd_header header;
 
 	header.id = YKD_HEADER_ATTEMPT;
 
 	iovec.iov_base = (char *)&header;
 	iovec.iov_len = sizeof (struct ykd_header);
 
-	res = api->tpg_joined_mcast (ykd_group_handle, &iovec, 1,
-		TOTEM_AGREED);
-
-	return (res);
+        return api->tpg_joined_mcast (ykd_group_handle, &iovec, 1, TOTEM_AGREED);
 }
 
 static void ykd_attempt_send (void)

--- a/exec/wd.c
+++ b/exec/wd.c
@@ -757,7 +757,7 @@ static int wd_exec_exit_fn (void)
 		    log_printf (LOGSYS_LEVEL_ERROR, "failed to write %c to dog(%d).", magic, dog);
 		}
 	}
-	return 0;
+        return true;
 }
 
 

--- a/include/corosync/coroapi.h
+++ b/include/corosync/coroapi.h
@@ -44,6 +44,8 @@
 #include <qb/qbloop.h>
 #include <corosync/swab.h>
 
+#include <stdbool.h>
+
 /**
  * @brief The mar_message_source_t struct
  */
@@ -278,7 +280,7 @@ struct corosync_api_v1 {
 
 	int (*totem_ring_reenable) (void);
 
-	int (*totem_mcast) (const struct iovec *iovec,
+        bool (*totem_mcast) (const struct iovec *iovec,
 			    unsigned int iov_len, unsigned int guarantee);
 
 	int (*totem_ifaces_get) (
@@ -338,7 +340,7 @@ struct corosync_api_v1 {
 		const struct corosync_tpg_group *groups,
 		size_t group_cnt);
 
-	int (*tpg_joined_mcast) (
+        bool (*tpg_joined_mcast) (
 		void *totempg_groups_instance,
 		const struct iovec *iovec,
 		unsigned int iov_len,
@@ -352,7 +354,7 @@ struct corosync_api_v1 {
 	int (*tpg_joined_release) (
 		int reserved_msgs);
 
-	int (*tpg_groups_mcast) (
+        bool (*tpg_groups_mcast) (
 		void *instance,
 		int guarantee,
 		const struct corosync_tpg_group *groups,
@@ -370,9 +372,9 @@ struct corosync_api_v1 {
 	int (*tpg_groups_release) (
 		int reserved_msgs);
 
-	int (*schedwrk_create) (
+        bool (*schedwrk_create) (
 		hdb_handle_t *handle,
-		int (schedwrk_fn) (const void *),
+                bool (schedwrk_fn) (const void *),
 		const void *context);
 
 	void (*schedwrk_destroy) (hdb_handle_t handle);
@@ -435,9 +437,9 @@ struct corosync_api_v1 {
 
 	void *(*totem_get_stats)(void);
 
-	int (*schedwrk_create_nolock) (
+        bool (*schedwrk_create_nolock) (
 		hdb_handle_t *handle,
-		int (schedwrk_fn) (const void *),
+                bool (schedwrk_fn) (const void *),
 		const void *context);
 
 	int (*poll_dispatch_add) (qb_loop_t * handle,
@@ -494,14 +496,14 @@ struct corosync_service_engine {
 	unsigned short priority; /* Lower priority are loaded first, unloaded last.
 				  * 0 is a special case which always loaded _and_ unloaded last
 				  */
-	unsigned int private_data_size;
+        size_t private_data_size;
 	enum cs_lib_flow_control flow_control;
 	enum cs_lib_allow_inquorate allow_inquorate;
 	char *(*exec_init_fn) (struct corosync_api_v1 *);
 	int (*exec_exit_fn) (void);
 	void (*exec_dump_fn) (void);
-	int (*lib_init_fn) (void *conn);
-	int (*lib_exit_fn) (void *conn);
+        bool (*lib_init_fn) (void *conn);
+        bool (*lib_exit_fn) (void *conn);
 	struct corosync_lib_handler *lib_engine;
 	int lib_engine_count;
 	struct corosync_exec_handler *exec_engine;
@@ -519,7 +521,7 @@ struct corosync_service_engine {
 		const unsigned int *member_list,
 		size_t member_list_entries,
 		const struct memb_ring_id *ring_id);
-	int (*sync_process) (void);
+        bool (*sync_process) (void);
 	void (*sync_activate) (void);
 	void (*sync_abort) (void);
 };

--- a/include/corosync/hdb.h
+++ b/include/corosync/hdb.h
@@ -49,6 +49,8 @@
 #include <inttypes.h>
 #include <qb/qbhdb.h>
 
+#include <stdbool.h>
+
 typedef qb_handle_t hdb_handle_t;
 
 /*
@@ -124,13 +126,12 @@ static inline void hdb_destroy (
  * @param handle_id_out
  * @return
  */
-static inline int hdb_handle_create (
+static inline bool hdb_handle_create (
 	struct hdb_handle_database *handle_database,
 	int instance_size,
 	hdb_handle_t *handle_id_out)
 {
-	return (qb_hdb_handle_create (handle_database, instance_size,
-		handle_id_out));
+        return 0 == qb_hdb_handle_create (handle_database, instance_size, handle_id_out);
 }
 
 /**
@@ -140,12 +141,12 @@ static inline int hdb_handle_create (
  * @param instance
  * @return
  */
-static inline int hdb_handle_get (
+static inline bool hdb_handle_get (
 	struct hdb_handle_database *handle_database,
 	hdb_handle_t handle_in,
 	void **instance)
 {
-	return (qb_hdb_handle_get (handle_database, handle_in, instance));
+        return 0 == qb_hdb_handle_get (handle_database, handle_in, instance);
 }
 
 /**

--- a/include/corosync/totem/totempg.h
+++ b/include/corosync/totem/totempg.h
@@ -51,6 +51,7 @@ extern "C" {
 #include <netinet/in.h>
 #include "totem.h"
 #include <qb/qbloop.h>
+#include <stdbool.h>
 
 struct totempg_group {
 	const void *group;
@@ -109,7 +110,7 @@ extern int totempg_groups_leave (
 	const struct totempg_group *groups,
 	size_t group_cnt);
 
-extern int totempg_groups_mcast_joined (
+extern bool totempg_groups_mcast_joined (
 	void *instance,
 	const struct iovec *iovec,
 	unsigned int iov_len,
@@ -123,7 +124,7 @@ extern int totempg_groups_joined_reserve (
 extern int totempg_groups_joined_release (
 	int msg_count);
 
-extern int totempg_groups_mcast_groups (
+extern bool totempg_groups_mcast_groups (
 	void *instance,
 	int guarantee,
 	const struct totempg_group *groups,


### PR DESCRIPTION
Using C99, we can return the new data type "bool" instead of relying on "int".

By changing the return types of functions where the only two possible returns are some indicator of success, and some indicator of failure to bool, we can drastically decrease the cognitive load on developers reading and trying to understand the code.

Instead of looking at a function and seeing "int some_function(...)", and wondering "Wow, I have no idea what the possible values that this can return are. Is it some kind of size? A specific list of possibilities? Perhaps a 32-bit pointer that hasn't been updated to 64bit? Or true/false", that same developer can see "bool some_function()" and know right away with absolutely no ambiguity, that this function can only ever return a single bit of information -- 0, or 1. Much easier to understand.

This pull request will refactor a small handful of functions in corosync to use bool.