### PR TITLE
fix issue in "corosync-cfgtool -s" for multiple link with knet

### DIFF
--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -122,6 +122,7 @@ linkstatusget_do (char *interface_name, int brief)
 					(!strstr(interface_status[i], "FAULTY"))) {
 					len = strlen(interface_status[i]);
 					printf ("\tstatus:\n");
+					s = 0;
 					while(s < len) {
 						t = interface_status[i][s] - '0';
 						printf("\t\tnode %d:\t", s++);


### PR DESCRIPTION
In the previous commit 0b5ab1,  the patch did not
reset s to 0 for each link. This will result in only the first link can
be printed.