### PR TITLE
corosync.conf.5: watchdog support is conditional

### DIFF
--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -691,6 +691,8 @@ directive it is possible to specify options for resources.
 Possible option is:
 .TP
 watchdog_device
+(Valid only if Corosync was compiled with watchdog support.)
+.br
 Watchdog device to use.
 The default value is /dev/watchdog.
 The special value "off" disables watchdog usage.


### PR DESCRIPTION
Signed-off-by: Ferenc Wágner <wferi@debian.org>
Reviewed-by: Jan Friesse <jfriesse@redhat.com>