### PR TITLE
fix compile errors in qdevice and vqsim on freebsd

### DIFF
--- a/qdevices/process-list.h
+++ b/qdevices/process-list.h
@@ -35,6 +35,7 @@
 #ifndef _PROCESS_LIST_H_
 #define _PROCESS_LIST_H_
 
+#include <signal.h>
 #include <sys/queue.h>
 
 #include "dynar.h"

--- a/qdevices/qdevice-cmap.h
+++ b/qdevices/qdevice-cmap.h
@@ -37,6 +37,8 @@
 
 #include <cmap.h>
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
 #include "node-list.h"
 #include "qdevice-instance.h"
 

--- a/qdevices/qdevice-config.h
+++ b/qdevices/qdevice-config.h
@@ -40,6 +40,9 @@
 #include <qb/qbdefs.h>
 #include <qb/qblog.h>
 
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <string.h>
 #include "qdevice-heuristics-mode.h"
 
 #ifdef __cplusplus

--- a/qdevices/unix-socket.h
+++ b/qdevices/unix-socket.h
@@ -35,6 +35,7 @@
 #ifndef _UNIX_SOCKET_H_
 #define _UNIX_SOCKET_H_
 
+#include <string.h>
 #include <sys/types.h>
 #include <inttypes.h>
 

--- a/vqsim/vqmain.c
+++ b/vqsim/vqmain.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 #include <sys/types.h>
-#include <wait.h>
+#include <sys/wait.h>
 #include <qb/qblog.h>
 #include <qb/qbloop.h>
 #include <sys/poll.h>


### PR DESCRIPTION
Some header files need to be specified on FreeBSD, otherwise there
compile errors. These files does not affect on Linux.