### PR TITLE
pkgconfig: the libraries require the libcorosync_common package

### DIFF
--- a/pkgconfig/libtemplate.pc.in
+++ b/pkgconfig/libtemplate.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: @LIB@
 Version: @LIBVERSION@
 Description: @LIB@
-Requires:
+Requires.private: libcorosync_common
 Libs: -L${libdir} -l@LIB@
 Cflags: -I${includedir}


### PR DESCRIPTION
Various library header files include headers from the common module,
and the transitive dependencies must be specified for static linking.
The self-dependency of libcorosync_common does not cause problems.

Signed-off-by: Ferenc Wágner <wferi@debian.org>

This commit cherry-picks cleanly into needle.