### PR TITLE
config: Allow selection of crypto_model

### DIFF
--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -889,7 +889,7 @@ int totemknet_initialize (
 	if (strcmp(instance->totem_config->crypto_cipher_type, "none") != 0) {
 		struct knet_handle_crypto_cfg crypto_cfg;
 
-		strcpy(crypto_cfg.crypto_model, "nss");
+		strcpy(crypto_cfg.crypto_model, instance->totem_config->crypto_model);
 		strcpy(crypto_cfg.crypto_cipher_type, instance->totem_config->crypto_cipher_type);
 		strcpy(crypto_cfg.crypto_hash_type, instance->totem_config->crypto_hash_type);
 		memcpy(crypto_cfg.private_key, instance->totem_config->private_key, instance->totem_config->private_key_len);

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -195,6 +195,8 @@ struct totem_config {
 
 	unsigned int broadcast_use;
 
+	char *crypto_model;
+
 	char *crypto_cipher_type;
 
 	char *crypto_hash_type;

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -194,6 +194,13 @@ WARNING: The clusters behavior is undefined if this option is enabled on only
 a subset of the cluster (for example during a rolling upgrade).
 
 .TP
+crypto_model
+This specifies which cryptographic library should be used by knet. Options
+are nss and openssl.
+
+The default is nss
+
+.TP
 crypto_hash
 This specifies which HMAC authentication should be used to authenticate all
 messages. Valid values are none (no authentication), md5, sha1, sha256,


### PR DESCRIPTION
KNET has options for nss or openssl crpyto libraries, make this
available to corosync.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>