### PR TITLE
Include fcntl.h for F_* and O_* defines

### DIFF
--- a/qdevices/utils.c
+++ b/qdevices/utils.c
@@ -39,6 +39,7 @@
 
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <libgen.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixes errors like
utils.c:95:22: error: use of undeclared identifier 'O_WRONLY'

Signed-off-by: Khem Raj <raj.khem@gmail.com>