### PR TITLE
fix output format for corosync-cfgtool with knet

### DIFF
--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -115,7 +115,7 @@ linkstatusget_do (char *interface_name, int brief)
 					printf ("\tstatus:\n");
 					while(s < len) {
 						t = interface_status[i][s] - '0';
-						printf("\t\tnode %d:\n", s++);
+						printf("\t\tnode %d:\t", s++);
 						printf("link enabled:%d\t", t&1? 1 : 0);
 						printf("link connected:%d\n", t&2? 1: 0);
 					}


### PR DESCRIPTION
the output is corosync-cfgtool -s
Printing link status.
Local node ID 1
LINK ID 0
	id	= 10.67.19.156
	status:
		node 0:
link enabled:1	link connected:1
		node 1:
link enabled:1	link connected:1
		node 2:
link enabled:1	link connected:1

this is not well formated by mistakenly type "\n" in the code, change the format to:

Printing link status.
Local node ID 1
LINK ID 0
	id	= 10.67.19.156
	status:
		node 0:	link enabled:1	link connected:1
		node 1:	link enabled:1	link connected:1
		node 2:	link enabled:1	link connected:1

Really sorry for the overlook.