### PR TITLE
Introduce --configdir (idea stolen from Pacemaker)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -365,6 +365,13 @@ AC_ARG_ENABLE([upstart],
 	[ enable_upstart="no" ])
 AM_CONDITIONAL(INSTALL_UPSTART, test x$enable_upstart = xyes)
 
+AC_ARG_WITH([initconfigdir],
+	[AS_HELP_STRING([--with-initconfigdir=DIR],
+		[configuration directory @<:@SYSCONFDIR/sysconfig@:>@])],
+	[INITCONFIGDIR="$withval"],
+	[INITCONFIGDIR='${sysconfdir}/sysconfig'])
+AC_SUBST([INITCONFIGDIR])
+
 AC_ARG_WITH([initddir],
 	[  --with-initddir=DIR     : path to init script directory. ],
 	[ INITDDIR="$withval" ],
@@ -777,6 +784,7 @@ AC_MSG_RESULT([  System tmpfiles.d        = ${TMPFILESDIR}])
 AC_MSG_RESULT([  Log directory            = ${LOGDIR}])
 AC_MSG_RESULT([  Log rotate directory     = ${LOGROTATEDIR}])
 AC_MSG_RESULT([  corosync config dir      = ${COROSYSCONFDIR}])
+AC_MSG_RESULT([  init config directory    = ${INITCONFIGDIR}])
 AC_MSG_RESULT([  Features                 =${PACKAGE_FEATURES}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([$PACKAGE build info:])

--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -76,6 +76,7 @@ endif
 		-e 's#@''SBINDIR@#$(sbindir)#g' \
 		-e 's#@''BINDIR@#$(bindir)#g' \
 		-e 's#@''SYSCONFDIR@#$(sysconfdir)#g' \
+		-e 's#@''INITCONFIGDIR@#$(INITCONFIGDIR)#g' \
 		-e 's#@''INITDDIR@#$(INITDDIR)#g' \
 		-e 's#@''INITWRAPPERSDIR@#$(INITWRAPPERSDIR)#g' \
 		-e 's#@''LOCALSTATEDIR@#$(localstatedir)#g' \

--- a/init/corosync-notifyd.conf.in
+++ b/init/corosync-notifyd.conf.in
@@ -6,14 +6,12 @@ expect fork
 respawn
 
 env prog=corosync-notifyd
-env rpm_sysconf=@SYSCONFDIR@/sysconfig/corosync-notifyd
+env initconf=@INITCONFIGDIR@/corosync-notifyd
 env rpm_lockfile=@LOCALSTATEDIR@/lock/subsys/corosync-notifyd
-env deb_sysconf=@SYSCONFDIR@/default/corosync-notifyd
 env deb_lockfile=@LOCALSTATEDIR@/lock/corosync-notifyd
 
 script
-    [ -f "$rpm_sysconf" ] && . $rpm_sysconf
-    [ -f "$deb_sysconf" ] && . $deb_sysconf
+    [ -f "$initconf" ] && . $initconf
     exec $prog $OPTIONS
 end script
 
@@ -22,16 +20,14 @@ pre-start script
 end script
 
 post-start script
-    [ -f "$rpm_sysconf" ] && . $rpm_sysconf
-    [ -f "$deb_sysconf" ] && . $deb_sysconf
+    [ -f "$initconf" ] && . $initconf
     [ -z "$LOCK_FILE" -a -d @SYSCONFDIR@/sysconfig ] && LOCK_FILE="$rpm_lockfile"
     [ -z "$LOCK_FILE" -a -d @SYSCONFDIR@/default ] && LOCK_FILE="$deb_lockfile"
     touch $LOCK_FILE
 end script
 
 post-stop script
-    [ -f "$rpm_sysconf" ] && . $rpm_sysconf
-    [ -f "$deb_sysconf" ] && . $deb_sysconf
+    [ -f "$initconf" ] && . $initconf
     [ -z "$LOCK_FILE" -a -d @SYSCONFDIR@/sysconfig ] && LOCK_FILE="$rpm_lockfile"
     [ -z "$LOCK_FILE" -a -d @SYSCONFDIR@/default ] && LOCK_FILE="$deb_lockfile"
     rm -f $LOCK_FILE

--- a/init/corosync-notifyd.in
+++ b/init/corosync-notifyd.in
@@ -49,16 +49,13 @@ status()
 
 [ -f @INITCONFIGDIR@/$prog ] && . @INITCONFIGDIR@/$prog
 
-# rpm based distros
-if [ -d @SYSCONFDIR@/sysconfig ]; then
+case '@INITCONFIGDIR@' in
+    */sysconfig) # rpm based distros
 	[ -f @INITDDIR@/functions ] && . @INITDDIR@/functions
-	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog"
-fi
-
-# deb based distros
-if [ -d @SYSCONFDIR@/default ]; then
-	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
-fi
+	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog";;
+    */default) # deb based distros
+	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog";;
+esac
 
 # The version of __pids_pidof in /etc/init.d/functions calls pidof with -x
 # This means it matches scripts, including this one.

--- a/init/corosync-notifyd.in
+++ b/init/corosync-notifyd.in
@@ -47,16 +47,16 @@ status()
 	return $rtrn
 }
 
