### PR TITLE
Delegate & avoid redundancy wrt. libqb's callsite section checking

### DIFF
--- a/include/corosync/logsys.h
+++ b/include/corosync/logsys.h
@@ -269,6 +269,7 @@ static int logsys_subsys_id __attribute__((unused)) = LOGSYS_MAX_SUBSYS_COUNT;
  * @param syslog_priority
  */
 #define LOGSYS_DECLARE_SYSTEM(name,mode,syslog_facility,syslog_priority)\
+QB_LOG_INIT_DATA(logsys_qb_init);					\
 __attribute__ ((constructor))						\
 static void logsys_system_init (void)					\
 {									\
@@ -279,12 +280,6 @@ static void logsys_system_init (void)					\
 	}								\
 }
 
-#ifdef QB_HAVE_ATTRIBUTE_SECTION
-#define LOGSYS_DECLARE_SECTION assert(__start___verbose != __stop___verbose)
-#else
-#define LOGSYS_DECLARE_SECTION
-#endif
-
 /**
  * @brief The LOGSYS_DECLARE_SUBSYS macro
  * @param subsys
@@ -293,7 +288,6 @@ static void logsys_system_init (void)					\
 __attribute__ ((constructor))						\
 static void logsys_subsys_init (void)					\
 {									\
-	LOGSYS_DECLARE_SECTION;						\
 	logsys_subsys_id =						\
 		_logsys_subsys_create ((subsys), __FILE__);		\
 	if (logsys_subsys_id == -1) {					\


### PR DESCRIPTION
Previously, corosync executable was repeatedly (proportionally to the
count of LOGSYS_DECLARE_SUBSYS macro applications involved in the
constituent source files) checking the same for no gain in the pre-main
startup.  This is not needed since nothing changes with static data
shared withing the same program space (it may have been a different
story once upon a time if loadable modules were in use), so make that
happen in (one-off per executable) LOGSYS_DECLARE_SYSTEM instead.

And as of 7+ years ago, libqb offers it's own ready-made macro to that
effect, simply to isolate the inner percularities from the library user
(that should not be required to understand anything about the orphan
sections and respective autocreated symbols to denote their boundaries).
As it is compile-time conditionalized in the same way, just use it
directly instead.  As a value added, corosync will be kept up to date
about the possibly growing set of the logging-sanity checks as it gets
compiled with newer and newer libqb versions (their header files, for
that matter).

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>