### PR TITLE
totemudp: Do not discard memb_join messages at udp layer

### DIFF
--- a/exec/totemudp.c
+++ b/exec/totemudp.c
@@ -88,8 +88,6 @@
 #define BIND_STATE_REGULAR	1
 #define BIND_STATE_LOOPBACK	2
 
-#define MESSAGE_TYPE_MEMB_JOIN	3
-
 struct totemudp_socket {
 	int mcast_recv;
 	int mcast_send;
@@ -454,7 +452,6 @@ static int net_deliver_fn (
 	struct sockaddr_storage system_from;
 	int bytes_received;
 	int res = 0;
-	char *message_type;
 
 	if (instance->flushing == 1) {
 		iovec = &instance->totemudp_iov_recv_flush;
@@ -504,17 +501,6 @@ static int net_deliver_fn (
 		return 0;
 	}
 	iovec->iov_len = bytes_received;
-
-	/*
-	 * Drop all non-mcast messages (more specifically join
-	 * messages should be dropped)
-	 */
-	message_type = (char *)iovec->iov_base;
-	if (instance->flushing == 1 && *message_type == MESSAGE_TYPE_MEMB_JOIN) {
-		log_printf(instance->totemudp_log_level_warning, "JOIN or LEAVE message was thrown away during flush operation.");
-		iovec->iov_len = FRAME_SIZE_MAX;
-		return (0);
-	}
 
 	/*
 	 * Handle incoming message


### PR DESCRIPTION
According to the https://github.com/corosync/corosync/commit/ab8942f6260fde93824ed2a18e09e572b59ceb25 , since totemsrp discards memb_join messages when flushing, I think it is unnecessary in totemudp.

If two nodes are stopped at the same time, the LEAVE message may be discarded here and a log indicating that it has not stopped cleanly may be output in some cases.
```
Sep 26 06:50:37 rhel69-3 corosync[22608]:  [TOTEM ] Failed to receive the leave message. failed: 3232261507
```

- node-1
    ```
    Sep 26 06:50:33 rhel69-1 pacemakerd[8821]:   notice: Caught 'Terminated' signal
    Sep 26 06:50:33 rhel69-1 pacemakerd[8821]:   notice: Shutting down Pacemaker
    (snip)
    Sep 26 06:50:34 rhel69-1 pacemakerd[8821]:     info: Exiting pacemakerd
    Sep 26 06:50:34 rhel69-1 pacemakerd[8821]:     info: Cleaning up memory from libxml2
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [MAIN  ] Node was shut down by a signal
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [SERV  ] Unloading all Corosync service engines.
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [SERV  ] Service engine unloaded: corosync vote quorum service v1.0
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [SERV  ] Service engine unloaded: corosync configuration map access
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [SERV  ] Service engine unloaded: corosync configuration service
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [SERV  ] Service engine unloaded: corosync cluster closed process group service v1.01
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [SERV  ] Service engine unloaded: corosync cluster quorum service v0.1
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [SERV  ] Service engine unloaded: corosync profile loading service
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [SERV  ] Service engine unloaded: corosync watchdog service
    Sep 26 06:50:34 rhel69-1 corosync[8812]:  [MAIN  ] Corosync Cluster Engine exiting normally
    ```
- node-2
    ```
    Sep 26 06:50:33 rhel69-3 crmd[22639]:     info: handle_request: Node rhel69-1[3232261507] - expected state is now down (was member)
    Sep 26 06:50:33 rhel69-3 crmd[22639]:     info: Creating shutdown request for rhel69-1 (state=S_IDLE)
    (snip)
    Sep 26 06:50:33 rhel69-3 pacemakerd[22617]:   notice: Caught 'Terminated' signal
    Sep 26 06:50:33 rhel69-3 pacemakerd[22617]:   notice: Shutting down Pacemaker
    (snip. the stop process of resources begins.)
    Sep 26 06:50:34 rhel69-3 corosync[22608]:  [TOTEM ] JOIN or LEAVE message was thrown away during flush operation.
    Sep 26 06:50:34 rhel69-3 corosync[22608]:  [TOTEM ] JOIN or LEAVE message was thrown away during flush operation.
    Sep 26 06:50:35 rhel69-3 corosync[22608]:  [TOTEM ] A processor failed, forming new configuration.
    Sep 26 06:50:37 rhel69-3 corosync[22608]:  [TOTEM ] A new membership (192.168.101.133:12) was formed. Members left: 3232261507

    Sep 26 06:50:37 rhel69-3 corosync[22608]:  [TOTEM ] Failed to receive the leave message. failed: 3232261507

    Sep 26 06:50:37 rhel69-3 corosync[22608]:  [QUORUM] This node is within the non-primary component and will NOT provide any services.
    Sep 26 06:50:37 rhel69-3 corosync[22608]:  [QUORUM] Members[1]: 3232261509
    Sep 26 06:50:37 rhel69-3 corosync[22608]:  [MAIN  ] Completed service synchronization, ready to provide service.
    (snip)
    Sep 26 06:50:38 rhel69-3 pacemakerd[22617]:     info: Exiting pacemakerd
    Sep 26 06:50:38 rhel69-3 pacemakerd[22617]:     info: Cleaning up memory from libxml2
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [MAIN  ] Node was shut down by a signal
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [SERV  ] Unloading all Corosync service engines.
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [SERV  ] Service engine unloaded: corosync vote quorum service v1.0
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [SERV  ] Service engine unloaded: corosync configuration map access
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [SERV  ] Service engine unloaded: corosync configuration service
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [SERV  ] Service engine unloaded: corosync cluster closed process group service v1.01
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [QB    ] withdrawing server sockets
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [SERV  ] Service engine unloaded: corosync cluster quorum service v0.1
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [SERV  ] Service engine unloaded: corosync profile loading service
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [SERV  ] Service engine unloaded: corosync watchdog service
    Sep 26 06:50:38 rhel69-3 corosync[22608]:  [MAIN  ] Corosync Cluster Engine exiting normally
    ```