### PR TITLE
totemsrp: Reverb totemsrp_get_ifaces() to previous code

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -1012,7 +1012,10 @@ static void message_handler_req_lib_cfg_get_node_addrs (void *conn,
 	if (nodeid == 0)
 		nodeid = api->totem_nodeid_get();
 
-	api->totem_ifaces_get(nodeid, node_ifs, INTERFACE_MAX, &status, &num_interfaces);
+	if (api->totem_ifaces_get(nodeid, node_ifs, INTERFACE_MAX, &status, &num_interfaces)) {
+		ret = CS_ERR_EXIST;
+		num_interfaces = 0;
+	}
 
 	res_lib_cfg_get_node_addrs->header.size = sizeof(struct res_lib_cfg_get_node_addrs) + (num_interfaces * TOTEMIP_ADDRLEN);
 	res_lib_cfg_get_node_addrs->header.id = MESSAGE_RES_CFG_GET_NODE_ADDRS;

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -1479,6 +1479,9 @@ const char *totempg_ifaces_print (unsigned int nodeid)
 	res = totempg_ifaces_get (nodeid, interfaces, INTERFACE_MAX, NULL, &iface_count);
 
 	for (i = 0; i < iface_count; i++) {
+		if (!interfaces[i].family) {
+			continue;
+		}
 		snprintf (one_iface, ONE_IFACE_LEN,
 			  "r(%d) ip(%s) ",
 			  i, totemip_print (&interfaces[i]));

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -216,10 +216,14 @@ static void showaddrs_do(unsigned int nodeid)
 			struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)addrs[i].address;
 			void *saddr;
 
-			if (ss->ss_family == AF_INET6)
+			if (!ss->ss_family) {
+				continue;
+			}
+			if (ss->ss_family == AF_INET6) {
 				saddr = &sin6->sin6_addr;
-			else
+			} else {
 				saddr = &sin->sin_addr;
+			}
 
 			inet_ntop(ss->ss_family, saddr, buf, sizeof(buf));
 			if (i != 0) {

--- a/tools/corosync-cpgtool.c
+++ b/tools/corosync-cpgtool.c
@@ -75,10 +75,16 @@ static void fprint_addrs(FILE *f, unsigned int nodeid)
 			struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)addrs[i].address;
 			void *saddr;
 
-			if (ss->ss_family == AF_INET6)
+			if (!ss->ss_family) {
+				continue;
+			}
+
+			if (ss->ss_family == AF_INET6) {
 				saddr = &sin6->sin6_addr;
-			else
+			}
+			else {
 				saddr = &sin->sin_addr;
+			}
 
 			inet_ntop(ss->ss_family, saddr, buf, sizeof(buf));
 			if (i != 0) {

--- a/tools/corosync-quorumtool.c
+++ b/tools/corosync-quorumtool.c
@@ -349,17 +349,21 @@ static const char *node_name(uint32_t nodeid, name_format_t name_format)
 
 	for (i=start_addr; i<numaddrs; i++) {
 
-		if (i) {
-			buf[bufptr++] = ',';
-			buf[bufptr++] = ' ';
-		}
-
 		ss = (struct sockaddr_storage *)addrs[i].address;
+
+		if (!ss->ss_family) {
+			continue;
+		}
 
 		if (ss->ss_family == AF_INET6) {
 			addrlen = sizeof(struct sockaddr_in6);
 		} else {
 			addrlen = sizeof(struct sockaddr_in);
+		}
+
+		if (i) {
+			buf[bufptr++] = ',';
+			buf[bufptr++] = ' ';
 		}
 
 		if (!getnameinfo(


### PR DESCRIPTION
In my enthusiasm for removing code while integrating knet I
also deleted the correct code for returning IP address for a node,
so that only the IP addres of the local node was ever returned.

This commit restores the the previous code.

Also, because we always return INTERFACE_MAX interfaces now (they don't
have to be contiguous) set ss_family to zero if that interface is not
in use so that downstream apps know and don't display a lot of 0.0.0.0

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>