### PR TITLE
config: Allow links to have different ip_versions

### DIFF
--- a/exec/totemconfig.h
+++ b/exec/totemconfig.h
@@ -61,6 +61,7 @@ extern int totem_config_keyread (
 	const char **error_string);
 
 extern int totem_config_find_local_addr_in_nodelist(
+	struct totem_config *totem_config,
 	const char *ipaddr_key_prefix,
 	unsigned int *node_pos);
 

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -278,9 +278,10 @@ equal to highest of collected versions, corosync is terminated.
 
 .TP
 ip_version
-Specifies version of IP to use for communication. Value can be one of
-ipv4 or ipv6. Default (if unspecified) is ipv4.
-
+For udp or udpu, this specifies version of IP to use for communication.
+The value can be one of ipv4 or ipv6. Default (if unspecified) is ipv4.
+This does not apply to knet where both ipv4 and ipv6 address can be used,
+provided they are consistent on each link.
 
 Within the
 .B totem


### PR DESCRIPTION
knet allows links to have different IP versions - proivided they
all match per link. So don't force them all to be the same.

I've added a check here to make sure that all nodes on the same
link are using the same IP version.