### PR TITLE
config: Don't fudge port numbers

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -846,7 +846,7 @@ static void reconfigure_links(struct totem_config *totem_config)
 		if (!totem_config->interfaces[i].knet_transport)
 			totem_config->interfaces[i].knet_transport = KNET_TRANSPORT_UDP;
 		if (!totem_config->interfaces[i].ip_port)
-			totem_config->interfaces[i].ip_port = DEFAULT_PORT;
+			totem_config->interfaces[i].ip_port = DEFAULT_PORT+i;
 
 		totempg_iface_set(&local_ip, totem_config->interfaces[i].ip_port, i);
 	}
@@ -1226,7 +1226,7 @@ static int get_interface_params(struct totem_config *totem_config,
 				if (totem_config->broadcast_use) {
 					totem_config->interfaces[linknumber].ip_port = DEFAULT_PORT + (2 * linknumber);
 				} else {
-					totem_config->interfaces[linknumber].ip_port = DEFAULT_PORT;
+					totem_config->interfaces[linknumber].ip_port = DEFAULT_PORT + linknumber;
 				}
 			}
 

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -1159,8 +1159,8 @@ int totemknet_member_add (
 
 	memset(&local_ss, 0, sizeof(local_ss));
 	/* Casts to remove const */
-	totemip_totemip_to_sockaddr_convert((struct totem_ip_address *)member, port+link_no, &remote_ss, &addrlen);
-	totemip_totemip_to_sockaddr_convert((struct totem_ip_address *)local, port+link_no, &local_ss, &addrlen);
+	totemip_totemip_to_sockaddr_convert((struct totem_ip_address *)member, port, &remote_ss, &addrlen);
+	totemip_totemip_to_sockaddr_convert((struct totem_ip_address *)local, port, &local_ss, &addrlen);
 	if (member->nodeid == instance->our_nodeid) {
 		err = knet_link_set_config(instance->knet_handle, member->nodeid, link_no,
 					   KNET_TRANSPORT_LOOPBACK,


### PR DESCRIPTION
When I was adding knet I wanted the port numbers to default to the
base port number + the linknumber.

However I seem to have messed this up such that any port number
specified in the config file has the link number added to it. Which
is almost certainly not what people would expect.

This patch sets it right. If a port number is not specified
then 5405+linknumber is used. If a port number IS specified
then that actual number is used.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>