### PR TITLE
Fix totempg fragmentation segfault.

### DIFF
--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -909,9 +909,9 @@ static int mcast_msg (
 			(max_packet_size - sizeof (unsigned short))) {
 
 			memcpy (&fragmentation_data[fragment_size],
-				(char *)iovec[i].iov_base + copy_base, copy_len);
-			fragment_size += copy_len;
-			mcast_packed_msg_lens[mcast_packed_msg_count] += copy_len;
+				(char *)iovec[i].iov_base + copy_base, iovec[i].iov_len);
+			fragment_size += iovec[i].iov_len;
+			mcast_packed_msg_lens[mcast_packed_msg_count] += iovec[i].iov_len;
 			next_fragment = 1;
 			copy_len = 0;
 			copy_base = 0;

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -905,7 +905,7 @@ static int mcast_msg (
 		 * fragment_buffer on exit so that max_packet_size + fragment_size
 		 * doesn't exceed the size of the fragment_buffer on the next call.
 		 */
-		if ((copy_len + fragment_size) <
+		if ((iovec[i].iov_len + fragment_size) <
 			(max_packet_size - sizeof (unsigned short))) {
 
 			memcpy (&fragmentation_data[fragment_size],
@@ -963,7 +963,7 @@ static int mcast_msg (
 			iovecs[1].iov_len = mcast_packed_msg_count *
 				sizeof(unsigned short);
 			iovecs[2].iov_base = (void *)data_ptr;
-			iovecs[2].iov_len = max_packet_size;
+			iovecs[2].iov_len = fragment_size + copy_len;
 			assert (totemsrp_avail(totemsrp_context) > 0);
 			res = totemsrp_mcast (totemsrp_context, iovecs, 3, guarantee);
 			if (res == -1) {


### PR DESCRIPTION
Proposed fix for #319.

Take accumulated messages branch only when whole message fits into packet, not when remainder fits.