### PR TITLE
Present information about when the last token was received

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -589,6 +589,7 @@ static int main_config_parser_cb(const char *path,
 			    (strcmp(path, "totem.nodeid") == 0) ||
 			    (strcmp(path, "totem.threads") == 0) ||
 			    (strcmp(path, "totem.token") == 0) ||
+			    (strcmp(path, "totem.token_warning") == 0) ||
 			    (strcmp(path, "totem.token_coefficient") == 0) ||
 			    (strcmp(path, "totem.token_retransmit") == 0) ||
 			    (strcmp(path, "totem.hold") == 0) ||

--- a/exec/main.c
+++ b/exec/main.c
@@ -479,6 +479,7 @@ static void corosync_totem_stats_updater (void *data)
 	int32_t token_count;
 	char key_name[ICMAP_KEYNAME_MAXLEN];
 	const char *cstr;
+	uint64_t tv_diff;
 
 	stats = api->totem_get_stats();
 
@@ -513,6 +514,9 @@ static void corosync_totem_stats_updater (void *data)
 
 	icmap_set_uint8("runtime.totem.pg.mrp.srp.firewall_enabled_or_nic_failure",
 		stats->mrp->srp->continuous_gather > MAX_NO_CONT_GATHER ? 1 : 0);
+
+	tv_diff = qb_util_nano_current_get () - stats->mrp->srp->token_last_received;
+	icmap_set_uint64("runtime.totem.pg.mrp.srp.token_last_received", tv_diff/QB_TIME_NS_IN_MSEC);
 
 	if (stats->mrp->srp->continuous_gather > MAX_NO_CONT_GATHER ||
 	    stats->mrp->srp->continuous_sendmsg_failures > MAX_NO_CONT_SENDMSG_FAILURES) {

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -131,6 +131,8 @@ struct totem_config {
 	 */
 	unsigned int token_timeout;
 
+	unsigned int token_warning;
+
 	unsigned int token_retransmit_timeout;
 
 	unsigned int token_hold_timeout;
@@ -270,6 +272,7 @@ typedef struct {
 	uint64_t rx_msg_dropped;
 	uint32_t continuous_gather;
 	uint32_t continuous_sendmsg_failures;
+	uint64_t token_last_received;
 
 	int earliest_token;
 	int latest_token;


### PR DESCRIPTION
This is a NOT a real pull request since I see that master has diverged significantly from these changes.  Instead, I'm wondering whether a patch like this, which presents information on when the last token was received both in logs and to corosync-cmapctl, would be useful to the larger community.  I envision this information as helping users find an appropriate token timeout (heartbeat used to have messages like these, for example).

If this would be useful, I can try to adapt this to the changes from 55c3dcb76d502b763dae93f692814504f966068f.

Thanks!!