### PR TITLE
libcpg: Handle fragmented message sending interruption

### DIFF
--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -494,8 +494,10 @@ cs_error_t cpg_dispatch (
 					 * As this is LIBCPG_PARTIAL_FIRST packet, check that there is no ongoing assembly
 					 */
 					if (assembly_data) {
-						error = CS_ERR_MESSAGE_ERROR;
-						goto error_put;
+						qb_list_del (&assembly_data->list);
+						free(assembly_data->assembly_buf);
+						free(assembly_data);
+						assembly_data = NULL;
 					}
 
 					assembly_data = malloc(sizeof(struct cpg_assembly_data));

--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -491,7 +491,9 @@ cs_error_t cpg_dispatch (
 				if (res_cpg_partial_deliver_callback->type == LIBCPG_PARTIAL_FIRST) {
 
 					/*
-					 * As this is LIBCPG_PARTIAL_FIRST packet, check that there is no ongoing assembly
+					 * As this is LIBCPG_PARTIAL_FIRST packet, check that there is no ongoing assembly.
+					 * Otherwise the sending of packet must have been interrupted and error should have
+					 * been reported to sending client. Therefore here last assembly will be dropped.
 					 */
 					if (assembly_data) {
 						qb_list_del (&assembly_data->list);


### PR DESCRIPTION
It turns out that there are some legitimate cases where fragmented messages might be interrupted during sending (e.g. CS_ERR_TRY_AGAIN or as in my case: CS_ERR_INTERRUPT). This creates a situation where LIBCPG_PARTIAL_FIRST is sent multiple times before receiving LIBCPG_PARTIAL_LAST.

I am proposing that incomplete message would be dropped and assembly of new message would be started as libcpg should have reported error during sending of that incomplete message. This PR implements that.