### PR TITLE
[rpm] fixup corosync.spec.in to build on opensuse

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -32,8 +32,14 @@ Requires: corosynclib%{?_isa} = %{version}-%{release}
 
 # Build bits
 
+# OpenSUSE needs groff-full to build html documentation,
+# but there is no clean way to express it here.
 BuildRequires: groff
 BuildRequires: libqb-devel
+# Use file based depedency to allow upstream spec file to
+# build on OpenSUSE since package name differs with Fedora/RHEL/Centos
+# and only recent versions of rpm supports BuildRequires: foo || bar
+# BuildRequires: nss-devel || mozilla-nss-devel
 BuildRequires: /usr/include/nss3/nss.h /usr/include/nspr4/nspr.h
 BuildRequires: libknet1-devel
 BuildRequires: zlib-devel
@@ -47,6 +53,10 @@ BuildRequires: libstatgrab-devel
 BuildRequires: net-snmp-devel
 %endif
 %if %{with dbus}
+# Use file based depedency to allow upstream spec file to
+# build on OpenSUSE since package name differs with Fedora/RHEL/Centos
+# and only recent versions of rpm supports BuildRequires: foo || bar
+# BuildRequires: dbus-devel || dbus-1-devel
 BuildRequires: /usr/include/dbus-1.0/dbus/dbus.h
 %endif
 %if %{with systemd}

--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -34,7 +34,7 @@ Requires: corosynclib%{?_isa} = %{version}-%{release}
 
 BuildRequires: groff
 BuildRequires: libqb-devel
-BuildRequires: nss-devel
+BuildRequires: /usr/include/nss3/nss.h /usr/include/nspr4/nspr.h
 BuildRequires: libknet1-devel
 BuildRequires: zlib-devel
 %if %{with runautogen}
@@ -47,7 +47,7 @@ BuildRequires: libstatgrab-devel
 BuildRequires: net-snmp-devel
 %endif
 %if %{with dbus}
-BuildRequires: dbus-devel
+BuildRequires: /usr/include/dbus-1.0/dbus/dbus.h
 %endif
 %if %{with systemd}
 %{?systemd_requires}
@@ -98,7 +98,8 @@ BuildRequires: libcgroup-devel
 	--enable-libcgroup \
 %endif
 	--with-initddir=%{_initrddir} \
-	--with-systemddir=%{_unitdir}
+	--with-systemddir=%{_unitdir} \
+	--docdir=%{_docdir}
 
 make %{_smp_mflags}
 


### PR DESCRIPTION
- move dbus-devel and nss-devel BuildRequires to file based depedency.
  Those 2 BR have different names in OpenSUSE vs Fedora/RHEL/Centos.
  This is kind of controversial as most distribution prefers a package
  based build depedency, but the rpm version that supports
  BuildRequires: foo || bar
  is only available in rawhide and tumbleweed (aka no stable releases
  are shipping it yet).
  In order to build rpms in CI and have some level of flexibility
  with upstream spec file, we need to compromise a bit.

- add explicit --docdir
  OpenSUSE does not ship docs in the normal dir and their rpm macro
  does not appear to set it for us.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>