### PR TITLE
knet: Misc fixes

### DIFF
--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -542,7 +542,7 @@ static int log_deliver_fn (
 	void *data)
 {
 	struct totemknet_instance *instance = (struct totemknet_instance *)data;
-	char buffer[KNET_MAX_LOG_MSG_SIZE*4];
+	char buffer[sizeof(struct knet_log_msg)*4];
 	char *bufptr = buffer;
 	int done = 0;
 	int len;
@@ -572,8 +572,8 @@ static int log_deliver_fn (
 					    msg->msg);
 			break;
 		}
-		bufptr += KNET_MAX_LOG_MSG_SIZE;
-		done += KNET_MAX_LOG_MSG_SIZE;
+		bufptr += sizeof(struct knet_log_msg);
+		done += sizeof(struct knet_log_msg);
 	}
 	return 0;
 }

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -1159,9 +1159,14 @@ int totemknet_member_add (
 	size_t num_host_ids;
 
 	/* Only create 1 loopback link and use link 0 */
-	if (member->nodeid == instance->our_nodeid && !instance->loopback_link) {
-		link_no = 0;
-		instance->loopback_link = 1;
+	if (member->nodeid == instance->our_nodeid) {
+		if (!instance->loopback_link) {
+			link_no = 0;
+			instance->loopback_link = 1;
+		} else {
+			/* Already done */
+			return 0;
+		}
 	}
 
 	knet_log_printf (LOGSYS_LEVEL_DEBUG, "knet: member_add: %d (%s), link=%d", member->nodeid, totemip_print(member), link_no);


### PR DESCRIPTION
knet sends log messages as struct knet_log_msg, not a string
of KNET_MAX_LOG_MSG_SIZE (which is only part of that structure).
So we were both losing and corrupting messages.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>