### PR TITLE
Iov recv fixes master

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -468,8 +468,7 @@ static int totem_config_get_ip_version(struct totem_config *totem_config)
 	char *str;
 
 	res = AF_INET;
-	if (totem_config->transport_number == TOTEM_TRANSPORT_KNET ||
-	    totem_config->transport_number == 0) {
+	if (totem_config->transport_number == TOTEM_TRANSPORT_KNET) {
 		res = AF_UNSPEC;
 	} else {
 		if (icmap_get_string("totem.ip_version", &str) == CS_OK) {
@@ -1300,6 +1299,23 @@ extern int totem_config_read (
 		return -1;
 	}
 
+	totem_config->transport_number = TOTEM_TRANSPORT_KNET;
+	if (icmap_get_string("totem.transport", &str) == CS_OK) {
+		if (strcmp (str, "udpu") == 0) {
+			totem_config->transport_number = TOTEM_TRANSPORT_UDPU;
+		}
+
+		if (strcmp (str, "udp") == 0) {
+			totem_config->transport_number = TOTEM_TRANSPORT_UDP;
+		}
+
+		if (strcmp (str, "knet") == 0) {
+			totem_config->transport_number = TOTEM_TRANSPORT_KNET;
+		}
+
+		free(str);
+	}
+
 	memset (totem_config->interfaces, 0,
 		sizeof (struct totem_interface) * INTERFACE_MAX);
 
@@ -1379,22 +1395,6 @@ extern int totem_config_read (
 			       "255.255.255.255", 0);
 	}
 
-	totem_config->transport_number = TOTEM_TRANSPORT_KNET;
-	if (icmap_get_string("totem.transport", &str) == CS_OK) {
-		if (strcmp (str, "udpu") == 0) {
-			totem_config->transport_number = TOTEM_TRANSPORT_UDPU;
-		}
-
-		if (strcmp (str, "udp") == 0) {
-			totem_config->transport_number = TOTEM_TRANSPORT_UDP;
-		}
-
-		if (strcmp (str, "knet") == 0) {
-			totem_config->transport_number = TOTEM_TRANSPORT_KNET;
-		}
-
-		free(str);
-	}
 
 	/*
 	 * Store automatically generated items back to icmap only for UDP

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -50,6 +50,16 @@
 #endif /* HAVE_SMALL_MEMORY_FOOTPRINT */
 
 #define FRAME_SIZE_MAX		KNET_MAX_PACKET_SIZE
+
+/*
+ * Estimation of required buffer size for totemudp and totemudpu - it should be at least
+ *   sizeof(memb_join) + PROCESSOR_MAX * 2 * sizeof(srp_addr))
+ * if we want to support PROCESSOR_MAX nodes, but because we don't have
+ * srp_addr and memb_join, we have to use estimation.
+ * TODO: Consider moving srp_addr/memb_join into totem headers instead of totemsrp.c
+ */
+#define UDP_RECEIVE_FRAME_SIZE_MAX     (PROCESSOR_COUNT_MAX * (INTERFACE_MAX * 2 * sizeof(struct totem_ip_address)) + 1024)
+
 #define TRANSMITS_ALLOWED	16
 #define SEND_THREADS_MAX	16
 


### PR DESCRIPTION
Patch from topic-scale, port to totemudp and port of part of the patch to the totemknet.

Unrelated patch is making auto-generated mcast address work again.
