### PR TITLE
main: Add support for libcgroup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -416,6 +416,10 @@ AC_ARG_ENABLE([qnetd],
 	[  --enable-qnetd                  : Quorum Net Daemon support ],,
 	[ enable_qnetd="no" ])
 AM_CONDITIONAL(BUILD_QNETD, test x$enable_qnetd = xyes)
+AC_ARG_ENABLE([libcgroup],
+	[  --enable-libcgroup                  : Enable libcgroup support ],,
+	[ enable_libcgroup="no" ])
+AM_CONDITIONAL(ENABLE_LIBCGROUP, test x$enable_libcgroup = xyes)
 
 # *FLAGS handling goes here
 
@@ -547,6 +551,13 @@ if test "x${enable_snmp}" = xyes; then
 	fi
 fi
 AM_CONDITIONAL(BUILD_SNMP, test "${do_snmp}" = "1")
+
+if test "x${enable_libcgroup}" = xyes; then
+    PKG_CHECK_MODULES([libcgroup], [libcgroup])
+    AC_DEFINE_UNQUOTED([HAVE_LIBCGROUP], 1, [have libcgroup])
+    PACKAGE_FEATURES="$PACKAGE_FEATURES libcgroup"
+    WITH_LIST="$WITH_LIST --with libcgroup"
+fi
 
 # extra warnings
 EXTRA_WARNINGS=""

--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -17,6 +17,7 @@
 %bcond_with runautogen
 %bcond_with qdevices
 %bcond_with qnetd
+%bcond_with libcgroup
 
 %global gitver %{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}
 %global gittarver %{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}
@@ -74,6 +75,9 @@ Requires: nss-tools
 %if %{with qnetd}
 BuildRequires: sed
 %endif
+%if %{with libcgroup}
+BuildRequires: libcgroup-devel
+%endif
 
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
@@ -124,6 +128,9 @@ export rdmacm_LIBS=-lrdmacm \
 %endif
 %if %{with qnetd}
 	--enable-qnetd \
+%endif
+%if %{with libcgroup}
+	--enable-libcgroup \
 %endif
 	--with-initddir=%{_initrddir} \
 	--with-systemddir=%{_unitdir} \

--- a/exec/Makefile.am
+++ b/exec/Makefile.am
@@ -78,5 +78,10 @@ corosync_LDADD		= libtotem_pg.la ../common_lib/libcorosync_common.la \
 
 corosync_DEPENDENCIES	= libtotem_pg.la ../common_lib/libcorosync_common.la
 
+if ENABLE_LIBCGROUP
+corosync_CFLAGS		+= $(libcgroup_CFLAGS)
+corosync_LDADD		+= $(libcgroup_LIBS)
+endif
+
 lint:
 	-splint $(LINT_FLAGS) $(CPPFLAGS) $(CFLAGS) *.c

--- a/man/corosync.8
+++ b/man/corosync.8
@@ -35,7 +35,7 @@
 .SH NAME
 corosync \- The Corosync Cluster Engine.
 .SH SYNOPSIS
-.B "corosync [\-f] [\-P num] [\-p] [\-r] [\-t] [\-v]"
+.B "corosync [\-f] [\-P num] [\-p] [\-r] [-R] [\-t] [\-v]"
 .SH DESCRIPTION
 .B corosync
 Corosync provides clustering infrastructure such as membership, messaging and quorum.
@@ -61,6 +61,10 @@ meaning maximal / minimal priority (so minimal / maximal nice value).
 .B -r
 Set round robin realtime scheduling with maximal priority (default). When setting
 of scheduler fails, fallback to set maximal priority.
+.TP
+.B -R
+Do not try to move Corosync to root cpu cgroup. This feature is available only
+for corosync with libcgroup enabled during the build.
 .TP
 .B -t
 Test configuration and then exit.


### PR DESCRIPTION
When corosync is started in environment where it ends in cgroup without
properly set rt_runtime_us it's impossible to get RT priority.

Already implemented workaround is to use higher non-RT priority.

This patch implements another solution. It moves corosync into root cpu
cgroup. Root cpu cgroup hopefully has enough RT budget.

Another solution was mentioned on ML
https://lists.freedesktop.org/archives/systemd-devel/2017-July/039353.html
but this means to generate some "random" values.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>