### PR TITLE
build: Remove totempg shared library leftovers

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -247,11 +247,6 @@ The Corosync Cluster Engine APIs.
 %{_includedir}/corosync/sam.h
 %{_includedir}/corosync/quorum.h
 %{_includedir}/corosync/votequorum.h
-%dir %{_includedir}/corosync/totem/
-%{_includedir}/corosync/totem/totem.h
-%{_includedir}/corosync/totem/totemip.h
-%{_includedir}/corosync/totem/totempg.h
-%{_includedir}/corosync/totem/totemstats.h
 %{_libdir}/libcfg.so
 %{_libdir}/libcpg.so
 %{_libdir}/libcmap.so

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -42,6 +42,6 @@ TOTEM_H			= totem.h totemip.h totempg.h totemstats.h
 
 EXTRA_DIST 		= $(noinst_HEADERS)
 
-noinst_HEADERS          = $(CS_INTERNAL_H:%=corosync/%)
+noinst_HEADERS          = $(CS_INTERNAL_H:%=corosync/%)  $(TOTEM_H:%=corosync/totem/%)
 
-nobase_include_HEADERS	= $(CS_H:%=corosync/%) $(TOTEM_H:%=corosync/totem/%)
+nobase_include_HEADERS	= $(CS_H:%=corosync/%)

--- a/pkgconfig/Makefile.am
+++ b/pkgconfig/Makefile.am
@@ -33,7 +33,7 @@ MAINTAINERCLEANFILES	= Makefile.in
 EXTRA_DIST		= libtemplate.pc.in corosync.pc.in
 
 LIBS	= cfg cpg quorum \
-	  totem_pg votequorum sam cmap corosync_common
+	  votequorum sam cmap corosync_common
 
 pkgconfigdir = $(libdir)/pkgconfig
 


### PR DESCRIPTION
Because totempg is not distributed it doesn't make sense to distribute
totem header files. Also pkgconfig file should not be created any more.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>