### PR TITLE
notifyd: Propagate error to exit code

### DIFF
--- a/tools/corosync-notifyd.c
+++ b/tools/corosync-notifyd.c
@@ -77,6 +77,8 @@ enum {
 };
 static int conf[CS_NTF_MAX];
 
+static int exit_code = 0;
+
 static int32_t _cs_is_quorate = 0;
 
 typedef void (*node_membership_fn_t)(char *nodename, uint32_t nodeid, char *state, char* ip);
@@ -410,6 +412,8 @@ _cs_cmap_dispatch(int fd, int revents, void *data)
 		qb_log(LOG_ERR, "Could not dispatch cmap events. Error %u", err);
 		qb_loop_stop(main_loop);
 
+		exit_code = 1;
+
 		return -1;
 	}
 
@@ -442,6 +446,8 @@ _cs_quorum_dispatch(int fd, int revents, void *data)
 		err != CS_ERR_QUEUE_FULL) {
 		qb_log(LOG_ERR, "Could not dispatch quorum events. Error %u", err);
 		qb_loop_stop(main_loop);
+
+		exit_code = 1;
 
 		return -1;
 	}
@@ -1371,6 +1377,6 @@ main(int argc, char *argv[])
 	_cs_quorum_finalize();
 	_cs_cmap_finalize();
 
-	return 0;
+	return (exit_code);
 }
 


### PR DESCRIPTION
When it's impossible to dispatch cmap/quorum messages exit code of
corosync-notifyd shouldn't be success.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>