### PR TITLE
corosync.conf: publicize nodelist.node.name configuration option

### DIFF
--- a/conf/lenses/corosync.aug
+++ b/conf/lenses/corosync.aug
@@ -167,6 +167,7 @@ let node =
   let setting =
    qstr /ring[0-9]_addr/
    |kv "nodeid" Rx.integer
+   |kv "name" Rx.hostname
    |kv "quorum_votes" Rx.integer in
   section "node" setting
 

--- a/conf/lenses/tests/test_corosync.aug
+++ b/conf/lenses/tests/test_corosync.aug
@@ -77,6 +77,7 @@ nodelist {
 	node {
 		ring0_addr: 192.168.122.1
 		nodeid: 1
+		name: balalaika
 		quorum_votes: 2
 	}
 
@@ -84,6 +85,7 @@ nodelist {
 		ring0_addr: 192.168.122.2
 		ring1_addr: 192.168.123.1
 		nodeid: 2
+		name: cythara
 	}
 }\n"
 
@@ -155,9 +157,11 @@ test Corosync.lns get conf =
     { "node"
       { "ring0_addr" = "192.168.122.1" }
       { "nodeid" = "1" }
+      { "name" = "balalaika" }
       { "quorum_votes" = "2" } }
     { }
     { "node"
       { "ring0_addr" = "192.168.122.2" }
       { "ring1_addr" = "192.168.123.1" }
-      { "nodeid" = "2" } } }
+      { "nodeid" = "2" }
+      { "name" = "cythara" } } }

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -639,7 +639,8 @@ Every node that should be a member of the membership must be specified.
 Possible options are:
 .TP
 ringX_addr
-This specifies IP address of one of the nodes. X is link number. 
+This specifies IP or network hostname address of the particular node.
+X is a link number.
 
 .TP
 nodeid
@@ -647,6 +648,16 @@ This configuration option is required for each node for Kronosnet mode.
 It is a 32 bit value specifying the node identifier delivered to the
 cluster membership service. The node identifier value of zero is
 reserved and should not be used. If knet is set, this field must be set.
+
+.TP
+name
+This optional configuration option provides a unified way for the
+client software (e.g. pacemaker) atop, respectively the end users,
+to guide establishing a nominal (self-)identification for each node
+in case neither respective
+.B ringX_addr
+specifies a network hostname nor other means are available/effective
+in this process.
 
 .PP
 Within the


### PR DESCRIPTION
It was discovered that pacemaker was occassionaly relying on that value
configured in corosync.conf (and documenting so), while backpropagation
got lost somewhere.  As the option is deemed generally beneficial by
Honza[1], rectify this gap now and make it standard, public part of
the configuration space, possibly also for other client SW to use now.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1517834#c6

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>