### PR TITLE
votequorum: Report errors from votequorum_exec_send_reconfigure

### DIFF
--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -2664,9 +2664,6 @@ static void message_handler_req_lib_votequorum_setexpected (void *conn, const vo
 					     req_lib_votequorum_setexpected->expected_votes)) {
 		error = CS_ERR_NO_RESOURCES;
 	}
-	else {
-		error = CS_OK;
-	}
 
 error_exit:
 	res_lib_votequorum_status.header.size = sizeof(res_lib_votequorum_status);
@@ -2715,9 +2712,6 @@ static void message_handler_req_lib_votequorum_setvotes (void *conn, const void 
 	if (votequorum_exec_send_reconfigure(VOTEQUORUM_RECONFIG_PARAM_NODE_VOTES, nodeid,
 					     req_lib_votequorum_setvotes->votes)) {
 		error = CS_ERR_NO_RESOURCES;
-	}
-	else {
-		error = CS_OK;
 	}
 
 error_exit:


### PR DESCRIPTION
If votequorum_exec_send_reconfigure() returns an error (ie the
packet could not be sent) then we should either return it to the
sender (for a library call) or, for an internal call, log it.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>