+[ -f @INITCONFIGDIR@/$prog ] && . @INITCONFIGDIR@/$prog
+
 # rpm based distros
 if [ -d @SYSCONFDIR@/sysconfig ]; then
 	[ -f @INITDDIR@/functions ] && . @INITDDIR@/functions
-	[ -f @SYSCONFDIR@/sysconfig/$prog ] && . @SYSCONFDIR@/sysconfig/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog"
 fi
 
 # deb based distros
 if [ -d @SYSCONFDIR@/default ]; then
-	[ -f @SYSCONFDIR@/default/$prog ] && . @SYSCONFDIR@/default/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
 fi
 

--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -5,7 +5,7 @@ Wants=corosync.service
 After=corosync.service
 
 [Service]
-EnvironmentFile=@SYSCONFDIR@/sysconfig/corosync-notifyd
+EnvironmentFile=-@INITCONFIGDIR@/corosync-notifyd
 ExecStart=@SBINDIR@/corosync-notifyd -f $OPTIONS
 Type=simple
 Restart=on-failure

--- a/init/corosync-qdevice.in
+++ b/init/corosync-qdevice.in
@@ -49,16 +49,13 @@ status()
 
 [ -f @INITCONFIGDIR@/$prog ] && . @INITCONFIGDIR@/$prog
 
-# rpm based distros
-if [ -d @SYSCONFDIR@/sysconfig ]; then
+case '@INITCONFIGDIR@' in
+    */sysconfig) # rpm based distros
 	[ -f @INITDDIR@/functions ] && . @INITDDIR@/functions
-	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog"
-fi
-
-# deb based distros
-if [ -d @SYSCONFDIR@/default ]; then
-	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
-fi
+	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog";;
+    */default) # deb based distros
+	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog";;
+esac
 
 # The version of __pids_pidof in /etc/init.d/functions calls pidof with -x
 # This means it matches scripts, including this one.

--- a/init/corosync-qdevice.in
+++ b/init/corosync-qdevice.in
@@ -47,16 +47,16 @@ status()
 	return $res
 }
 
+[ -f @INITCONFIGDIR@/$prog ] && . @INITCONFIGDIR@/$prog
+
 # rpm based distros
 if [ -d @SYSCONFDIR@/sysconfig ]; then
 	[ -f @INITDDIR@/functions ] && . @INITDDIR@/functions
-	[ -f @SYSCONFDIR@/sysconfig/$prog ] && . @SYSCONFDIR@/sysconfig/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog"
 fi
 
 # deb based distros
 if [ -d @SYSCONFDIR@/default ]; then
-	[ -f @SYSCONFDIR@/default/$prog ] && . @SYSCONFDIR@/default/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
 fi
 

--- a/init/corosync-qnetd.in
+++ b/init/corosync-qnetd.in
@@ -49,16 +49,13 @@ status()
 
 [ -f @INITCONFIGDIR@/$prog ] && . @INITCONFIGDIR@/$prog
 
-# rpm based distros
-if [ -d @SYSCONFDIR@/sysconfig ]; then
+case '@INITCONFIGDIR@' in
+    */sysconfig) # rpm based distros
 	[ -f @INITDDIR@/functions ] && . @INITDDIR@/functions
-	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog"
-fi
-
-# deb based distros
-if [ -d @SYSCONFDIR@/default ]; then
-	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
-fi
+	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog";;
+    */default) # deb based distros
+	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog";;
+esac
 
 # The version of __pids_pidof in /etc/init.d/functions calls pidof with -x
 # This means it matches scripts, including this one.

--- a/init/corosync-qnetd.in
+++ b/init/corosync-qnetd.in
@@ -47,16 +47,16 @@ status()
 	return $res
 }
 
+[ -f @INITCONFIGDIR@/$prog ] && . @INITCONFIGDIR@/$prog
+
 # rpm based distros
 if [ -d @SYSCONFDIR@/sysconfig ]; then
 	[ -f @INITDDIR@/functions ] && . @INITDDIR@/functions
-	[ -f @SYSCONFDIR@/sysconfig/$prog ] && . @SYSCONFDIR@/sysconfig/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog"
 fi
 
 # deb based distros
 if [ -d @SYSCONFDIR@/default ]; then
-	[ -f @SYSCONFDIR@/default/$prog ] && . @SYSCONFDIR@/default/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
 fi
 

