### PR TITLE
fix corrupted messages

### DIFF
--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -909,9 +909,9 @@ static int mcast_msg (
 			(max_packet_size - sizeof (unsigned short))) {
 
 			memcpy (&fragmentation_data[fragment_size],
-				(char *)iovec[i].iov_base + copy_base, iovec[i].iov_len);
-			fragment_size += iovec[i].iov_len;
-			mcast_packed_msg_lens[mcast_packed_msg_count] += iovec[i].iov_len;
+				(char *)iovec[i].iov_base + copy_base, copy_len);
+			fragment_size += copy_len;
+			mcast_packed_msg_lens[mcast_packed_msg_count] += copy_len;
 			next_fragment = 1;
 			copy_len = 0;
 			copy_base = 0;


### PR DESCRIPTION
After several days of testing I realised, that I introduced a regression with #320, this PR fixes it.

For details:
Second commit of  #320  changed copy_len to iovec[i].iov_len, assuming, copy_len is always the same as iovec[i].iov_len under those circumstances, but I missed the possability of small message being partly put at the end of packet, which cuts this message in two parts and therefore making copy_len not equal to iovec[i].iov_len.

Sorry for my mistake...