### PR TITLE
coroparse: Do not convert empty uid, gid to 0

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -147,7 +147,7 @@ static int uid_determine (const char *req_user)
 	char *ep;
 
 	id = strtol(req_user, &ep, 10);
-	if (*ep == '\0' && id >= 0 && id <= UINT_MAX) {
+	if (*req_user != '\0' && *ep == '\0' && id >= 0 && id <= UINT_MAX) {
 		return (id);
 	}
 
@@ -201,7 +201,7 @@ static int gid_determine (const char *req_group)
 	char *ep;
 
 	id = strtol(req_group, &ep, 10);
-	if (*ep == '\0' && id >= 0 && id <= UINT_MAX) {
+	if (*req_group != '\0' && *ep == '\0' && id >= 0 && id <= UINT_MAX) {
 		return (id);
 	}
 


### PR DESCRIPTION
When uid (or gid) value was empty string it was incorrectly converted to
0. Solution is to check input string emptines.

Thanks Bin Liu <bliu@suse.com> for reporting the bug.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>