### PR TITLE
Remove libcgroup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -394,11 +394,6 @@ AC_ARG_ENABLE([xmlconf],
 	[ enable_xmlconf="no" ])
 AM_CONDITIONAL(INSTALL_XMLCONF, test x$enable_xmlconf = xyes)
 
-AC_ARG_ENABLE([libcgroup],
-	[  --enable-libcgroup                  : Enable libcgroup support ],,
-	[ enable_libcgroup="no" ])
-AM_CONDITIONAL(ENABLE_LIBCGROUP, test x$enable_libcgroup = xyes)
-
 AC_ARG_ENABLE([vqsim],
 	[  --enable-vqsim               : Quorum simulator support ],,
 	[ enable_vqsim="no" ])
@@ -526,13 +521,6 @@ if test "x${enable_snmp}" = xyes; then
 	fi
 fi
 AM_CONDITIONAL(BUILD_SNMP, test "${do_snmp}" = "1")
-
-if test "x${enable_libcgroup}" = xyes; then
-    PKG_CHECK_MODULES([libcgroup], [libcgroup])
-    AC_DEFINE_UNQUOTED([HAVE_LIBCGROUP], 1, [have libcgroup])
-    PACKAGE_FEATURES="$PACKAGE_FEATURES libcgroup"
-    WITH_LIST="$WITH_LIST --with libcgroup"
-fi
 
 # extra warnings
 EXTRA_WARNINGS=""

--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -13,7 +13,6 @@
 %bcond_with systemd
 %bcond_with xmlconf
 %bcond_with runautogen
-%bcond_with libcgroup
 
 %global gitver %{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}
 %global gittarver %{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}
@@ -73,9 +72,6 @@ Requires(preun): /sbin/chkconfig
 %if %{with xmlconf}
 Requires: libxslt
 %endif
-%if %{with libcgroup}
-BuildRequires: libcgroup-devel
-%endif
 
 %prep
 %setup -q -n %{name}-%{version}%{?gittarver}
@@ -106,9 +102,6 @@ BuildRequires: libcgroup-devel
 %endif
 %if %{with xmlconf}
 	--enable-xmlconf \
-%endif
-%if %{with libcgroup}
-	--enable-libcgroup \
 %endif
 	--with-initddir=%{_initrddir} \
 	--with-systemddir=%{_unitdir} \

--- a/exec/Makefile.am
+++ b/exec/Makefile.am
@@ -74,10 +74,5 @@ corosync_LDADD		= libtotem_pg.la ../common_lib/libcorosync_common.la \
 
 corosync_DEPENDENCIES	= libtotem_pg.la ../common_lib/libcorosync_common.la
 
-if ENABLE_LIBCGROUP
-corosync_CFLAGS		+= $(libcgroup_CFLAGS)
-corosync_LDADD		+= $(libcgroup_LIBS)
-endif
-
 lint:
 	-splint $(LINT_FLAGS) $(CPPFLAGS) $(CFLAGS) *.c

--- a/man/corosync.8
+++ b/man/corosync.8
@@ -31,7 +31,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC 8 2017-07-07
+.TH COROSYNC 8 2018-08-14
 .SH NAME
 corosync \- The Corosync Cluster Engine.
 .SH SYNOPSIS
@@ -64,7 +64,9 @@ of scheduler fails, fallback to set maximal priority.
 .TP
 .B -R
 Do not try to move Corosync to root cpu cgroup. This feature is available only
-for corosync with libcgroup enabled during the build.
+for cgroups with RT sched enabled systems (Linux with
+CONFIG_RT_GROUP_SCHED kernel option). It's also expected to be removed as soon as
+systemd gets support for managing RT configuration.
 .TP
 .B -t
 Test configuration and then exit.


### PR DESCRIPTION
Libcgroup is deprecated and not shipping with new distributions
(OpenSuSE is one example). Solution is to have a partial implementation
of required functionality of libcgroup in the corosync code.

Patch uses hardcoded cgroup mount point, because most of the systems are
now systemd and systemd is also using hardcoded mountpoint (see
https://github.com/systemd/systemd/blob/master/src/core/mount-setup.c)

Configuration option --enable-cgroup is gone, because it's not needed
any longer.

Big thanks to Christine Caulfield <ccaulfie@redhat.com> for example of
simplified implementation of cgroup management code primitives.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>