### PR TITLE
Use size_t for corosync_service_engine.private_data_size. 

### DIFF
--- a/exec/ipc_glue.c
+++ b/exec/ipc_glue.c
@@ -272,7 +272,7 @@ static void cs_ipcs_connection_created(qb_ipcs_connection_t *c)
 	struct cs_ipcs_conn_context *context;
 	char proc_name[32];
 	struct qb_ipcs_connection_stats stats;
-	int32_t size = sizeof(struct cs_ipcs_conn_context);
+	size_t size = sizeof(struct cs_ipcs_conn_context);
 	char key_name[ICMAP_KEYNAME_MAXLEN];
 	int set_client_pid = 0;
 	int set_proc_name = 0;

--- a/include/corosync/coroapi.h
+++ b/include/corosync/coroapi.h
@@ -494,7 +494,7 @@ struct corosync_service_engine {
 	unsigned short priority; /* Lower priority are loaded first, unloaded last.
 				  * 0 is a special case which always loaded _and_ unloaded last
 				  */
-	unsigned int private_data_size;
+	size_t private_data_size;
 	enum cs_lib_flow_control flow_control;
 	enum cs_lib_allow_inquorate allow_inquorate;
 	char *(*exec_init_fn) (struct corosync_api_v1 *);


### PR DESCRIPTION
Unsigned int and size_t represent two different concepts