### PR TITLE
stats: add knet 'handle' stats

### DIFF
--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -1273,6 +1273,17 @@ int totemknet_link_get_status (
 	return (ret);
 }
 
+int totemknet_handle_get_stats (
+	struct knet_handle_stats *stats)
+{
+	/* We are probably not using knet */
+	if (!global_instance) {
+		return CS_ERR_NOT_EXIST;
+	}
+
+	return knet_handle_get_stats(global_instance->knet_handle, stats, sizeof(struct knet_handle_stats));
+}
+
 static void timer_function_merge_detect_timeout (
 	void *data)
 {

--- a/include/corosync/totem/totemstats.h
+++ b/include/corosync/totem/totemstats.h
@@ -102,6 +102,9 @@ extern int totemknet_link_get_status (
 	knet_node_id_t node, uint8_t link,
 	struct knet_link_status *status);
 
+int totemknet_handle_get_stats (
+	struct knet_handle_stats *stats);
+
 void stats_knet_add_member(knet_node_id_t nodeid, uint8_t link);
 
 void stats_knet_del_member(knet_node_id_t nodeid, uint8_t link);


### PR DESCRIPTION
knet handle stats show compression and crypto statistics. With these
you can see the effectiveness of compression and the overheads of both
crypto and compression.

I left compression stats in (even though corosync doesn't support knet compression) as we might add it in future.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>