### PR TITLE
totemsrp: Fix srp_addr_compare

### DIFF
--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -3159,7 +3159,7 @@ static int srp_addr_compare (const void *a, const void *b)
 	const struct srp_addr *srp_a = (const struct srp_addr *)a;
 	const struct srp_addr *srp_b = (const struct srp_addr *)b;
 
-	return (srp_a->nodeid == srp_b->nodeid);
+	return (srp_a->nodeid - srp_b->nodeid);
 }
 
 static void memb_state_commit_token_create (


### PR DESCRIPTION
There is regression caused by "totem: Use nodeid ONLY in srp_addr" patch
in srp_addr_compare function. This function should be usable with qsort,
so it should return values less than, equal to or greater than zero. It
was however returning only zero or negation of a zero. Final results
were unable to reach consensus in following test case:
- 3 node cluster
- start nodes 1, 2, 3
- shutdown node 3
- start node 3
- shutdown node 2
- start node 2
- shutdown node 1

After this steps, node 2 and 3 were unable to reach consensus.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>