### PR TITLE
qnetd-certutil: fix format option name in stat invocation

### DIFF
--- a/qdevices/corosync-qnetd-certutil.sh
+++ b/qdevices/corosync-qnetd-certutil.sh
@@ -60,7 +60,7 @@ usage() {
 
 chown_ref_cfgdir() {
     if [ "$UID" == "0" ];then
-        chown --reference="$CONFIG_DIR" "$@" 2>/dev/null || chown "$(stat -f "%u:%g" "$CONFIG_DIR")" "$@" 2>/dev/null || return $?
+        chown --reference="$CONFIG_DIR" "$@" 2>/dev/null || chown "$(stat --format="%u:%g" "$CONFIG_DIR")" "$@" 2>/dev/null || return $?
     fi
 }
 


### PR DESCRIPTION
On my Debian machines `-f` is the short name for the `--file-system` option.
So this usage very much seems like a typo, especially before a format string.

This patch should apply to the split-out qdevice repository all the same.

Regards,
Feri.