### PR TITLE
NSS_NoDB_Init: the parameter is reserved, must be NULL

### DIFF
--- a/cts/agents/cpg_test_agent.c
+++ b/cts/agents/cpg_test_agent.c
@@ -788,7 +788,7 @@ main(int argc, char *argv[])
 	list_init (&msg_log_head);
 	list_init (&config_chg_log_head);
 
-	if (NSS_NoDB_Init(".") != SECSuccess) {
+	if (NSS_NoDB_Init(NULL) != SECSuccess) {
 		qb_log(LOG_ERR, "Couldn't initialize nss");
 		exit (0);
 	}

--- a/exec/totemcrypto.c
+++ b/exec/totemcrypto.c
@@ -670,7 +670,7 @@ static int init_nss_db(struct crypto_instance *instance)
 		return 0;
 	}
 
-	if (NSS_NoDB_Init(".") != SECSuccess) {
+	if (NSS_NoDB_Init(NULL) != SECSuccess) {
 		log_printf(instance->log_level_security, "NSS DB initialization failed (err %d)",
 			   PR_GetError());
 		return -1;

--- a/test/cpgverify.c
+++ b/test/cpgverify.c
@@ -137,7 +137,7 @@ int main (int argc, char *argv[])
 		exit (0);
 	}
 
-	if (NSS_NoDB_Init(".") != SECSuccess) {
+	if (NSS_NoDB_Init(NULL) != SECSuccess) {
 		printf ("Couldn't initialize nss\n");
 		exit (0);
 	}


### PR DESCRIPTION
This does not make an actual difference, because the current implementation of `NSS_NoDB_Init()` simply ignores the passed parameter. However, the documentation says it should be `NULL`. I notice that even official code samples use `"."` occasionally, but I don't see the point :)