### PR TITLE
Blackbox disable

### DIFF
--- a/exec/logsys.c
+++ b/exec/logsys.c
@@ -861,3 +861,19 @@ void logsys_blackbox_set(int enable)
 
 	pthread_mutex_unlock (&logsys_config_mutex);
 }
+
+/*
+ * To set correct pid to qb blackbox filename after tty dettach (fork) we have to
+ * close (this function) and (if needed) reopen blackbox (logsys_blackbox_postfork function).
+ */
+void logsys_blackbox_prefork(void)
+{
+
+	(void)qb_log_ctl(QB_LOG_BLACKBOX, QB_LOG_CONF_ENABLED, QB_FALSE);
+}
+
+void logsys_blackbox_postfork(void)
+{
+
+	_logsys_config_apply_blackbox();
+}

--- a/exec/logsys.c
+++ b/exec/logsys.c
@@ -118,6 +118,8 @@ static char *format_buffer=NULL;
 
 static int logsys_thread_started = 0;
 
+static int logsys_blackbox_enabled = 1;
+
 static int _logsys_config_subsys_get_unlocked (const char *subsys)
 {
 	unsigned int i;
@@ -308,7 +310,6 @@ int _logsys_system_setup(
 	int i;
 	int32_t fidx;
 	char tempsubsys[LOGSYS_MAX_SUBSYS_NAMELEN];
-	int blackbox_enable_res;
 
 	if ((mainsystem == NULL) ||
 	    (strlen(mainsystem) >= LOGSYS_MAX_SUBSYS_NAMELEN)) {
@@ -370,7 +371,12 @@ int _logsys_system_setup(
 			  QB_LOG_FILTER_FILE, "*", LOG_TRACE);
 	qb_log_ctl(QB_LOG_BLACKBOX, QB_LOG_CONF_SIZE, IPC_LOGSYS_SIZE);
 	qb_log_ctl(QB_LOG_BLACKBOX, QB_LOG_CONF_THREADED, QB_FALSE);
-	blackbox_enable_res = qb_log_ctl(QB_LOG_BLACKBOX, QB_LOG_CONF_ENABLED, QB_TRUE);
+
+	/*
+	 * Blackbox is disabled at the init and enabled later based
+	 * on config (logging.blackbox) value.
+	 */
+	qb_log_ctl(QB_LOG_BLACKBOX, QB_LOG_CONF_ENABLED, QB_FALSE);
 
 	if (logsys_format_set(NULL) == -1) {
 		return -1;
@@ -394,14 +400,6 @@ int _logsys_system_setup(
 			_logsys_config_mode_set_unlocked(i, logsys_loggers[i].mode);
 			_logsys_config_apply_per_subsys(i);
 		}
-	}
-
-	if (blackbox_enable_res < 0) {
-		LOGSYS_PERROR (-blackbox_enable_res, LOGSYS_LEVEL_WARNING,
-		    "Unable to initialize log flight recorder. "\
-		    "The most common cause of this error is " \
-		    "not enough space on /dev/shm. Corosync will continue work, " \
-		    "but blackbox will not be available");
 	}
 
 	pthread_mutex_unlock (&logsys_config_mutex);
@@ -766,9 +764,25 @@ static void _logsys_config_apply_per_subsys(int32_t s)
 	logsys_loggers[s].dirty = QB_FALSE;
 }
 
+static void _logsys_config_apply_blackbox(void) {
+	int blackbox_enable_res;
+
+	blackbox_enable_res = qb_log_ctl(QB_LOG_BLACKBOX, QB_LOG_CONF_ENABLED, logsys_blackbox_enabled);
+
+	if (blackbox_enable_res < 0) {
+		LOGSYS_PERROR (-blackbox_enable_res, LOGSYS_LEVEL_WARNING,
+		    "Unable to initialize log flight recorder. "\
+		    "The most common cause of this error is " \
+		    "not enough space on /dev/shm. Corosync will continue work, " \
+		    "but blackbox will not be available");
+	}
+}
+
 void logsys_config_apply(void)
 {
 	int32_t s;
+
+	_logsys_config_apply_blackbox();
 
 	for (s = 0; s <= LOGSYS_MAX_SUBSYS_COUNT; s++) {
 		if (strcmp(logsys_loggers[s].subsys, "") == 0) {
@@ -836,4 +850,14 @@ int logsys_thread_start (void)
 	logsys_thread_started = 1;
 
 	return (0);
+}
+
+void logsys_blackbox_set(int enable)
+{
+
+	pthread_mutex_lock (&logsys_config_mutex);
+
+	logsys_blackbox_enabled = enable;
+
+	pthread_mutex_unlock (&logsys_config_mutex);
 }

--- a/exec/main.c
+++ b/exec/main.c
@@ -225,6 +225,7 @@ static void corosync_blackbox_write_to_file (void)
 
 	if ((res = qb_log_blackbox_write_to_file(fname)) < 0) {
 		LOGSYS_PERROR(-res, LOGSYS_LEVEL_ERROR, "Can't store blackbox file");
+		return ;
 	}
 	snprintf(fdata_fname, sizeof(fdata_fname), "%s/fdata", get_run_dir());
 	unlink(fdata_fname);

--- a/exec/main.c
+++ b/exec/main.c
@@ -1442,7 +1442,13 @@ int main (int argc, char **argv, char **envp)
 	 * Now we are fully initialized.
 	 */
 	if (background) {
+		logsys_blackbox_prefork();
+
 		corosync_tty_detach ();
+
+		logsys_blackbox_postfork();
+
+		log_printf (LOGSYS_LEVEL_DEBUG, "Corosync TTY detached");
 	}
 
 	/*

--- a/include/corosync/logsys.h
+++ b/include/corosync/logsys.h
@@ -256,6 +256,8 @@ extern int _logsys_subsys_create (const char *subsys, const char *filename);
  */
 extern int logsys_thread_start (void);
 
+extern void logsys_blackbox_set(int enable);
+
 /**
  * @brief logsys_subsys_id
  */

--- a/include/corosync/logsys.h
+++ b/include/corosync/logsys.h
@@ -258,6 +258,11 @@ extern int logsys_thread_start (void);
 
 extern void logsys_blackbox_set(int enable);
 
+extern void logsys_blackbox_prefork(void);
+
+extern void logsys_blackbox_postfork(void);
+
+
 /**
  * @brief logsys_subsys_id
  */

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -533,6 +533,12 @@ This specifies that the code function name should be printed.
 
 The default is off.
 
+.TP
+blackbox
+This specifies that blackbox functionality should be enabled.
+
+The defualt is on.
+
 .PP
 The following options are valid both for top level logging directive
 and they can be overridden in logger_subsys entries.


### PR DESCRIPTION
First patch is for sure something we would like to have (at least in my opinion :) )

Second patch is more like a speculative and  I believe the problem should be solved by libqb (not overwriting existing file/unlink after mmap) and not workarounded by corosync.

Both patches are applicable to both master and needle.
