### PR TITLE
votequorum: make auto-tie-breaker consistent on cluster membership changes

### DIFF
--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -81,7 +81,7 @@ static uint8_t two_node = 0;
 static uint8_t wait_for_all = 0;
 static uint8_t wait_for_all_status = 0;
 
-static enum {ATB_NONE, ATB_LOWEST, ATB_HIGHEST, ATB_LIST} auto_tie_breaker = ATB_NONE;
+static enum {ATB_NONE, ATB_LOWEST, ATB_HIGHEST, ATB_LIST} auto_tie_breaker = ATB_NONE, initial_auto_tie_breaker = ATB_NONE;
 static int lowest_node_id = -1;
 static int highest_node_id = -1;
 
@@ -1253,6 +1253,13 @@ static char *votequorum_readconfig(int runtime)
 	if (runtime) {
 		two_node = 0;
 		expected_votes = 0;
+		/* auto_tie_breaker cannot be changed by config reload, but
+		 * we automatically disable it on odd-sized clusters without
+		 * wait_for_all.
+		 * We may need to re-enable it when membership changes to ensure
+		 * that auto_tie_breaker is consistent across all nodes */
+		auto_tie_breaker = initial_auto_tie_breaker;
+		icmap_set_uint32("runtime.votequorum.atb_type", auto_tie_breaker);
 	}
 
 	/*
@@ -1331,6 +1338,7 @@ static char *votequorum_readconfig(int runtime)
 			parse_atb_string(atb_string);
 		}
 		free(atb_string);
+		initial_auto_tie_breaker = auto_tie_breaker;
 
 		/* allow_downscale requires ev_tracking */
 		if (allow_downscale) {


### PR DESCRIPTION
Steps to reproduce:

```
pcs cluster setup --name cluster node1 node2 --auto_tie_breaker=1
pcs stonith sbd enable
pcs cluster start --all
pcs property set stonith-watchdog-timeout=10s
pcs cluster node add node3 --start
pcs cluster node add node4 --start
```

Actual result:
- `auto_tie_breaker` is reported inconsistently across the cluster according to `corosync-quorumtool`, only the newly added node considers auto tie breaker to be on
- if you cause a network partition at the switch level between nodes 1,2 and 3,4 then the whole cluster fences because node 1 thinks it is not in auto tie breaker mode
- same problem if you do a `pcs cluster stop --force` on nodes 3 and  4 instead of the partition

Expected result:

- whenever the cluster is even sized `auto-tie-breaker` should be enabled as the `corosync.conf` says
- a 2 / 2 network partition on a cluster with tie breaker enabled should leave 2 nodes alive

Reproduced on corosync `2.4.0-9` on CentOS 7.4.

A similar situation occurs if you grow a 1 node  cluster to 2 node, but the 2nd node doesn't start soon enough that I reported on the mailing list.

Upon reading the manpage I would've expected `auto_tie_breaker` to work only on even sized clusters, so my patch just reloads the initial value on nodelist changes and then lets corosync decide again whether it should disable `auto_tie_breaker` (due to odd-sized cluster and no `wait_for_all`).
This fixed the problem described above, but may not be the cleanest way.

Tried to reproduce the problem with `vqsim` but since it doesn't support nodelist  changes I haven't found a way.

Perhaps the manpage should also be updated to take into account https://github.com/corosync/corosync/issues/74#issuecomment-109980323 and document the behaviour of `auto_tie_breaker` with odd-sized  clusters and `wait-for-all` , should  I submit that as a separate PR?