### PR TITLE
cmap: Add knet stats map

### DIFF
--- a/exec/Makefile.am
+++ b/exec/Makefile.am
@@ -40,7 +40,7 @@ noinst_HEADERS		= apidef.h cs_queue.h logconfig.h main.h \
 
 TOTEM_SRC		= totemip.c totemnet.c totemudp.c \
 			  totemudpu.c totemsrp.c \
-			  totempg.c totemknet.c
+			  totempg.c totemknet.c stats.c
 
 
 lib_LTLIBRARIES		= libtotem_pg.la

--- a/exec/cmap.c
+++ b/exec/cmap.c
@@ -54,6 +54,7 @@
 #include <corosync/icmap.h>
 
 #include "service.h"
+#include "stats.h"
 
 LOGSYS_DECLARE_SUBSYS ("CMAP");
 
@@ -61,6 +62,8 @@ LOGSYS_DECLARE_SUBSYS ("CMAP");
 #define ICMAP_VALUETYPE_NOT_EXIST		0
 
 struct cmap_map {
+
+	cs_error_t (*map_init)(const struct corosync_api_v1 *api);
 	cs_error_t (*map_get)(const char *key_name,
 			      void *value,
 			      size_t *value_len,
@@ -92,6 +95,7 @@ struct cmap_map {
 };
 
 struct cmap_map icmap_map = {
+	.map_init = NULL,
 	.map_get = icmap_get,
 	.map_set = icmap_set,
 	.map_adjust_int = icmap_adjust_int,
@@ -103,6 +107,21 @@ struct cmap_map icmap_map = {
 	.map_track_add = icmap_track_add,
 	.map_track_delete = icmap_track_delete,
 	.map_track_get_user_data = icmap_track_get_user_data,
+};
+
+struct cmap_map stats_map = {
+	.map_init = stats_map_init,
+	.map_get = stats_map_get,
+	.map_set = stats_map_set,
+	.map_adjust_int = stats_map_adjust_int,
+	.map_delete = stats_map_delete,
+	.map_is_key_ro = stats_map_is_key_ro,
+	.map_iter_init = stats_map_iter_init,
+	.map_iter_next = stats_map_iter_next,
+	.map_iter_finalize = stats_map_iter_finalize,
+	.map_track_add = stats_map_track_add,
+	.map_track_delete = stats_map_track_delete,
+	.map_track_get_user_data = stats_map_track_get_user_data,
 };
 
 struct cmap_conn_info {
@@ -378,7 +397,7 @@ static int cmap_lib_exit_fn (void *conn)
         while (hdb_iterator_next(&conn_info->iter_db,
                 (void*)&iter, &iter_handle) == 0) {
 
-		icmap_iter_finalize(*iter);
+		conn_info->map_fns.map_iter_finalize(*iter);
 
 		(void)hdb_handle_put (&conn_info->iter_db, iter_handle);
         }
@@ -389,9 +408,9 @@ static int cmap_lib_exit_fn (void *conn)
         while (hdb_iterator_next(&conn_info->track_db,
                 (void*)&track, &track_handle) == 0) {
 
-		free(icmap_track_get_user_data(*track));
+		free(conn_info->map_fns.map_track_get_user_data(*track));
 
-		icmap_track_delete(*track);
+		conn_info->map_fns.map_track_delete(*track);
 
 		(void)hdb_handle_put (&conn_info->track_db, track_handle);
         }
@@ -586,13 +605,8 @@ static void message_handler_req_lib_cmap_adjust_int(void *conn, const void *mess
 	if (conn_info->map_fns.map_is_key_ro((char *)req_lib_cmap_adjust_int->key_name.value)) {
 		ret = CS_ERR_ACCESS;
 	} else {
-		if (conn_info->map_fns.map_adjust_int) {
-			ret = conn_info->map_fns.map_adjust_int((char *)req_lib_cmap_adjust_int->key_name.value,
+		ret = conn_info->map_fns.map_adjust_int((char *)req_lib_cmap_adjust_int->key_name.value,
 								req_lib_cmap_adjust_int->step);
-		}
-		else {
-			ret = CS_ERR_BAD_OPERATION;
-		}
 	}
 
 	memset(&res_lib_cmap_adjust_int, 0, sizeof(res_lib_cmap_adjust_int));
@@ -874,16 +888,16 @@ static void message_handler_req_lib_cmap_set_current_map(void *conn, const void 
 
 	/* Cannot switch maps while there are tracks or iterators active */
 	hdb_iterator_reset(&conn_info->iter_db);
-        while (hdb_iterator_next(&conn_info->iter_db,
-                (void*)&iter, &iter_handle) == 0) {
+	while (hdb_iterator_next(&conn_info->iter_db,
+				 (void*)&iter, &iter_handle) == 0) {
 		handles_open++;
-        }
+	}
 
 	hdb_iterator_reset(&conn_info->track_db);
-        while (hdb_iterator_next(&conn_info->track_db,
-                (void*)&track, &track_handle) == 0) {
+	while (hdb_iterator_next(&conn_info->track_db,
+				 (void*)&track, &track_handle) == 0) {
 		handles_open++;
-        }
+	}
 
 	if (handles_open) {
 		ret = CS_ERR_BUSY;
@@ -895,8 +909,8 @@ static void message_handler_req_lib_cmap_set_current_map(void *conn, const void 
 			conn_info->map_fns = icmap_map;
 			break;
 		case CMAP_SETMAP_STATS:
-			ret = CS_ERR_NOT_SUPPORTED;
-//			conn_info->map_fns = stats_map;
+			conn_info->map_fns = stats_map;
+			conn_info->map_fns.map_init(api);
 			break;
 		default:
 			ret = CS_ERR_NOT_EXIST;
@@ -1050,7 +1064,7 @@ static void message_handler_req_exec_cmap_mcast_reason_sync_nv(
 	}
 
 	snprintf(member_config_version, ICMAP_KEYNAME_MAXLEN,
-		"runtime.totem.pg.mrp.srp.members.%u.config_version", nodeid);
+		"runtime.members.%u.config_version", nodeid);
 	icmap_set_uint64(member_config_version, config_version);
 
 	LEAVE();

--- a/exec/cmap.c
+++ b/exec/cmap.c
@@ -60,9 +60,55 @@ LOGSYS_DECLARE_SUBSYS ("CMAP");
 #define MAX_REQ_EXEC_CMAP_MCAST_ITEMS		32
 #define ICMAP_VALUETYPE_NOT_EXIST		0
 
+struct cmap_map {
+	cs_error_t (*map_get)(const char *key_name,
+			      void *value,
+			      size_t *value_len,
+			      icmap_value_types_t *type);
+
+	cs_error_t (*map_set)(const char *key_name,
+			      const void *value,
+			      size_t value_len,
+			      icmap_value_types_t type);
+
+	cs_error_t (*map_adjust_int)(const char *key_name, int32_t step);
+
+	cs_error_t (*map_delete)(const char *key_name);
+
+	int (*map_is_key_ro)(const char *key_name);
+
+	icmap_iter_t (*map_iter_init)(const char *prefix);
+	const char * (*map_iter_next)(icmap_iter_t iter, size_t *value_len, icmap_value_types_t *type);
+	void (*map_iter_finalize)(icmap_iter_t iter);
+
+	cs_error_t (*map_track_add)(const char *key_name,
+				    int32_t track_type,
+				    icmap_notify_fn_t notify_fn,
+				    void *user_data,
+				    icmap_track_t *icmap_track);
+
+	cs_error_t (*map_track_delete)(icmap_track_t icmap_track);
+	void * (*map_track_get_user_data)(icmap_track_t icmap_track);
+};
+
+struct cmap_map icmap_map = {
+	.map_get = icmap_get,
+	.map_set = icmap_set,
+	.map_adjust_int = icmap_adjust_int,
+	.map_delete = icmap_delete,
+	.map_is_key_ro = icmap_is_key_ro,
+	.map_iter_init = icmap_iter_init,
+	.map_iter_next = icmap_iter_next,
+	.map_iter_finalize = icmap_iter_finalize,
+	.map_track_add = icmap_track_add,
+	.map_track_delete = icmap_track_delete,
+	.map_track_get_user_data = icmap_track_get_user_data,
+};
+
 struct cmap_conn_info {
 	struct hdb_handle_database iter_db;
 	struct hdb_handle_database track_db;
+	struct cmap_map map_fns;
 };
 
 typedef uint64_t cmap_iter_handle_t;
@@ -100,6 +146,7 @@ static void message_handler_req_lib_cmap_iter_next(void *conn, const void *messa
 static void message_handler_req_lib_cmap_iter_finalize(void *conn, const void *message);
 static void message_handler_req_lib_cmap_track_add(void *conn, const void *message);
 static void message_handler_req_lib_cmap_track_delete(void *conn, const void *message);
+static void message_handler_req_lib_cmap_set_current_map(void *conn, const void *message);
 
 static void cmap_notify_fn(int32_t event,
 		const char *key_name,
@@ -179,6 +226,10 @@ static struct corosync_lib_handler cmap_lib_engine[] =
 	},
 	{ /* 8 */
 		.lib_handler_fn				= message_handler_req_lib_cmap_track_delete,
+		.flow_control				= CS_LIB_FLOW_CONTROL_NOT_REQUIRED
+	},
+	{ /* 9 */
+		.lib_handler_fn				= message_handler_req_lib_cmap_set_current_map,
 		.flow_control				= CS_LIB_FLOW_CONTROL_NOT_REQUIRED
 	},
 };
@@ -306,6 +357,7 @@ static int cmap_lib_init_fn (void *conn)
 	api->ipc_refcnt_inc(conn);
 
 	memset(conn_info, 0, sizeof(*conn_info));
+	conn_info->map_fns = icmap_map;
 	hdb_create(&conn_info->iter_db);
 	hdb_create(&conn_info->track_db);
 
@@ -425,14 +477,15 @@ static void cmap_sync_abort (void)
 static void message_handler_req_lib_cmap_set(void *conn, const void *message)
 {
 	const struct req_lib_cmap_set *req_lib_cmap_set = message;
+	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
 	struct res_lib_cmap_set res_lib_cmap_set;
 	cs_error_t ret;
 
-	if (icmap_is_key_ro((char *)req_lib_cmap_set->key_name.value)) {
+	if (conn_info->map_fns.map_is_key_ro((char *)req_lib_cmap_set->key_name.value)) {
 		ret = CS_ERR_ACCESS;
 	} else {
-		ret = icmap_set((char *)req_lib_cmap_set->key_name.value, &req_lib_cmap_set->value,
-				req_lib_cmap_set->value_len, req_lib_cmap_set->type);
+		ret = conn_info->map_fns.map_set((char *)req_lib_cmap_set->key_name.value, &req_lib_cmap_set->value,
+						 req_lib_cmap_set->value_len, req_lib_cmap_set->type);
 	}
 
 	memset(&res_lib_cmap_set, 0, sizeof(res_lib_cmap_set));
@@ -446,13 +499,14 @@ static void message_handler_req_lib_cmap_set(void *conn, const void *message)
 static void message_handler_req_lib_cmap_delete(void *conn, const void *message)
 {
 	const struct req_lib_cmap_set *req_lib_cmap_set = message;
+	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
 	struct res_lib_cmap_delete res_lib_cmap_delete;
 	cs_error_t ret;
 
-	if (icmap_is_key_ro((char *)req_lib_cmap_set->key_name.value)) {
+	if (conn_info->map_fns.map_is_key_ro((char *)req_lib_cmap_set->key_name.value)) {
 		ret = CS_ERR_ACCESS;
 	} else {
-		ret = icmap_delete((char *)req_lib_cmap_set->key_name.value);
+		ret = conn_info->map_fns.map_delete((char *)req_lib_cmap_set->key_name.value);
 	}
 
 	memset(&res_lib_cmap_delete, 0, sizeof(res_lib_cmap_delete));
@@ -466,6 +520,7 @@ static void message_handler_req_lib_cmap_delete(void *conn, const void *message)
 static void message_handler_req_lib_cmap_get(void *conn, const void *message)
 {
 	const struct req_lib_cmap_get *req_lib_cmap_get = message;
+	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
 	struct res_lib_cmap_get *res_lib_cmap_get;
 	struct res_lib_cmap_get error_res_lib_cmap_get;
 	cs_error_t ret;
@@ -491,10 +546,10 @@ static void message_handler_req_lib_cmap_get(void *conn, const void *message)
 		value = NULL;
 	}
 
-	ret = icmap_get((char *)req_lib_cmap_get->key_name.value,
-			value,
-			&value_len,
-			&type);
+	ret = conn_info->map_fns.map_get((char *)req_lib_cmap_get->key_name.value,
+					  value,
+					  &value_len,
+					  &type);
 
 	if (ret != CS_OK) {
 		free(res_lib_cmap_get);
@@ -524,14 +579,20 @@ error_exit:
 static void message_handler_req_lib_cmap_adjust_int(void *conn, const void *message)
 {
 	const struct req_lib_cmap_adjust_int *req_lib_cmap_adjust_int = message;
+	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
 	struct res_lib_cmap_adjust_int res_lib_cmap_adjust_int;
 	cs_error_t ret;
 
-	if (icmap_is_key_ro((char *)req_lib_cmap_adjust_int->key_name.value)) {
+	if (conn_info->map_fns.map_is_key_ro((char *)req_lib_cmap_adjust_int->key_name.value)) {
 		ret = CS_ERR_ACCESS;
 	} else {
-		ret = icmap_adjust_int((char *)req_lib_cmap_adjust_int->key_name.value,
-		    req_lib_cmap_adjust_int->step);
+		if (conn_info->map_fns.map_adjust_int) {
+			ret = conn_info->map_fns.map_adjust_int((char *)req_lib_cmap_adjust_int->key_name.value,
+								req_lib_cmap_adjust_int->step);
+		}
+		else {
+			ret = CS_ERR_BAD_OPERATION;
+		}
 	}
 
 	memset(&res_lib_cmap_adjust_int, 0, sizeof(res_lib_cmap_adjust_int));
@@ -559,7 +620,7 @@ static void message_handler_req_lib_cmap_iter_init(void *conn, const void *messa
 		prefix = NULL;
 	}
 
-	iter = icmap_iter_init(prefix);
+	iter = conn_info->map_fns.map_iter_init(prefix);
 	if (iter == NULL) {
 		ret = CS_ERR_NO_SECTIONS;
 		goto reply_send;
@@ -606,7 +667,7 @@ static void message_handler_req_lib_cmap_iter_next(void *conn, const void *messa
 		goto reply_send;
 	}
 
-	res = icmap_iter_next(*iter, &value_len, &type);
+	res = conn_info->map_fns.map_iter_next(*iter, &value_len, &type);
 	if (res == NULL) {
 		ret = CS_ERR_NO_SECTIONS;
 	}
@@ -644,7 +705,7 @@ static void message_handler_req_lib_cmap_iter_finalize(void *conn, const void *m
 		goto reply_send;
 	}
 
-	icmap_iter_finalize(*iter);
+	conn_info->map_fns.map_iter_finalize(*iter);
 
 	(void)hdb_handle_destroy(&conn_info->iter_db, req_lib_cmap_iter_finalize->iter_handle);
 
@@ -722,11 +783,11 @@ static void message_handler_req_lib_cmap_track_add(void *conn, const void *messa
 		key_name = NULL;
 	}
 
-	ret = icmap_track_add(key_name,
-			req_lib_cmap_track_add->track_type,
-			cmap_notify_fn,
-			cmap_track_user_data,
-			&track);
+	ret = conn_info->map_fns.map_track_add(key_name,
+					       req_lib_cmap_track_add->track_type,
+					       cmap_notify_fn,
+					       cmap_track_user_data,
+					       &track);
 	if (ret != CS_OK) {
 		free(cmap_track_user_data);
 
@@ -781,9 +842,9 @@ static void message_handler_req_lib_cmap_track_delete(void *conn, const void *me
 
 	track_inst_handle = ((struct cmap_track_user_data *)icmap_track_get_user_data(*track))->track_inst_handle;
 
-	free(icmap_track_get_user_data(*track));
+	free(conn_info->map_fns.map_track_get_user_data(*track));
 
-	ret = icmap_track_delete(*track);
+	ret = conn_info->map_fns.map_track_delete(*track);
 
 	(void)hdb_handle_put (&conn_info->track_db, req_lib_cmap_track_delete->track_handle);
 	(void)hdb_handle_destroy(&conn_info->track_db, req_lib_cmap_track_delete->track_handle);
@@ -796,6 +857,58 @@ reply_send:
 	res_lib_cmap_track_delete.track_inst_handle = track_inst_handle;
 
 	api->ipc_response_send(conn, &res_lib_cmap_track_delete, sizeof(res_lib_cmap_track_delete));
+}
+
+
+static void message_handler_req_lib_cmap_set_current_map(void *conn, const void *message)
+{
+	const struct req_lib_cmap_set_current_map *req_lib_cmap_set_current_map = message;
+	struct qb_ipc_response_header res;
+	cs_error_t ret = CS_OK;
+	struct cmap_conn_info *conn_info = (struct cmap_conn_info *)api->ipc_private_data_get (conn);
+	int handles_open = 0;
+	hdb_handle_t iter_handle = 0;
+	icmap_iter_t *iter;
+	hdb_handle_t track_handle = 0;
+	icmap_track_t *track;
+
+	/* Cannot switch maps while there are tracks or iterators active */
+	hdb_iterator_reset(&conn_info->iter_db);
+        while (hdb_iterator_next(&conn_info->iter_db,
+                (void*)&iter, &iter_handle) == 0) {
+		handles_open++;
+        }
+
+	hdb_iterator_reset(&conn_info->track_db);
+        while (hdb_iterator_next(&conn_info->track_db,
+                (void*)&track, &track_handle) == 0) {
+		handles_open++;
+        }
+
+	if (handles_open) {
+		ret = CS_ERR_BUSY;
+		goto reply_send;
+	}
+
+	switch (req_lib_cmap_set_current_map->new_map) {
+		case CMAP_SETMAP_DEFAULT:
+			conn_info->map_fns = icmap_map;
+			break;
+		case CMAP_SETMAP_STATS:
+			ret = CS_ERR_NOT_SUPPORTED;
+//			conn_info->map_fns = stats_map;
+			break;
+		default:
+			ret = CS_ERR_NOT_EXIST;
+			break;
+	}
+
+reply_send:
+	res.size = sizeof(res);
+	res.id = MESSAGE_RES_CMAP_SET_CURRENT_MAP;
+	res.error = ret;
+
+	api->ipc_response_send(conn, &res, sizeof(res));
 }
 
 static cs_error_t cmap_mcast_send(enum cmap_mcast_reason reason, int argc, char *argv[])

--- a/exec/icmap.c
+++ b/exec/icmap.c
@@ -91,11 +91,6 @@ static int icmap_check_key_name(const char *key_name);
 static int icmap_check_value_len(const void *value, size_t value_len, icmap_value_types_t type);
 
 /*
- * Returns length of value of given type, or 0 for string and binary data type
- */
-static size_t icmap_get_valuetype_len(icmap_value_types_t type);
-
-/*
  * Converts track type of icmap to qb
  */
 static int32_t icmap_tt_to_qbtt(int32_t track_type);
@@ -316,7 +311,7 @@ static int icmap_check_key_name(const char *key_name)
 	return (0);
 }
 
-static size_t icmap_get_valuetype_len(icmap_value_types_t type)
+size_t icmap_get_valuetype_len(icmap_value_types_t type)
 {
 	size_t res = 0;
 

--- a/exec/main.c
+++ b/exec/main.c
@@ -120,6 +120,7 @@
 #include "apidef.h"
 #include "service.h"
 #include "schedwrk.h"
+#include "stats.h"
 
 #ifdef HAVE_SMALL_MEMORY_FOOTPRINT
 #define IPC_LOGSYS_SIZE			1024*64
@@ -318,11 +319,11 @@ static void member_object_joined (unsigned int nodeid)
 	char member_status[ICMAP_KEYNAME_MAXLEN];
 
 	snprintf(member_ip, ICMAP_KEYNAME_MAXLEN,
-		"runtime.totem.pg.mrp.srp.members.%u.ip", nodeid);
+		"runtime.members.%u.ip", nodeid);
 	snprintf(member_join_count, ICMAP_KEYNAME_MAXLEN,
-		"runtime.totem.pg.mrp.srp.members.%u.join_count", nodeid);
+		"runtime.members.%u.join_count", nodeid);
 	snprintf(member_status, ICMAP_KEYNAME_MAXLEN,
-		"runtime.totem.pg.mrp.srp.members.%u.status", nodeid);
+		"runtime.members.%u.status", nodeid);
 
 	if (icmap_get(member_ip, NULL, NULL, NULL) == CS_OK) {
 		icmap_inc(member_join_count);
@@ -342,7 +343,7 @@ static void member_object_left (unsigned int nodeid)
 	char member_status[ICMAP_KEYNAME_MAXLEN];
 
 	snprintf(member_status, ICMAP_KEYNAME_MAXLEN,
-		"runtime.totem.pg.mrp.srp.members.%u.status", nodeid);
+		"runtime.members.%u.status", nodeid);
 	icmap_set_string(member_status, "left");
 
 	log_printf (LOGSYS_LEVEL_DEBUG,
@@ -475,37 +476,8 @@ static void corosync_totem_stats_updater (void *data)
 
 	stats = api->totem_get_stats();
 
-	icmap_set_uint32("runtime.totem.pg.msg_reserved", stats->msg_reserved);
-	icmap_set_uint32("runtime.totem.pg.msg_queue_avail", stats->msg_queue_avail);
-	icmap_set_uint64("runtime.totem.pg.srp.orf_token_tx", stats->srp->orf_token_tx);
-	icmap_set_uint64("runtime.totem.pg.srp.orf_token_rx", stats->srp->orf_token_rx);
-	icmap_set_uint64("runtime.totem.pg.srp.memb_merge_detect_tx", stats->srp->memb_merge_detect_tx);
-	icmap_set_uint64("runtime.totem.pg.srp.memb_merge_detect_rx", stats->srp->memb_merge_detect_rx);
-	icmap_set_uint64("runtime.totem.pg.srp.memb_join_tx", stats->srp->memb_join_tx);
-	icmap_set_uint64("runtime.totem.pg.srp.memb_join_rx", stats->srp->memb_join_rx);
-	icmap_set_uint64("runtime.totem.pg.srp.mcast_tx", stats->srp->mcast_tx);
-	icmap_set_uint64("runtime.totem.pg.srp.mcast_retx", stats->srp->mcast_retx);
-	icmap_set_uint64("runtime.totem.pg.srp.mcast_rx", stats->srp->mcast_rx);
-	icmap_set_uint64("runtime.totem.pg.srp.memb_commit_token_tx", stats->srp->memb_commit_token_tx);
-	icmap_set_uint64("runtime.totem.pg.srp.memb_commit_token_rx", stats->srp->memb_commit_token_rx);
-	icmap_set_uint64("runtime.totem.pg.srp.token_hold_cancel_tx", stats->srp->token_hold_cancel_tx);
-	icmap_set_uint64("runtime.totem.pg.srp.token_hold_cancel_rx", stats->srp->token_hold_cancel_rx);
-	icmap_set_uint64("runtime.totem.pg.srp.operational_entered", stats->srp->operational_entered);
-	icmap_set_uint64("runtime.totem.pg.srp.operational_token_lost", stats->srp->operational_token_lost);
-	icmap_set_uint64("runtime.totem.pg.srp.gather_entered", stats->srp->gather_entered);
-	icmap_set_uint64("runtime.totem.pg.srp.gather_token_lost", stats->srp->gather_token_lost);
-	icmap_set_uint64("runtime.totem.pg.srp.commit_entered", stats->srp->commit_entered);
-	icmap_set_uint64("runtime.totem.pg.srp.commit_token_lost", stats->srp->commit_token_lost);
-	icmap_set_uint64("runtime.totem.pg.srp.recovery_entered", stats->srp->recovery_entered);
-	icmap_set_uint64("runtime.totem.pg.srp.recovery_token_lost", stats->srp->recovery_token_lost);
-	icmap_set_uint64("runtime.totem.pg.srp.consensus_timeouts", stats->srp->consensus_timeouts);
-	icmap_set_uint64("runtime.totem.pg.srp.rx_msg_dropped", stats->srp->rx_msg_dropped);
-	icmap_set_uint32("runtime.totem.pg.srp.continuous_gather", stats->srp->continuous_gather);
-	icmap_set_uint32("runtime.totem.pg.srp.continuous_sendmsg_failures",
-	    stats->srp->continuous_sendmsg_failures);
 
-	icmap_set_uint8("runtime.totem.pg.srp.firewall_enabled_or_nic_failure",
-		stats->srp->continuous_gather > MAX_NO_CONT_GATHER ? 1 : 0);
+	stats->srp->firewall_enabled_or_nic_failure = stats->srp->continuous_gather > MAX_NO_CONT_GATHER ? 1 : 0;
 
 	if (stats->srp->continuous_gather > MAX_NO_CONT_GATHER ||
 	    stats->srp->continuous_sendmsg_failures > MAX_NO_CONT_SENDMSG_FAILURES) {
@@ -524,9 +496,9 @@ static void corosync_totem_stats_updater (void *data)
 			"operating system or network fault (reason: %s). The most common "
 			"cause of this message is that the local firewall is "
 			"configured improperly.", cstr);
-		icmap_set_uint8("runtime.totem.pg.srp.firewall_enabled_or_nic_failure", 1);
+		stats->srp->firewall_enabled_or_nic_failure = 1;
 	} else {
-		icmap_set_uint8("runtime.totem.pg.srp.firewall_enabled_or_nic_failure", 0);
+		stats->srp->firewall_enabled_or_nic_failure = 0;
 	}
 
 	total_mtt_rx_token = 0;
@@ -552,12 +524,13 @@ static void corosync_totem_stats_updater (void *data)
 		t = prev;
 	}
 	if (token_count) {
-		icmap_set_uint32("runtime.totem.pg.srp.mtt_rx_token", (total_mtt_rx_token / token_count));
-		icmap_set_uint32("runtime.totem.pg.srp.avg_token_workload", (total_token_holdtime / token_count));
-		icmap_set_uint32("runtime.totem.pg.srp.avg_backlog_calc", (total_backlog_calc / token_count));
+		stats->srp->mtt_rx_token = (total_mtt_rx_token / token_count);
+		stats->srp->avg_token_workload = (total_token_holdtime / token_count);
+		stats->srp->avg_backlog_calc = (total_backlog_calc / token_count);
 	}
 
 	cs_ipcs_stats_update();
+	stats_trigger_trackers();
 
 	api->timer_add_duration (1500 * MILLI_2_NANO_SECONDS, NULL,
 		corosync_totem_stats_updater,
@@ -566,10 +539,6 @@ static void corosync_totem_stats_updater (void *data)
 
 static void corosync_totem_stats_init (void)
 {
-	icmap_set_uint32("runtime.totem.pg.srp.mtt_rx_token", 0);
-	icmap_set_uint32("runtime.totem.pg.srp.avg_token_workload", 0);
-	icmap_set_uint32("runtime.totem.pg.srp.avg_backlog_calc", 0);
-
 	/* start stats timer */
 	api->timer_add_duration (1500 * MILLI_2_NANO_SECONDS, NULL,
 		corosync_totem_stats_updater,
@@ -1294,8 +1263,8 @@ int main (int argc, char **argv, char **envp)
 
 	totem_config.totem_logging_configuration = totem_logging_configuration;
 	totem_config.totem_logging_configuration.log_subsys_id = _logsys_subsys_create("TOTEM", "totem,"
-			"totemmrp.c,totemrrp.c,totemip.c,totemconfig.c,totemcrypto.c,totemsrp.c,"
-			"totempg.c,totemiba.c,totemudp.c,totemudpu.c,totemnet.c,totemknet.c");
+			"totemip.c,totemconfig.c,totemcrypto.c,totemsrp.c,"
+			"totempg.c,totemudp.c,totemudpu.c,totemnet.c,totemknet.c");
 
 	totem_config.totem_logging_configuration.log_level_security = LOGSYS_LEVEL_WARNING;
 	totem_config.totem_logging_configuration.log_level_error = LOGSYS_LEVEL_ERROR;

--- a/exec/stats.c
+++ b/exec/stats.c
@@ -1,0 +1,483 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * All rights reserved.
+ *
+ * Authors: Christine Caulfield (ccaulfie@redhat.com)
+ *
+ * This software licensed under BSD license, the text of which follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the MontaVista Software, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <unistd.h>
+#include <libknet.h>
+
+#include <qb/qblist.h>
+#include <qb/qbipc_common.h>
+
+#include <corosync/corodefs.h>
+#include <corosync/coroapi.h>
+#include <corosync/logsys.h>
+#include <corosync/icmap.h>
+#include <corosync/totem/totemstats.h>
+
+#include "util.h"
+#include "stats.h"
+
+LOGSYS_DECLARE_SUBSYS ("STATS");
+
+/* Global struct for people who use stats_get_map() */
+static struct knet_link_status link_status;
+
+/* Convert iterator number to text and a stats pointer */
+struct cs_stats_conv {
+	const char *text;
+	const size_t offset;
+	const icmap_value_types_t type;
+};
+
+struct cs_stats_conv cs_pg_stats[] = {
+	{ "msg_queue_avail",        offsetof(totempg_stats_t, msg_queue_avail),         ICMAP_VALUETYPE_UINT32},
+	{ "msg_reserved",           offsetof(totempg_stats_t, msg_reserved),            ICMAP_VALUETYPE_UINT32},
+};
+
+struct cs_stats_conv cs_srp_stats[] = {
+	{ "orf_token_tx",           offsetof(totemsrp_stats_t, orf_token_tx),           ICMAP_VALUETYPE_UINT64},
+	{ "orf_token_rx",           offsetof(totemsrp_stats_t, orf_token_rx),           ICMAP_VALUETYPE_UINT64},
+	{ "memb_merge_detect_tx",   offsetof(totemsrp_stats_t, memb_merge_detect_tx),   ICMAP_VALUETYPE_UINT64},
+	{ "memb_merge_detect_rx",   offsetof(totemsrp_stats_t, memb_merge_detect_rx),   ICMAP_VALUETYPE_UINT64},
+	{ "memb_join_tx",           offsetof(totemsrp_stats_t, memb_join_tx),           ICMAP_VALUETYPE_UINT64},
+	{ "memb_join_rx",           offsetof(totemsrp_stats_t, memb_join_rx),           ICMAP_VALUETYPE_UINT64},
+	{ "mcast_tx",               offsetof(totemsrp_stats_t, mcast_tx),               ICMAP_VALUETYPE_UINT64},
+	{ "mcast_retx",             offsetof(totemsrp_stats_t, mcast_retx),             ICMAP_VALUETYPE_UINT64},
+	{ "mcast_rx",               offsetof(totemsrp_stats_t, mcast_rx),               ICMAP_VALUETYPE_UINT64},
+	{ "memb_commit_token_tx",   offsetof(totemsrp_stats_t, memb_commit_token_tx),   ICMAP_VALUETYPE_UINT64},
+	{ "memb_commit_token_rx",   offsetof(totemsrp_stats_t, memb_commit_token_rx),   ICMAP_VALUETYPE_UINT64},
+	{ "token_hold_cancel_tx",   offsetof(totemsrp_stats_t, token_hold_cancel_tx),   ICMAP_VALUETYPE_UINT64},
+	{ "token_hold_cancel_rx",   offsetof(totemsrp_stats_t, token_hold_cancel_rx),   ICMAP_VALUETYPE_UINT64},
+	{ "operational_entered",    offsetof(totemsrp_stats_t, operational_entered),    ICMAP_VALUETYPE_UINT64},
+	{ "operational_token_lost", offsetof(totemsrp_stats_t, operational_token_lost), ICMAP_VALUETYPE_UINT64},
+	{ "gather_entered",         offsetof(totemsrp_stats_t, gather_entered),         ICMAP_VALUETYPE_UINT64},
+	{ "gather_token_lost",      offsetof(totemsrp_stats_t, gather_token_lost),      ICMAP_VALUETYPE_UINT64},
+	{ "commit_entered",         offsetof(totemsrp_stats_t, commit_entered),         ICMAP_VALUETYPE_UINT64},
+	{ "commit_token_lost",      offsetof(totemsrp_stats_t, commit_token_lost),      ICMAP_VALUETYPE_UINT64},
+	{ "recovery_entered",       offsetof(totemsrp_stats_t, recovery_entered),       ICMAP_VALUETYPE_UINT64},
+	{ "recovery_token_lost",    offsetof(totemsrp_stats_t, recovery_token_lost),    ICMAP_VALUETYPE_UINT64},
+	{ "consensus_timeouts",     offsetof(totemsrp_stats_t, consensus_timeouts),     ICMAP_VALUETYPE_UINT64},
+	{ "rx_msg_dropped",         offsetof(totemsrp_stats_t, rx_msg_dropped),         ICMAP_VALUETYPE_UINT64},
+	{ "continuous_gather",      offsetof(totemsrp_stats_t, continuous_gather),      ICMAP_VALUETYPE_UINT32},
+	{ "continuous_sendmsg_failures", offsetof(totemsrp_stats_t, continuous_sendmsg_failures), ICMAP_VALUETYPE_UINT32},
+	{ "firewall_enabled_or_nic_failure", offsetof(totemsrp_stats_t, firewall_enabled_or_nic_failure), ICMAP_VALUETYPE_UINT8},
+	{ "mtt_rx_token",           offsetof(totemsrp_stats_t, mtt_rx_token),           ICMAP_VALUETYPE_UINT32},
+	{ "avg_token_workload",     offsetof(totemsrp_stats_t, avg_token_workload),     ICMAP_VALUETYPE_UINT32},
+	{ "avg_backlog_calc",       offsetof(totemsrp_stats_t, avg_backlog_calc),       ICMAP_VALUETYPE_UINT32},
+};
+
+/* knet stats - this needs updating for each knet stats update */
+struct cs_stats_conv cs_knet_link_stats[] = {
+	{ "tx_data_packets",  offsetof(struct knet_link_stats, tx_data_packets),  ICMAP_VALUETYPE_UINT64},
+	{ "rx_data_packets",  offsetof(struct knet_link_stats, rx_data_packets),  ICMAP_VALUETYPE_UINT64},
+	{ "tx_data_bytes",    offsetof(struct knet_link_stats, tx_data_bytes),    ICMAP_VALUETYPE_UINT64},
+	{ "rx_data_bytes",    offsetof(struct knet_link_stats, rx_data_bytes),    ICMAP_VALUETYPE_UINT64},
+	{ "tx_ping_packets",  offsetof(struct knet_link_stats, tx_ping_packets),  ICMAP_VALUETYPE_UINT64},
+	{ "rx_ping_packets",  offsetof(struct knet_link_stats, rx_ping_packets),  ICMAP_VALUETYPE_UINT64},
+	{ "tx_ping_bytes",    offsetof(struct knet_link_stats, tx_ping_bytes),    ICMAP_VALUETYPE_UINT64},
+	{ "rx_ping_bytes",    offsetof(struct knet_link_stats, rx_ping_bytes),    ICMAP_VALUETYPE_UINT64},
+	{ "tx_pong_packets",  offsetof(struct knet_link_stats, tx_pong_packets),  ICMAP_VALUETYPE_UINT64},
+	{ "rx_pong_packets",  offsetof(struct knet_link_stats, rx_pong_packets),  ICMAP_VALUETYPE_UINT64},
+	{ "tx_pong_bytes",    offsetof(struct knet_link_stats, tx_pong_bytes),    ICMAP_VALUETYPE_UINT64},
+	{ "rx_pong_bytes",    offsetof(struct knet_link_stats, rx_pong_bytes),    ICMAP_VALUETYPE_UINT64},
+	{ "tx_pmtu_packets",  offsetof(struct knet_link_stats, tx_pmtu_packets),  ICMAP_VALUETYPE_UINT64},
+	{ "rx_pmtu_packets",  offsetof(struct knet_link_stats, rx_pmtu_packets),  ICMAP_VALUETYPE_UINT64},
+	{ "tx_pmtu_bytes",    offsetof(struct knet_link_stats, tx_pmtu_bytes),    ICMAP_VALUETYPE_UINT64},
+	{ "rx_pmtu_bytes",    offsetof(struct knet_link_stats, rx_pmtu_bytes),    ICMAP_VALUETYPE_UINT64},
+
+	{ "tx_total_packets", offsetof(struct knet_link_stats, tx_total_packets), ICMAP_VALUETYPE_UINT64},
+	{ "rx_total_packets", offsetof(struct knet_link_stats, rx_total_packets), ICMAP_VALUETYPE_UINT64},
+	{ "tx_total_bytes",   offsetof(struct knet_link_stats, tx_total_bytes),   ICMAP_VALUETYPE_UINT64},
+	{ "rx_total_bytes",   offsetof(struct knet_link_stats, rx_total_bytes),   ICMAP_VALUETYPE_UINT64},
+	{ "tx_total_errors",  offsetof(struct knet_link_stats, tx_total_errors),  ICMAP_VALUETYPE_UINT64},
+	{ "rx_total_retries", offsetof(struct knet_link_stats, tx_total_retries), ICMAP_VALUETYPE_UINT64},
+
+	{ "tx_pmtu_errors",   offsetof(struct knet_link_stats, tx_pmtu_errors),   ICMAP_VALUETYPE_UINT32},
+	{ "tx_pmtu_retries",  offsetof(struct knet_link_stats, tx_pmtu_retries),  ICMAP_VALUETYPE_UINT32},
+	{ "tx_ping_errors",   offsetof(struct knet_link_stats, tx_ping_errors),   ICMAP_VALUETYPE_UINT32},
+	{ "tx_ping_retries",  offsetof(struct knet_link_stats, tx_ping_retries),  ICMAP_VALUETYPE_UINT32},
+	{ "tx_pong_errors",   offsetof(struct knet_link_stats, tx_pong_errors),   ICMAP_VALUETYPE_UINT32},
+	{ "tx_pong_retries",  offsetof(struct knet_link_stats, tx_pong_retries),  ICMAP_VALUETYPE_UINT32},
+	{ "tx_data_errors",   offsetof(struct knet_link_stats, tx_data_errors),   ICMAP_VALUETYPE_UINT32},
+	{ "tx_data_retries",  offsetof(struct knet_link_stats, tx_data_retries),  ICMAP_VALUETYPE_UINT32},
+
+	{ "latency_min",      offsetof(struct knet_link_stats, latency_min),      ICMAP_VALUETYPE_UINT32},
+	{ "latency_max",      offsetof(struct knet_link_stats, latency_max),      ICMAP_VALUETYPE_UINT32},
+	{ "latency_ave",      offsetof(struct knet_link_stats, latency_ave),      ICMAP_VALUETYPE_UINT32},
+	{ "latency_samples",  offsetof(struct knet_link_stats, latency_samples),  ICMAP_VALUETYPE_UINT32},
+
+	{ "down_count",       offsetof(struct knet_link_stats, down_count),       ICMAP_VALUETYPE_UINT32},
+	{ "up_count",         offsetof(struct knet_link_stats, up_count),         ICMAP_VALUETYPE_UINT32},
+};
+
+#define NUM_PG_STATS (sizeof(cs_pg_stats) / sizeof(struct cs_stats_conv))
+#define NUM_SRP_STATS (sizeof(cs_srp_stats) / sizeof(struct cs_stats_conv))
+#define NUM_KNET_STATS (sizeof(cs_knet_link_stats) / sizeof(struct cs_stats_conv))
+
+#define STATS_TRACKER_TIMER_MS 1000
+
+static const struct corosync_api_v1 *corosync_api;
+
+/* One of these per iterator */
+struct stats_iterator
+{
+	knet_node_id_t knet_node;
+	uint8_t knet_link;
+	uint32_t stats_index;
+	char key_name[ICMAP_KEYNAME_MAXLEN];
+	enum {PG_STATS, SRP_STATS, KNET_STATS} stats_state;
+};
+
+/* One of these per tracker */
+struct cs_stats_tracker
+{
+	char *key_name;
+	void *user_data;
+	icmap_notify_fn_t notify_fn;
+	struct qb_list_head list;
+};
+QB_LIST_DECLARE (stats_tracker_list_head);
+
+static void stats_map_set_value(struct cs_stats_conv *conv_array,
+				int index,
+				void *stat_array,
+				void *value,
+				size_t *value_len,
+				icmap_value_types_t *type)
+{
+	if (type) {
+		*type = conv_array[index].type;
+	}
+	if (value_len) {
+		*value_len = icmap_get_valuetype_len(conv_array[index].type);
+	}
+	if (value) {
+		memcpy(value, (char *)(stat_array) + conv_array[index].offset, *value_len);
+	}
+}
+
+static int stats_map_find_and_set_value(const char *key_name,
+					struct cs_stats_conv *conv_array,
+					int array_size,
+					void *stat_array,
+					void *value,
+					size_t *value_len,
+					icmap_value_types_t *type)
+{
+	int i;
+
+	for (i=0; i < array_size; i++) {
+		if (strcmp(key_name, conv_array[i].text) == 0) {
+			stats_map_set_value(conv_array, i, stat_array, value, value_len, type);
+			return CS_OK;
+		}
+	}
+	return CS_ERR_NOT_EXIST;
+}
+
+
+cs_error_t stats_map_init(const struct corosync_api_v1 *api)
+{
+	corosync_api = api;
+	return CS_OK;
+}
+
+cs_error_t stats_map_get(const char *key_name,
+			 void *value,
+			 size_t *value_len,
+			 icmap_value_types_t *type)
+{
+	int link, node;
+	totempg_stats_t *stats;
+	char param[ICMAP_KEYNAME_MAXLEN];
+	int res;
+
+	log_printf(LOGSYS_LEVEL_DEBUG, "stats_map_get: %s", key_name);
+
+	if (strncmp(key_name, "stats.pg.", 9) == 0) {
+		stats = corosync_api->totem_get_stats();
+
+		return stats_map_find_and_set_value(key_name+9,
+						    cs_pg_stats,
+						    NUM_PG_STATS,
+						    stats,
+						    value,
+						    value_len,
+						    type);
+	}
+
+	if (strncmp(key_name, "stats.srp.", 10) == 0) {
+		stats = corosync_api->totem_get_stats();
+
+		return stats_map_find_and_set_value(key_name+10,
+						    cs_srp_stats,
+						    NUM_SRP_STATS,
+						    stats->srp,
+						    value,
+						    value_len,
+						    type);
+	}
+
+
+	if (strncmp(key_name, "stats.knet.", 11) == 0) {
+		/* KNET stats */
+		if (sscanf(key_name, "stats.knet.node%d.link%d.%s", &node, &link, param) != 3) {
+			return CS_ERR_INVALID_PARAM;
+		}
+
+		if (node < 0 || node > KNET_MAX_HOST ||
+		    link < 0 || link > KNET_MAX_LINK) {
+			return CS_ERR_INVALID_PARAM;
+		}
+		log_printf(LOGSYS_LEVEL_DEBUG, "stats_map_get: node:%d, link:%d, stat %s", node, link, param);
+
+		res = totemknet_link_get_status(node, link, &link_status);
+
+		/* returns < 0 indicate invalid nodeid or link id
+		   (used by the iterators) */
+		if (res < 0) {
+			return CS_ERR_INVALID_PARAM;
+		}
+		if (res != CS_OK) {
+			return res;
+		}
+
+		return stats_map_find_and_set_value(param,
+						    cs_knet_link_stats,
+						    NUM_KNET_STATS,
+						    &link_status.stats,
+						    value,
+						    value_len,
+						    type);
+	}
+
+	return CS_ERR_NOT_EXIST;
+}
+
+
+cs_error_t stats_map_set(const char *key_name,
+			 const void *value,
+			 size_t value_len,
+			 icmap_value_types_t type)
+{
+	return CS_ERR_NOT_SUPPORTED;
+}
+
+cs_error_t stats_map_adjust_int(const char *key_name, int32_t step)
+{
+	return CS_ERR_NOT_SUPPORTED;
+}
+
+cs_error_t stats_map_delete(const char *key_name)
+{
+	return CS_ERR_NOT_SUPPORTED;
+}
+
+int stats_map_is_key_ro(const char *key_name)
+{
+	/* It's all read-only */
+	return 1;
+}
+
+icmap_iter_t stats_map_iter_init(const char *prefix)
+{
+	struct stats_iterator *iter;
+
+	iter = malloc(sizeof(struct stats_iterator));
+	if (!iter) {
+		return NULL;
+	}
+
+	iter->knet_node = 1;
+	iter->knet_link = 0xFF; /* wraps around to 0 the first time we do a get */
+	iter->stats_index = 0;
+	iter->stats_state = PG_STATS;
+
+        return (icmap_iter_t)iter;
+}
+
+
+const char *stats_map_iter_next(icmap_iter_t iter, size_t *value_len, icmap_value_types_t *type)
+{
+	struct stats_iterator *siter = (struct stats_iterator *)iter;
+	int ret;
+
+	/* Non-knet stats first */
+	if (siter->stats_state == PG_STATS) {
+
+		if (siter->stats_index >= NUM_PG_STATS) {
+			siter->stats_state = SRP_STATS;
+			siter->stats_index = 0;
+		}
+		else {
+			sprintf(siter->key_name, "stats.pg.%s", cs_pg_stats[siter->stats_index].text);
+
+			stats_map_set_value(cs_pg_stats, siter->stats_index, NULL, NULL, value_len, type);
+			goto return_iter;
+		}
+	}
+
+	if (siter->stats_state == SRP_STATS) {
+
+		if (siter->stats_index >= NUM_SRP_STATS) {
+			siter->stats_state = KNET_STATS;
+			siter->stats_index = NUM_KNET_STATS; /* Force re-read */
+		}
+		else {
+			sprintf(siter->key_name, "stats.srp.%s", cs_srp_stats[siter->stats_index].text);
+
+			stats_map_set_value(cs_srp_stats, siter->stats_index, NULL, NULL, value_len, type);
+			goto return_iter;
+		}
+	}
+
+	/* Now knet */
+	if (siter->stats_index >= NUM_KNET_STATS) {
+
+		siter->knet_link++;
+	retry:
+		log_printf(LOGSYS_LEVEL_DEBUG, "Getting stats for node %d link %d", siter->knet_node, siter->knet_link);
+		ret = totemknet_link_get_status(siter->knet_node, siter->knet_link,
+						&link_status);
+		if (ret == -1) { /* no more links for this node */
+			siter->knet_node++;
+
+			/* Don't try and get stats for the local node id */
+			if (siter->knet_node == corosync_api->totem_nodeid_get()) {
+				siter->knet_node++;
+			}
+			siter->knet_link = 0;
+			siter->stats_index = 0;
+			goto retry;
+		}
+		if (ret != CS_OK) { /* includes no more nodes */
+			return NULL;
+		}
+		siter->stats_index = 0;
+	}
+	sprintf(siter->key_name, "stats.knet.node%d.link%d.%s",
+		siter->knet_node, siter->knet_link, cs_knet_link_stats[siter->stats_index].text);
+
+	stats_map_set_value(cs_knet_link_stats, siter->stats_index, NULL, NULL, value_len, type);
+
+return_iter:
+	siter->stats_index++;
+	return siter->key_name;
+}
+
+void stats_map_iter_finalize(icmap_iter_t iter)
+{
+        free(iter);
+}
+
+void stats_trigger_trackers()
+{
+	struct cs_stats_tracker *tracker;
+	struct qb_list_head *iter;
+	cs_error_t res;
+	size_t value_len;
+	icmap_value_types_t type;
+	uint64_t value;
+	struct icmap_notify_value new_val;
+	struct icmap_notify_value old_val;
+
+	qb_list_for_each(iter, &stats_tracker_list_head) {
+
+		tracker = qb_list_entry(iter, struct cs_stats_tracker, list);
+		res = stats_map_get(tracker->key_name,
+				    &value, &value_len, &type);
+
+		if (res == CS_OK) {
+			old_val.type = new_val.type = type;
+			old_val.len = new_val.len = value_len;
+			old_val.data = new_val.data = &value;
+
+			tracker->notify_fn(ICMAP_TRACK_MODIFY, tracker->key_name,
+					   old_val, new_val, tracker->user_data);
+		}
+	}
+}
+
+
+cs_error_t stats_map_track_add(const char *key_name,
+			       int32_t track_type,
+			       icmap_notify_fn_t notify_fn,
+			       void *user_data,
+			       icmap_track_t *icmap_track)
+{
+	struct cs_stats_tracker *tracker;
+
+	if (track_type & ICMAP_TRACK_PREFIX) {
+		return CS_ERR_NOT_SUPPORTED;
+	}
+
+	tracker = malloc(sizeof(struct cs_stats_tracker));
+	if (!tracker) {
+		return CS_ERR_NO_MEMORY;
+	}
+
+	tracker->notify_fn = notify_fn;
+	tracker->user_data = user_data;
+	tracker->key_name = strdup(key_name);
+
+	qb_list_add (&tracker->list, &stats_tracker_list_head);
+
+	*icmap_track = (icmap_track_t)tracker;
+
+	return CS_OK;
+}
+
+cs_error_t stats_map_track_delete(icmap_track_t icmap_track)
+{
+	struct cs_stats_tracker *tracker = (struct cs_stats_tracker *)icmap_track;
+
+	qb_list_del(&tracker->list);
+	free(tracker->key_name);
+	free(tracker);
+
+	return CS_OK;
+}
+
+void *stats_map_track_get_user_data(icmap_track_t icmap_track)
+{
+	struct cs_stats_tracker *tracker = (struct cs_stats_tracker *)icmap_track;
+
+	return tracker->user_data;
+}

--- a/exec/stats.h
+++ b/exec/stats.h
@@ -1,0 +1,32 @@
+cs_error_t stats_map_init(const struct corosync_api_v1 *api);
+
+cs_error_t stats_map_get(const char *key_name,
+		   void *value,
+		   size_t *value_len,
+		   icmap_value_types_t *type);
+
+cs_error_t stats_map_set(const char *key_name,
+		   const void *value,
+		   size_t value_len,
+		   icmap_value_types_t type);
+
+cs_error_t stats_map_adjust_int(const char *key_name, int32_t step);
+
+cs_error_t stats_map_delete(const char *key_name);
+
+int stats_map_is_key_ro(const char *key_name);
+
+icmap_iter_t stats_map_iter_init(const char *prefix);
+const char *stats_map_iter_next(icmap_iter_t iter, size_t *value_len, icmap_value_types_t *type);
+void stats_map_iter_finalize(icmap_iter_t iter);
+
+cs_error_t stats_map_track_add(const char *key_name,
+			 int32_t track_type,
+			 icmap_notify_fn_t notify_fn,
+			 void *user_data,
+			 icmap_track_t *icmap_track);
+
+cs_error_t stats_map_track_delete(icmap_track_t icmap_track);
+void *stats_map_track_get_user_data(icmap_track_t icmap_track);
+
+void stats_trigger_trackers(void);

--- a/include/corosync/cmap.h
+++ b/include/corosync/cmap.h
@@ -104,6 +104,12 @@ typedef enum {
     CMAP_VALUETYPE_BINARY	= 12,
 } cmap_value_types_t;
 
+typedef enum {
+	CMAP_MAP_DEFAULT        = 0,
+	CMAP_MAP_ICMAP          = 0,
+	CMAP_MAP_STATS          = 1,
+} cmap_map_t;
+
 /**
  * Structure passed as new_value and old_value in change callback. It contains type of
  * key, length of key and pointer to value of key
@@ -349,6 +355,13 @@ extern cs_error_t cmap_track_add(
  * @param track_handle Track handle
  */
 extern cs_error_t cmap_track_delete(cmap_handle_t handle, cmap_track_handle_t track_handle);
+
+/**
+ * Delete track created previously by cmap_track_add
+ * @param handle cmap handle
+ * @param new_map map type from one of CMAP_MAP_*
+ */
+extern cs_error_t cmap_set_current_map(cmap_handle_t handle, cmap_map_t new_map);
 
 /** @} */
 

--- a/include/corosync/icmap.h
+++ b/include/corosync/icmap.h
@@ -542,6 +542,16 @@ extern void icmap_convert_name_to_valid_name(char *key_name);
  */
 extern cs_error_t icmap_copy_map(icmap_map_t dst_map, const icmap_map_t src_map);
 
+
+
+/**
+ * @brief Returns length of value of given type, or 0 for string and binary data type
+ * @param type
+ * @return
+ */
+extern size_t icmap_get_valuetype_len(icmap_value_types_t type);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/corosync/ipc_cmap.h
+++ b/include/corosync/ipc_cmap.h
@@ -52,6 +52,7 @@ enum req_cmap_types {
 	MESSAGE_REQ_CMAP_ITER_FINALIZE = 6,
 	MESSAGE_REQ_CMAP_TRACK_ADD = 7,
 	MESSAGE_REQ_CMAP_TRACK_DELETE = 8,
+	MESSAGE_REQ_CMAP_SET_CURRENT_MAP = 9,
 };
 
 /**
@@ -68,6 +69,12 @@ enum res_cmap_types {
 	MESSAGE_RES_CMAP_TRACK_ADD = 7,
 	MESSAGE_RES_CMAP_TRACK_DELETE = 8,
 	MESSAGE_RES_CMAP_NOTIFY_CALLBACK = 9,
+	MESSAGE_RES_CMAP_SET_CURRENT_MAP = 10,
+};
+
+enum {
+	CMAP_SETMAP_DEFAULT        = 0,
+	CMAP_SETMAP_STATS          = 1,
 };
 
 /**
@@ -242,5 +249,14 @@ struct res_lib_cmap_notify_callback {
 	 */
 	mar_uint8_t new_value[];
 };
+
+/**
+ * @brief The req_lib_cmap_set_current_map struct
+ */
+struct req_lib_cmap_set_current_map {
+	struct qb_ipc_request_header header __attribute__((aligned(8)));
+	mar_int32_t new_map __attribute__((aligned(8)));
+};
+
 
 #endif /* IPC_CMAP_H_DEFINED */

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -36,6 +36,7 @@
 #define TOTEM_H_DEFINED
 #include "totemip.h"
 #include "libknet.h"
+#include "totemstats.h"
 #include <corosync/hdb.h>
 
 #ifdef HAVE_SMALL_MEMORY_FOOTPRINT
@@ -224,66 +225,4 @@ enum totem_event_type {
 	TOTEM_EVENT_DELIVERY_CONGESTED,
 	TOTEM_EVENT_NEW_MSG,
 };
-
-typedef struct {
-	int is_dirty;
-	time_t last_updated;
-} totem_stats_header_t;
-
-typedef struct {
-	totem_stats_header_t hdr;
-	uint32_t iface_changes;
-} totemnet_stats_t;
-
-typedef struct {
-	uint32_t rx;
-	uint32_t tx;
-	int backlog_calc;
-} totemsrp_token_stats_t;
-
-typedef struct {
-	totem_stats_header_t hdr;
-	uint64_t orf_token_tx;
-	uint64_t orf_token_rx;
-	uint64_t memb_merge_detect_tx;
-	uint64_t memb_merge_detect_rx;
-	uint64_t memb_join_tx;
-	uint64_t memb_join_rx;
-	uint64_t mcast_tx;
-	uint64_t mcast_retx;
-	uint64_t mcast_rx;
-	uint64_t memb_commit_token_tx;
-	uint64_t memb_commit_token_rx;
-	uint64_t token_hold_cancel_tx;
-	uint64_t token_hold_cancel_rx;
-	uint64_t operational_entered;
-	uint64_t operational_token_lost;
-	uint64_t gather_entered;
-	uint64_t gather_token_lost;
-	uint64_t commit_entered;
-	uint64_t commit_token_lost;
-	uint64_t recovery_entered;
-	uint64_t recovery_token_lost;
-	uint64_t consensus_timeouts;
-	uint64_t rx_msg_dropped;
-	uint32_t continuous_gather;
-	uint32_t continuous_sendmsg_failures;
-
-	int earliest_token;
-	int latest_token;
-#define TOTEM_TOKEN_STATS_MAX 100
-	totemsrp_token_stats_t token[TOTEM_TOKEN_STATS_MAX];
-
-} totemsrp_stats_t;
-
- 
- #define TOTEM_CONFIGURATION_TYPE
-
-typedef struct {
-	totem_stats_header_t hdr;
-	totemsrp_stats_t *srp;
-	uint32_t msg_reserved;
-	uint32_t msg_queue_avail;
-} totempg_stats_t;
-
 #endif /* TOTEM_H_DEFINED */

--- a/include/corosync/totem/totemstats.h
+++ b/include/corosync/totem/totemstats.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2017 Red Hat, Inc.
+ *
+ * Author: Christine Caulfield (ccaulfie@redhat.com)
+ *
+ * All rights reserved.
+ *
+ * This software licensed under BSD license, the text of which follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * - Neither the name of the MontaVista Software, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef TOTEMSTATS_H_DEFINED
+#define TOTEMSTATS_H_DEFINED
+
+typedef struct {
+	int is_dirty;
+	time_t last_updated;
+} totem_stats_header_t;
+
+typedef struct {
+	totem_stats_header_t hdr;
+	uint32_t iface_changes;
+} totemnet_stats_t;
+
+typedef struct {
+	uint32_t rx;
+	uint32_t tx;
+	int backlog_calc;
+} totemsrp_token_stats_t;
+
+typedef struct {
+	totem_stats_header_t hdr;
+	uint64_t orf_token_tx;
+	uint64_t orf_token_rx;
+	uint64_t memb_merge_detect_tx;
+	uint64_t memb_merge_detect_rx;
+	uint64_t memb_join_tx;
+	uint64_t memb_join_rx;
+	uint64_t mcast_tx;
+	uint64_t mcast_retx;
+	uint64_t mcast_rx;
+	uint64_t memb_commit_token_tx;
+	uint64_t memb_commit_token_rx;
+	uint64_t token_hold_cancel_tx;
+	uint64_t token_hold_cancel_rx;
+	uint64_t operational_entered;
+	uint64_t operational_token_lost;
+	uint64_t gather_entered;
+	uint64_t gather_token_lost;
+	uint64_t commit_entered;
+	uint64_t commit_token_lost;
+	uint64_t recovery_entered;
+	uint64_t recovery_token_lost;
+	uint64_t consensus_timeouts;
+	uint64_t rx_msg_dropped;
+	uint32_t continuous_gather;
+	uint32_t continuous_sendmsg_failures;
+
+	uint8_t  firewall_enabled_or_nic_failure;
+	uint32_t mtt_rx_token;
+	uint32_t avg_token_workload;
+	uint32_t avg_backlog_calc;
+
+	int earliest_token;
+	int latest_token;
+#define TOTEM_TOKEN_STATS_MAX 100
+	totemsrp_token_stats_t token[TOTEM_TOKEN_STATS_MAX];
+
+} totemsrp_stats_t;
+
+typedef struct {
+	totem_stats_header_t hdr;
+	totemsrp_stats_t *srp;
+	uint32_t msg_reserved;
+	uint32_t msg_queue_avail;
+} totempg_stats_t;
+
+
+extern int totemknet_link_get_status (
+	knet_node_id_t node, uint8_t link,
+	struct knet_link_status *status);
+
+#endif /* TOTEMSTATS_H_DEFINED */

--- a/lib/cmap.c
+++ b/lib/cmap.c
@@ -1072,3 +1072,43 @@ error_put:
 
 	return (error);
 }
+
+cs_error_t cmap_set_current_map (
+	cmap_handle_t handle,
+	cmap_map_t new_map)
+{
+	cs_error_t error;
+	struct iovec iov[1];
+	struct cmap_inst *cmap_inst;
+	struct req_lib_cmap_set_current_map req_lib_cmap_set_current_map;
+	struct qb_ipc_response_header res_lib_cmap_set_current_map;
+
+
+	error = hdb_error_to_cs(hdb_handle_get (&cmap_handle_t_db, handle, (void *)&cmap_inst));
+	if (error != CS_OK) {
+		return (error);
+	}
+
+	memset(&req_lib_cmap_set_current_map, 0, sizeof(req_lib_cmap_set_current_map));
+	req_lib_cmap_set_current_map.header.size = sizeof(req_lib_cmap_set_current_map);
+	req_lib_cmap_set_current_map.header.id = MESSAGE_REQ_CMAP_SET_CURRENT_MAP;
+	req_lib_cmap_set_current_map.new_map = new_map;
+
+	iov[0].iov_base = (char *)&req_lib_cmap_set_current_map;
+	iov[0].iov_len = sizeof(req_lib_cmap_set_current_map);
+
+	error = qb_to_cs_error(qb_ipcc_sendv_recv(
+		cmap_inst->c,
+		iov,
+		1,
+		&res_lib_cmap_set_current_map,
+		sizeof (res_lib_cmap_set_current_map), CS_IPC_TIMEOUT_MS));
+
+	if (error == CS_OK) {
+		error = res_lib_cmap_set_current_map.error;
+	}
+
+	(void)hdb_handle_put (&cmap_handle_t_db, handle);
+
+	return (error);
+}

--- a/man/corosync-cmapctl.8
+++ b/man/corosync-cmapctl.8
@@ -35,9 +35,17 @@
 .SH NAME
 corosync-cmapctl: \- A tool for accessing the object database.
 .SH DESCRIPTION
-usage:  corosync\-cmapctl [\-b] [\-DdghsTt] [\-p filename] [params...]
+usage:  corosync\-cmapctl [\-b] [\-DdghsTt] [\-m map] [\-p filename] [params...]
 .HP
 \fB\-b\fR show binary values
+.HP
+\fB\-m\fR select map to use
+.IP
+The default map is 'icmap' which contains configuration information and some runtime variables
+used by corosync. A 'stats' map is also available which displays network statistics - in 
+great detail when knet is used as the transport. Tracking of individual keys (but not prefixes) 
+works on the stats map but notifications are sent on a timer, and not every time a value changes.
+
 .SS "Set key:"
 .IP
 corosync\-cmapctl \fB\-s\fR key_name type value

--- a/tools/corosync-cmapctl.c
+++ b/tools/corosync-cmapctl.c
@@ -100,6 +100,9 @@ static int print_help(void)
 	printf("\n");
 	printf("    -b show binary values\n");
 	printf("\n");
+	printf("    map can be 'icmap', 'default' or 'stats'\n");
+	printf("    the default is 'icmap'\n");
+	printf("\n");
 	printf("Set key:\n");
 	printf("    corosync-cmapctl -s key_name type value\n");
 	printf("\n");

--- a/tools/corosync-cmapctl.c
+++ b/tools/corosync-cmapctl.c
@@ -96,7 +96,7 @@ static int convert_name_to_type(const char *name)
 static int print_help(void)
 {
 	printf("\n");
-	printf("usage:  corosync-cmapctl [-b] [-DdghsTt] [-p filename] [params...]\n");
+	printf("usage:  corosync-cmapctl [-b] [-DdghsTt] [-p filename] [-m map] [params...]\n");
 	printf("\n");
 	printf("    -b show binary values\n");
 	printf("\n");
@@ -745,6 +745,8 @@ int main(int argc, char *argv[])
 	int i;
 	size_t value_len;
 	cmap_value_types_t type;
+	cmap_map_t map = CMAP_MAP_DEFAULT;
+	int map_set = 0;
 	int track_prefix;
 	int no_retries;
 	char * settings_file = NULL;
@@ -752,7 +754,7 @@ int main(int argc, char *argv[])
 	action = ACTION_PRINT_PREFIX;
 	track_prefix = 1;
 
-	while ((c = getopt(argc, argv, "hgsdDtTbp:")) != -1) {
+	while ((c = getopt(argc, argv, "m:hgsdDtTbp:")) != -1) {
 		switch (c) {
 		case 'h':
 			return print_help();
@@ -783,6 +785,21 @@ int main(int argc, char *argv[])
 		case 'T':
 			action = ACTION_TRACK;
 			break;
+		case 'm':
+			if (strcmp(optarg, "icmap") == 0 ||
+			    strcmp(optarg, "default") == 0) {
+				map = CMAP_MAP_ICMAP;
+				map_set = 1;
+			}
+			if (strcmp(optarg, "stats") == 0) {
+				map = CMAP_MAP_STATS;
+				map_set = 1;
+			}
+			if (!map_set) {
+				fprintf(stderr, "invalid map name, must be 'default', 'icmap' or 'stats'\n");
+				return (EXIT_FAILURE);
+			}
+			break;
 		case '?':
 			return (EXIT_FAILURE);
 			break;
@@ -792,7 +809,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (argc == 1 || (argc == 2 && show_binary)) {
+	if (argc == 1 || (argc == 2 && show_binary) || (argc == 2 && map_set)) {
 		action = ACTION_PRINT_ALL;
 	}
 
@@ -814,6 +831,14 @@ int main(int argc, char *argv[])
 	if (err != CS_OK) {
 		fprintf (stderr, "Failed to initialize the cmap API. Error %s\n", cs_strerror(err));
 		exit (EXIT_FAILURE);
+	}
+
+	if (map_set) {
+		err = cmap_set_current_map(handle, map);
+		if (err != CS_OK) {
+			fprintf (stderr, "Failed to set the map. error %s\n", cs_strerror(err));
+			exit (EXIT_FAILURE);
+		}
 	}
 
 	switch (action) {


### PR DESCRIPTION
Change cmap so it can use multiple different 'maps', and add an API call to change the current map.

Then add a 'stats' map that allows access to the multitude of knet and SRP statistics. These are generated (or rather requested from the subsystems) on-the-fly rather than constantly updating icmap.