### PR TITLE
cmap: don't shutdown node with highest config_version

### DIFF
--- a/exec/cmap.c
+++ b/exec/cmap.c
@@ -430,11 +430,12 @@ static void cmap_sync_init (
 
 	cmap_sync_trans_list_entries = trans_list_entries;
 	cmap_sync_member_list_entries = member_list_entries;
-	cmap_highest_config_version_received = 0;
 
 	if (icmap_get_uint64("totem.config_version", &cmap_my_config_version) != CS_OK) {
 		cmap_my_config_version = 0;
 	}
+
+	cmap_highest_config_version_received = cmap_my_config_version;
 }
 
 static int cmap_sync_process (void)


### PR DESCRIPTION
Scenario:
 1. node A starts corosync with config_version = 2, nodelist = {A, B}, then
 2. node B starts corosync with config_version = 1, nodelist = {A, B}

corosync.conf(5) says the config_version option is "used to prevent joining old
nodes with not up-to-date configuration."

So expected outcome is:
 * corosync on node A remains alive
 * corosync on node B exits

Actual outcome is:
 * corosync on node A exits
 * corosync on node B exits

Explanation of actual behaviour:
 * Host A will have cmap_my_config_version = 2 but
   cmap_highest_config_version_received = 1, so will shutdown in
   cmap_sync_activate because these are not equal.
 * Host B will have cmap_my_config_version = 1 but
   cmap_highest_config_version_received = 2, so will shutdown in
   cmap_sync_activate because these are not equal.

Instead, node A should consider its own config_version in the calculation of the
highest config_version, i.e. cmap_highest_config_version_received = 2, and so
not shutdown in cmap_sync_activate.