### PR TITLE
man: support SOURCE_DATE_EPOCH

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -167,7 +167,7 @@ HTML_DOCS 		= $(dist_man_MANS:%=%.html) $(man_MANS:%=%.html)
 %.3: %.3.in $(autogen_common)
 	@echo Generating $@ man page && \
 	rm -f $@-t-t $@-t $@ && \
-	date="$$(LC_ALL=C date "+%F")" && \
+	date="$$(LC_ALL=C date "+%F" $${SOURCE_DATE_EPOCH+-d @$$SOURCE_DATE_EPOCH})" && \
 	awk "{print}(\$$1 ~ /@COMMONIPCERRORS@/){exit 0}" ${top_srcdir}/man/$@.in > $@-t-t && \
 	cat ${top_srcdir}/man/$(autogen_common) >> $@-t-t && \
 	awk -v p=0 "(\$$1 ~ /@COMMONIPCERRORS@/){p = 1} {if(p==1)print}" ${top_srcdir}/man/$@.in >> $@-t-t && \


### PR DESCRIPTION
Make reproducible builds possible by supporting
https://reproducible-builds.org/specs/source-date-epoch/

Signed-off-by: Ferenc Wágner <wferi@debian.org>

This commit cherry-pick cleanly to needle as well.