### PR TITLE
Organize the header necessary for RPM build

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -350,6 +350,7 @@ The Corosync Cluster Engine APIs.
 %{_includedir}/corosync/totem/totem.h
 %{_includedir}/corosync/totem/totemip.h
 %{_includedir}/corosync/totem/totempg.h
+%{_includedir}/corosync/totem/totemstats.h
 %{_libdir}/libcfg.so
 %{_libdir}/libcpg.so
 %{_libdir}/libcmap.so

--- a/exec/Makefile.am
+++ b/exec/Makefile.am
@@ -36,7 +36,7 @@ noinst_HEADERS		= apidef.h cs_queue.h logconfig.h main.h \
 			  totemnet.h totemudp.h \
 			  totemudpu.h totemsrp.h util.h vsf.h \
 			  schedwrk.h sync.h fsm.h votequorum.h vsf_ykd.h \
-			  totemknet.h stats.h
+			  totemknet.h stats.h ipcs_stats.h
 
 TOTEM_SRC		= totemip.c totemnet.c totemudp.c \
 			  totemudpu.c totemsrp.c \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -38,7 +38,7 @@ CS_INTERNAL_H		= ipc_cfg.h ipc_cpg.h ipc_quorum.h 	\
 			quorum.h sq.h ipc_votequorum.h ipc_cmap.h \
 			logsys.h coroapi.h icmap.h mar_gen.h swab.h
 
-TOTEM_H			= totem.h totemip.h totempg.h
+TOTEM_H			= totem.h totemip.h totempg.h totemstats.h
 
 EXTRA_DIST 		= $(noinst_HEADERS)
 


### PR DESCRIPTION
"make rpm" will fail, so please merge the following fixes

```
# make rpm
(snip)
cmap.c:59:24: fatal error: ipcs_stats.h: No such file or directory
 #include "ipcs_stats.h"
                        ^
compilation terminated.
  CC       corosync-cpg.o
  CC       corosync-pload.o
make[3]: *** [corosync-cmap.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory `/usr/local/src/repo/corosync/corosync-2.4.1.176-23603/exec'
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory `/usr/local/src/repo/corosync/corosync-2.4.1.176-23603'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/usr/local/src/repo/corosync/corosync-2.4.1.176-23603'
error: Bad exit status from /var/tmp/rpm-tmp.pQ112k (%build)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.pQ112k (%build)
make: *** [rpm] Error 1
```