### PR TITLE
build: Support for git archive stored tags

### DIFF
--- a/.gitarchivever
+++ b/.gitarchivever
@@ -1,0 +1,1 @@
+ref names:$Format:%d$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.gitarchivever export-subst

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -67,14 +67,15 @@ scriptversion=2010-10-13.20; # UTC
 #	echo $(VERSION) > $(distdir)/.tarball-version
 
 case $# in
-    1|2) ;;
+    1|2|3) ;;
     *) echo 1>&2 "Usage: $0 \$srcdir/.tarball-version" \
-         '[TAG-NORMALIZATION-SED-SCRIPT]'
+         '[$srcdir/.gitarchive-version] [TAG-NORMALIZATION-SED-SCRIPT]'
        exit 1;;
 esac
 
 tarball_version_file=$1
-tag_sed_script="${2:-s/x/x/}"
+gitarchive_version_file=$2
+tag_sed_script="${3:-s/x/x/}"
 nl='
 '
 
@@ -131,7 +132,20 @@ then
     # Remove the "g" in git describe's output string, to save a byte.
     v=`echo "$v" | sed 's/-/./;s/\(.*\)-g/\1-/'`;
 else
-    v=UNKNOWN
+    if test -f $gitarchive_version_file
+    then
+        v=`sed 's/^.*tag: \(v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*$/\1/' $gitarchive_version_file` || exit 1
+        case $v in
+            *$nl*) v= ;; # reject multi-line output
+            v[0-9]*) ;;
+            *) v= ;;
+        esac
+        test -z "$v" \
+            && echo "$0: WARNING: $gitarchive_version_file doesn't contain valid version tag" 1>&2 \
+            && v=UNKNOWN
+    else
+        v=UNKNOWN
+    fi
 fi
 
 v=`echo "$v" |sed 's/^v//'`

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Print a version string.
-scriptversion=2010-10-13.20; # UTC
+scriptversion=2018-08-31.20; # UTC
 
+# Copyright (C) 2018 Red Hat, Inc.
 # Copyright (C) 2007-2010 Free Software Foundation, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -46,6 +47,17 @@ scriptversion=2010-10-13.20; # UTC
 #
 # It is probably wise to add these two files to .gitignore, so that you
 # don't accidentally commit either generated file.
+#
+# In order to use git archive versions another two files has to be presented:
+#
+# .gitarchive-version - present in checked-out repository and git
+#   archive tarball, but not in the distribution tarball. Used as a last
+#   option for version. File must contain special string $Format:%d$,
+#   which is substitued by git on archive operation.
+#
+# .gitattributes - present in checked-out repository and git archive
+#   tarball, but not in the distribution tarball. Must set export-subst
+#   attribute for .gitarchive-version file.
 #
 # Use the following line in your configure.ac, so that $(VERSION) will
 # automatically be up-to-date each time configure is run (and note that

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -160,6 +160,14 @@ else
     fi
 fi
 
+if test "$v" = "UNKNOWN"
+then
+  echo "$0: ERROR: Can't find valid version. Please use valid git repository," \
+    "released tarball or version tagged archive" 1>&2
+
+  exit 1
+fi
+
 v=`echo "$v" |sed 's/^v//'`
 
 # Don't declare a version "dirty" merely because a time stamp has changed.

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 AC_PREREQ([2.61])
 
 AC_INIT([corosync],
-	m4_esyscmd([build-aux/git-version-gen .tarball-version]),
+	m4_esyscmd([build-aux/git-version-gen .tarball-version .gitarchivever]),
 	[users@clusterlabs.org])
 
 AC_USE_SYSTEM_EXTENSIONS


### PR DESCRIPTION
Attempt to solve problem with git archive generated tarballs
(used for example by github when release is downloaded) which are no
longer git tree and (in contrast to officially released tarballs) also
doesn't contain .tarball-version file so git-version-gen script simply
cannot obtain valid version info.

Solution is based on using gitattributes which is instructs git to
replace string in the .gitarchivever file by known ref names.
git-version-gen is enhanced to support this file and tries to parse
any string which looks like "tag: v[0-9]+.[0-9]+.[0-9]". If such string
is found it's used as a version. This file is used as a last attempt and
other methods (.tarball-version, git abbrev) have precedence.

Based on idea stated by Jan Pokorný <jpokorny@redhat.com>.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>