### PR TITLE
Systemd notification support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -386,11 +386,6 @@ AC_ARG_WITH([upstartdir],
 	[ UPSTARTDIR="$withval" ],
 	[ UPSTARTDIR="$sysconfdir/init" ])
 
-AC_ARG_WITH([initwrappersdir],
-	[  --with-initwrappersdir=DIR   : path to init wrappers files directory. ],
-	[ INITWRAPPERSDIR="$withval" ],
-	[ INITWRAPPERSDIR="$datarootdir/corosync" ])
-
 AC_ARG_WITH([logdir],
 	[  --with-logdir=DIR       : the base directory for corosync logging files. ],
 	[ LOGDIR="$withval" ],
@@ -729,8 +724,6 @@ AC_SUBST([BASHPATH])
 AC_SUBST([INITDDIR])
 AC_SUBST([SYSTEMDDIR])
 AC_SUBST([UPSTARTDIR])
-INITWRAPPERSDIR=$(eval echo ${INITWRAPPERSDIR})
-AC_SUBST([INITWRAPPERSDIR])
 AC_SUBST([LOGDIR])
 AC_SUBST([LOGROTATEDIR])
 
@@ -774,7 +767,6 @@ AC_MSG_RESULT([  System configuration     = ${sysconfdir}])
 AC_MSG_RESULT([  System init.d directory  = ${INITDDIR}])
 AC_MSG_RESULT([  System systemd directory = ${SYSTEMDDIR}])
 AC_MSG_RESULT([  System upstart directory = ${UPSTARTDIR}])
-AC_MSG_RESULT([  System init wraps dir    = ${INITWRAPPERSDIR}])
 AC_MSG_RESULT([  Log directory            = ${LOGDIR}])
 AC_MSG_RESULT([  Log rotate directory     = ${LOGROTATEDIR}])
 AC_MSG_RESULT([  corosync config dir      = ${COROSYSCONFDIR}])

--- a/configure.ac
+++ b/configure.ac
@@ -486,6 +486,8 @@ if test "x${enable_augeas}" = xyes; then
 	PACKAGE_FEATURES="$PACKAGE_FEATURES augeas"
 fi
 if test "x${enable_systemd}" = xyes; then
+	PKG_CHECK_MODULES([libsystemd], [libsystemd])
+	AC_DEFINE([HAVE_LIBSYSTEMD], [1], [have systemd interface library])
 	PACKAGE_FEATURES="$PACKAGE_FEATURES systemd"
 	WITH_LIST="$WITH_LIST --with systemd"
 fi

--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -63,6 +63,7 @@ BuildRequires: dbus-devel
 %endif
 %if %{with systemd}
 BuildRequires: systemd-units
+BuildRequires: systemd-devel
 Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd

--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -248,9 +248,6 @@ fi
 %if %{with systemd}
 %{_unitdir}/corosync.service
 %{_unitdir}/corosync-notifyd.service
-%dir %{_datadir}/corosync
-%{_datadir}/corosync/corosync
-%{_datadir}/corosync/corosync-notifyd
 %else
 %{_initrddir}/corosync
 %{_initrddir}/corosync-notifyd
@@ -429,8 +426,6 @@ fi
 %config(noreplace) %{_sysconfdir}/sysconfig/corosync-qdevice
 %if %{with systemd}
 %{_unitdir}/corosync-qdevice.service
-%dir %{_datadir}/corosync
-%{_datadir}/corosync/corosync-qdevice
 %else
 %{_initrddir}/corosync-qdevice
 %endif
@@ -499,8 +494,6 @@ fi
 %config(noreplace) %{_sysconfdir}/sysconfig/corosync-qnetd
 %if %{with systemd}
 %{_unitdir}/corosync-qnetd.service
-%dir %{_datadir}/corosync
-%{_datadir}/corosync/corosync-qnetd
 %else
 %{_initrddir}/corosync-qnetd
 %endif

--- a/exec/Makefile.am
+++ b/exec/Makefile.am
@@ -68,10 +68,10 @@ endif
 
 corosync_CPPFLAGS	= -DLOGCONFIG_USE_ICMAP=1
 
-corosync_CFLAGS         = $(statgrab_CFLAGS)
+corosync_CFLAGS         = $(statgrab_CFLAGS) $(libsystemd_CFLAGS)
 
 corosync_LDADD		= libtotem_pg.la ../common_lib/libcorosync_common.la \
-			  $(LIBQB_LIBS) $(statgrab_LIBS)
+			  $(LIBQB_LIBS) $(statgrab_LIBS) $(libsystemd_LIBS)
 
 corosync_DEPENDENCIES	= libtotem_pg.la ../common_lib/libcorosync_common.la
 

--- a/exec/main.c
+++ b/exec/main.c
@@ -96,6 +96,10 @@
 #include <semaphore.h>
 #include <string.h>
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #include <qb/qbdefs.h>
 #include <qb/qblog.h>
 #include <qb/qbloop.h>
@@ -292,6 +296,10 @@ static void corosync_sync_completed (void)
 	 * Inform totem to start using new message queue again
 	 */
 	totempg_trans_ack();
+
+#ifdef HAVE_LIBSYSTEMD
+	sd_notify (0, "READY=1");
+#endif
 }
 
 static int corosync_sync_callbacks_retrieve (

--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -45,23 +45,24 @@ EXTRA_DIST		= corosync.in corosync-notifyd.in corosync.service.in \
 if INSTALL_SYSTEMD
 systemdconfdir	   = $(SYSTEMDDIR)
 systemdconf_DATA   = corosync.service corosync-notifyd.service
-initscriptdir	   = $(INITWRAPPERSDIR)
 else
 initscriptdir	   = $(INITDDIR)
-endif
 initscript_SCRIPTS  = corosync corosync-notifyd
+endif
 
 if BUILD_QDEVICES
-initscript_SCRIPTS  += corosync-qdevice
 if INSTALL_SYSTEMD
 systemdconf_DATA   += corosync-qdevice.service
+else
+initscript_SCRIPTS  += corosync-qdevice
 endif
 endif
 
 if BUILD_QNETD
-initscript_SCRIPTS  += corosync-qnetd
 if INSTALL_SYSTEMD
 systemdconf_DATA   += corosync-qnetd.service
+else
+initscript_SCRIPTS  += corosync-qnetd
 endif
 endif
 
@@ -78,7 +79,6 @@ endif
 		-e 's#@''SYSCONFDIR@#$(sysconfdir)#g' \
 		-e 's#@''INITCONFIGDIR@#$(INITCONFIGDIR)#g' \
 		-e 's#@''INITDDIR@#$(INITDDIR)#g' \
-		-e 's#@''INITWRAPPERSDIR@#$(INITWRAPPERSDIR)#g' \
 		-e 's#@''LOCALSTATEDIR@#$(localstatedir)#g' \
 		-e 's#@''BASHPATH@#${BASHPATH}#g' \
 	    > $@-t

--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -7,7 +7,7 @@ After=corosync.service
 [Service]
 EnvironmentFile=-@INITCONFIGDIR@/corosync-notifyd
 ExecStart=@SBINDIR@/corosync-notifyd -f $OPTIONS
-Type=simple
+Type=notify
 Restart=on-failure
 
 [Install]

--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Corosync Dbus and snmp notifier
 Documentation=man:corosync-notifyd
-Wants=corosync.service
+Requires=corosync.service
 After=corosync.service
 
 [Service]

--- a/init/corosync-qdevice.service.in
+++ b/init/corosync-qdevice.service.in
@@ -6,11 +6,12 @@ Wants=corosync.service
 After=corosync.service
 
 [Service]
-ExecStart=@INITWRAPPERSDIR@/corosync-qdevice start
-ExecStop=@INITWRAPPERSDIR@/corosync-qdevice stop
-Type=forking
+EnvironmentFile=-@INITCONFIGDIR@/corosync-qdevice
+ExecStart=@SBINDIR@/corosync-qdevice -f $COROSYNC_QDEVICE_OPTIONS
+Type=notify
 RuntimeDirectory=corosync-qdevice
 RuntimeDirectoryMode=0770
+Restart=on-abnormal
 
 [Install]
 WantedBy=multi-user.target

--- a/init/corosync-qnetd.service.in
+++ b/init/corosync-qnetd.service.in
@@ -8,7 +8,7 @@ After=network-online.target
 [Service]
 EnvironmentFile=-@INITCONFIGDIR@/corosync-qnetd
 ExecStart=@BINDIR@/corosync-qnetd -f $COROSYNC_QNETD_OPTIONS
-Type=simple
+Type=notify
 Restart=on-abnormal
 # Uncomment and set user who should be used for executing qnetd
 #User=coroqnetd

--- a/init/corosync.service.in
+++ b/init/corosync.service.in
@@ -6,9 +6,9 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=@INITWRAPPERSDIR@/corosync start
-ExecStop=@INITWRAPPERSDIR@/corosync stop
-Type=forking
+EnvironmentFile=-@INITCONFIGDIR@/corosync
+ExecStart=@SBINDIR@/corosync -f $OPTIONS
+Type=notify
 
 # The following config is for corosync with enabled watchdog service.
 #

--- a/qdevices/Makefile.am
+++ b/qdevices/Makefile.am
@@ -145,8 +145,9 @@ corosync_qdevice_SOURCES = corosync-qdevice.c \
 corosync_qdevice_tool_SOURCES = corosync-qdevice-tool.c unix-socket.c unix-socket.h dynar.c dynar.h \
                                 dynar-str.c dynar-str.h utils.c utils.h
 
-corosync_qdevice_CFLAGS	= $(nss_CFLAGS)
-corosync_qdevice_LDADD	= $(nss_LIBS) $(LIBQB_LIBS) $(top_builddir)/lib/libcmap.la \
+corosync_qdevice_CFLAGS	= $(nss_CFLAGS) $(libsystemd_CFLAGS)
+corosync_qdevice_LDADD	= $(nss_LIBS)   $(libsystemd_LIBS) $(LIBQB_LIBS) \
+                          $(top_builddir)/lib/libcmap.la \
                           $(top_builddir)/lib/libvotequorum.la
 
 corosync-qdevice-net-certutil: corosync-qdevice-net-certutil.sh

--- a/qdevices/Makefile.am
+++ b/qdevices/Makefile.am
@@ -75,8 +75,8 @@ corosync_qnetd_SOURCES	= corosync-qnetd.c \
 corosync_qnetd_tool_SOURCES = corosync-qnetd-tool.c unix-socket.c unix-socket.h dynar.c dynar.h \
                               dynar-str.c dynar-str.h utils.c utils.h
 
-corosync_qnetd_CFLAGS		= $(nss_CFLAGS)
-corosync_qnetd_LDADD		= $(nss_LIBS)
+corosync_qnetd_CFLAGS		= $(nss_CFLAGS) $(libsystemd_CFLAGS)
+corosync_qnetd_LDADD		= $(nss_LIBS)   $(libsystemd_LIBS)
 
 corosync-qnetd-certutil: corosync-qnetd-certutil.sh
 	sed -e 's#@''DATADIR@#${datadir}#g' \

--- a/qdevices/corosync-qdevice.c
+++ b/qdevices/corosync-qdevice.c
@@ -48,6 +48,10 @@
 #include "qdevice-votequorum.h"
 #include "utils.h"
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 struct qdevice_instance *global_instance;
 
 static void
@@ -258,6 +262,9 @@ main(int argc, char * const argv[])
 	signal_handlers_register();
 
 	qdevice_log(LOG_DEBUG, "Running qdevice model");
+#ifdef HAVE_LIBSYSTEMD
+	sd_notify (0, "READY=1");
+#endif
 	if (qdevice_model_run(&instance) != 0) {
 		return (1);
 	}

--- a/qdevices/corosync-qnetd.c
+++ b/qdevices/corosync-qnetd.c
@@ -56,6 +56,10 @@
 #include "utils.h"
 #include "msg.h"
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 /*
  * This is global variable used for comunication with main loop and signal (calls close)
  */
@@ -613,6 +617,9 @@ main(int argc, char * const argv[])
 	}
 
 	qnetd_log(LOG_DEBUG, "QNetd ready to provide service");