--- a/init/corosync-qnetd.service.in
+++ b/init/corosync-qnetd.service.in
@@ -6,7 +6,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-EnvironmentFile=@SYSCONFDIR@/sysconfig/corosync-qnetd
+EnvironmentFile=-@INITCONFIGDIR@/corosync-qnetd
 ExecStart=@BINDIR@/corosync-qnetd -f $COROSYNC_QNETD_OPTIONS
 Type=simple
 Restart=on-abnormal

--- a/init/corosync.conf.in
+++ b/init/corosync.conf.in
@@ -5,14 +5,12 @@
 expect fork
 
 env prog=corosync
-env rpm_sysconf=@SYSCONFDIR@/sysconfig/corosync
+env initconf=@INITCONFIGDIR@/corosync
 env rpm_lockfile=@LOCALSTATEDIR@/lock/subsys/corosync
-env deb_sysconf=@SYSCONFDIR@/default/corosync
 env deb_lockfile=@LOCALSTATEDIR@/lock/corosync
 
 script
-    [ -f "$rpm_sysconf" ] && . $rpm_sysconf
-    [ -f "$deb_sysconf" ] && . $deb_sysconf
+    [ -f "$initconf" ] && . $initconf
     exec $prog $COROSYNC_OPTIONS
 end script
 
@@ -25,8 +23,7 @@ end script
 post-start script
 wait_for_ipc()
 {
-    [ -f "$rpm_sysconf" ] && . $rpm_sysconf
-    [ -f "$deb_sysconf" ] && . $deb_sysconf
+    [ -f "$initconf" ] && . $initconf
     try=0
     max_try=$((COROSYNC_INIT_TIMEOUT*2-1))
     [ "$max_try" -le "0" ] && max_try=120
@@ -43,16 +40,14 @@ wait_for_ipc()
 }
     wait_for_ipc || { stop; exit 1; }
 
-    [ -f "$rpm_sysconf" ] && . $rpm_sysconf
-    [ -f "$deb_sysconf" ] && . $deb_sysconf
+    [ -f "$initconf" ] && . $initconf
     [ -z "$LOCK_FILE" -a -d @SYSCONFDIR@/sysconfig ] && LOCK_FILE="$rpm_lockfile"
     [ -z "$LOCK_FILE" -a -d @SYSCONFDIR@/default ] && LOCK_FILE="$deb_lockfile"
     touch $LOCK_FILE
 end script
 
 post-stop script
-    [ -f "$rpm_sysconf" ] && . $rpm_sysconf
-    [ -f "$deb_sysconf" ] && . $deb_sysconf
+    [ -f "$initconf" ] && . $initconf
     [ -z "$LOCK_FILE" -a -d @SYSCONFDIR@/sysconfig ] && LOCK_FILE="$rpm_lockfile"
     [ -z "$LOCK_FILE" -a -d @SYSCONFDIR@/default ] && LOCK_FILE="$deb_lockfile"
     rm -f $LOCK_FILE

--- a/init/corosync.in
+++ b/init/corosync.in
@@ -48,16 +48,16 @@ status()
 	return $res
 }
 
+[ -f @INITCONFIGDIR@/$prog ] && . @INITCONFIGDIR@/$prog
+
 # rpm based distros
 if [ -d @SYSCONFDIR@/sysconfig ]; then
 	[ -f @INITDDIR@/functions ] && . @INITDDIR@/functions
-	[ -f @SYSCONFDIR@/sysconfig/$prog ] && . @SYSCONFDIR@/sysconfig/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog"
 fi
 
 # deb based distros
 if [ -d @SYSCONFDIR@/default ]; then
-	[ -f @SYSCONFDIR@/default/$prog ] && . @SYSCONFDIR@/default/$prog
 	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
 fi
 

--- a/init/corosync.in
+++ b/init/corosync.in
@@ -50,16 +50,13 @@ status()
 
 [ -f @INITCONFIGDIR@/$prog ] && . @INITCONFIGDIR@/$prog
 
-# rpm based distros
-if [ -d @SYSCONFDIR@/sysconfig ]; then
+case '@INITCONFIGDIR@' in
+    */sysconfig) # rpm based distros
 	[ -f @INITDDIR@/functions ] && . @INITDDIR@/functions
-	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog"
-fi
-
-# deb based distros
-if [ -d @SYSCONFDIR@/default ]; then
-	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog"
-fi
+	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/subsys/$prog";;
+    */default) # deb based distros
+	[ -z "$LOCK_FILE" ] && LOCK_FILE="@LOCALSTATEDIR@/lock/$prog";;
+esac
 
 # The version of __pids_pidof in /etc/init.d/functions calls pidof with -x
 # This means it matches scripts, including this one.


### PR DESCRIPTION
To make the first commit message more explicit:
1. I didn't test the changed SysV init scripts and Upstart files. Debian ships its own init scripts, but even those don't get much testing, because almost everyone uses systemd nowadays, I guess.
2. I think Upstart support should be removed altogether.

These commits cherry-pick cleanly into needle as well.