### PR TITLE
man: fix cmap key name (runtime.config.totem.token)

### DIFF
--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -315,7 +315,7 @@ in the current configuration.  Reforming a new configuration takes about 50
 milliseconds in addition to this timeout.
 
 For real token timeout used by totem it's possible to read cmap value of
-.B runtime.config.token
+.B runtime.config.totem.token
 key.
 
 The default is 1000 milliseconds.


### PR DESCRIPTION
(Applies to needle as well.)