### PR TITLE
config: if local node addr is wrong, fail with a sensible message

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1476,6 +1476,7 @@ int totem_config_validate (
 	char parse_error[512];
 	const char *error_reason = local_error_reason;
 	int i,j;
+	uint32_t u32;
 	int num_configured = 0;
 	unsigned int interface_max = INTERFACE_MAX;
 
@@ -1488,6 +1489,12 @@ int totem_config_validate (
 	}
 	if (num_configured == 0) {
 		error_reason = "No interfaces defined";
+		goto parse_error;
+	}
+
+	/* Check we found a local node address */
+	if (icmap_get_uint32("nodelist.local_node_pos", &u32) != CS_OK) {
+		error_reason = "No valid address found for local host";
 		goto parse_error;
 	}
 


### PR DESCRIPTION
If no valid local address is found in corosync.conf then corosync
exits with: "parse error in config: No multicast port specified"

This is because of the config change for knet that always populates
the interfaces. The old error of "no interfaces found" was only
slightly better anyway IMHO.

This patch adds an explicit check that local_node_pos has been
set in icmap and uses that to determine if a valid local address
has been found.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>