### PR TITLE
systemd: prevent redundancy in journal originating from a dual sink

### DIFF
--- a/init/corosync.service.in
+++ b/init/corosync.service.in
@@ -10,6 +10,13 @@ EnvironmentFile=-@INITCONFIGDIR@/corosync
 ExecStart=@SBINDIR@/corosync -f $COROSYNC_OPTIONS
 Type=notify
 
+# In typical systemd deployments, both standard outputs are forwarded to
+# journal (stderr is what's relevant in the pristine corosync configuration),
+# which hazards a message redundancy since the syslog stream usually ends there
+# as well; before editing this line, you may want to check DefaultStandardError
+# in systemd-system.conf(5) and whether /dev/log is a systemd related symlink.
+StandardError=null
+
 # The following config is for corosync with enabled watchdog service.
 #
 #  When corosync watchdog service is being enabled and using with


### PR DESCRIPTION
Annotated example from "journalctl -b --no-hostname -u corosync":

Aug 14 00:27:45 corosync[5203]:  [MAIN  ] Corosync Cluster Engine ('2.99.3'): started and ready to provide service.
  ^ from syslog source
Aug 14 00:27:45 corosync[5203]: notice  [MAIN  ] Corosync Cluster Engine ('2.99.3'): started and ready to provide service.
  ^ from stderr source

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>