### PR TITLE
Spec: fix arch-qualified dependencies

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -33,7 +33,7 @@ Source0: http://build.clusterlabs.org/corosync/releases/%{name}-%{version}%{?git
 
 # Runtime bits
 # The automatic dependency overridden in favor of explicit version lock
-Requires: corosynclib{?_isa} = %{version}-%{release}
+Requires: corosynclib%{?_isa} = %{version}-%{release}
 Requires(pre): /usr/sbin/useradd
 Requires(post): /sbin/chkconfig
 Requires(preun): /sbin/chkconfig
@@ -383,7 +383,7 @@ Summary: The Corosync Cluster Engine Qdevice
 Group: System Environment/Base
 Requires: %{name} = %{version}-%{release}
 # The automatic dependency overridden in favor of explicit version lock
-Requires: corosynclib{?_isa} = %{version}-%{release}
+Requires: corosynclib%{?_isa} = %{version}-%{release}
 Requires: nss-tools
 
 %if %{with systemd}


### PR DESCRIPTION
RPM installation of corosync fails if it's built from the latest repository:
```
[root@build-centos71 x86_64 (needle)]# yum install corosync-2.4.2-1.45.2fbb.el7.x86_64.rpm corosynclib-2.4.2-1.45.2fbb.el7.x86_64.rpm corosynclib-devel-2.4.2-1.45.2fbb.el7.x86_64.rpm 
(...)
Error: Package: corosync-2.4.2-1.45.2fbb.el7.x86_64 (/corosync-2.4.2-1.45.2fbb.el7.x86_64)
           Requires: corosynclib{?_isa} = 2.4.2-1.45.2fbb.el7
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
[root@build-centos71 x86_64 (needle)]# 
``` 
It is apparently related to the commit 30af25294e019678c4f31e3368b19266f69b8254 .
The same fix seems to be needed both for master and needle branches.
