### PR TITLE
Add missing options to corosync.aug

### DIFF
--- a/conf/lenses/corosync.aug
+++ b/conf/lenses/corosync.aug
@@ -40,6 +40,7 @@ let interface =
     kv "ringnumber" Rx.integer
     |kv "mcastport" Rx.integer
     |kv "ttl" Rx.integer
+    |kv "broadcast" /yes|no/
     |qstr /bindnetaddr|mcastaddr/ in
   section "interface" setting
 

--- a/conf/lenses/corosync.aug
+++ b/conf/lenses/corosync.aug
@@ -53,7 +53,7 @@ let totem =
     |kv "crypto_type" /nss|aes256|aes192|aes128|3des/
     |kv "crypto_cipher" /none|nss|aes256|aes192|aes128|3des/
     |kv "crypto_hash" /none|md5|sha1|sha256|sha384|sha512/
-    |kv "transport" /udp|iba/
+    |kv "transport" /udp|iba|udpu/
     |kv "version" Rx.integer
     |kv "nodeid" Rx.integer
     |kv "threads" Rx.integer
@@ -76,6 +76,7 @@ let totem =
     |kv "rrp_problem_count_timeout" Rx.integer
     |kv "rrp_problem_count_threshold" Rx.integer
     |kv "rrp_token_expired_timeout" Rx.integer
+    |qstr /cluster_name/
     |interface in
   section "totem" setting
 


### PR DESCRIPTION
Setting up a fairly basic cluster on CentOS 7, I noticed that the generated `corosync.conf` is unable to be parsed by `augtool`:
```
augtool> match /augeas//error
/augeas/files/etc/corosync/corosync.conf/error = parse_failed
```
This PR adds the missing `cluster_name` `qstr`, and also adds the additional `udpu` protocol to the supplied augeas lens.

After this, I can load and manipulate `corosync.conf` with `augtool`.