### PR TITLE
systemd: corosync-qdevice can not run without corosync

### DIFF
--- a/init/corosync-qdevice.service.in
+++ b/init/corosync-qdevice.service.in
@@ -2,7 +2,7 @@
 Description=Corosync Qdevice daemon
 Documentation=man:corosync-qdevice
 ConditionKernelCommandLine=!nocluster
-Wants=corosync.service
+Requires=corosync.service
 After=corosync.service
 
 [Service]


### PR DESCRIPTION
Signed-off-by: Ferenc Wágner <wferi@debian.org>

This commit cherry-picks cleanly into needle.