+#ifdef HAVE_LIBSYSTEMD
+	sd_notify (0, "READY=1");
+#endif
 	/*
 	 * MAIN LOOP
 	 */

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -67,8 +67,9 @@ corosync_quorumtool_LDADD = $(LIBQB_LIBS) \
 			    $(top_builddir)/lib/libquorum.la \
 			    $(top_builddir)/lib/libvotequorum.la
 
-corosync_notifyd_CFLAGS   = $(DBUS_CFLAGS)
+corosync_notifyd_CFLAGS   = $(DBUS_CFLAGS) $(libsystemd_CFLAGS)
 corosync_notifyd_LDADD    = $(LIBQB_LIBS) $(DBUS_LIBS) $(SNMP_LIBS) \
+			    $(libsystemd_LIBS) \
 			    $(top_builddir)/lib/libcmap.la \
 			    $(top_builddir)/lib/libcfg.la \
 			    $(top_builddir)/lib/libquorum.la

--- a/tools/corosync-notifyd.c
+++ b/tools/corosync-notifyd.c
@@ -60,6 +60,10 @@
 #include <corosync/quorum.h>
 #include <corosync/cmap.h>
 
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 /*
  * generic declarations
  */
@@ -1317,6 +1321,10 @@ main(int argc, char *argv[])
 			   NULL,
 			   sig_exit_handler,
 			   NULL);
+
+#ifdef HAVE_LIBSYSTEMD
+	sd_notify (0, "READY=1");
+#endif
 
 	qb_loop_run(main_loop);
 


### PR DESCRIPTION
I'm not sure you meant to kill INITWRAPPERSDIR the way it's done here. The other way is installing the init scripts regardless of systemd support: they are simply ignored by systemd but enable switching init systems (in theory).
Upstart removal is not included here to keep us focused. And because I haven't done that yet.
Furthermore, I haven't tested these patches on master yet: I have to sort out kronosnet first. But they've been working very well on needle in Debian (except for the last one, which is new invention).