### PR TITLE
add nodeid check for knet

### DIFF
--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -625,6 +625,10 @@ static void timer_function_netif_check_timeout (
 		if (!instance->totem_config->interfaces[i].configured) {
 			continue;
 		}
+		if (!instance->my_ids[i].nodeid) {
+			libknet_log_printf(LOGSYS_LEVEL_ERROR, "With knet, you must specify nodeid for each node in nodelist");
+			corosync_exit_error(COROSYNC_DONE_FATAL_ERR);
+		}
 		instance->totemknet_iface_change_fn (instance->context,
 						     &instance->my_ids[i],
 						     i);

--- a/man/corosync-qdevice.8
+++ b/man/corosync-qdevice.8
@@ -139,7 +139,7 @@ value.
 defines executables.
 .I NAME
 can be arbitrary valid cmap key name string and it has no special meaning.
-The value of this variable must contain a command to execute. The alue is parsed (split)
+The value of this variable must contain a command to execute. The value is parsed (split)
 into arguments similarly as Bourne shell would do. Quoting is possible by
 using backslash and double quotes.
 


### PR DESCRIPTION
As described in 83467ac, corosync will abort when nodeid is not set with
knet, this patch gives warnings to set nodeid in knet.