### PR TITLE
config: Fix crash in reload if new interfaces are added

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1137,7 +1137,7 @@ static void check_things_have_not_changed(struct totem_config *totem_config)
 				log_printf(LOGSYS_LEVEL_ERROR, "New config has different knet transport for link %d. Internal value was NOT changed.\n", i);
 				changed = 1;
 			}
-			for (j=0; j<totem_config->interfaces[i].member_count; j++) {
+			for (j=0; j < min(totem_config->interfaces[i].member_count, totem_config->orig_interfaces[i].member_count); j++) {
 				if (memcmp(&totem_config->interfaces[i].member_list[j],
 					   &totem_config->orig_interfaces[i].member_list[j],
 					   sizeof(struct totem_ip_address))) {
@@ -1152,7 +1152,7 @@ static void check_things_have_not_changed(struct totem_config *totem_config)
 	}
 
 	if (changed) {
-		log_printf(LOGSYS_LEVEL_ERROR, "To reconfigure and interface it must be deleted and recreated. A working interface needs to be available to corosync at all times");
+		log_printf(LOGSYS_LEVEL_ERROR, "To reconfigure an interface it must be deleted and recreated. A working interface needs to be available to corosync at all times");
 	}
 }
 

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -108,9 +108,8 @@
 #define LOGSYS_UTILS_ONLY 1
 #include <corosync/logsys.h>
 
+#include "util.h"
 #include "totemsrp.h"
-
-#define min(a,b) ((a) < (b)) ? a : b
 
 struct totempg_mcast_header {
 	short version;

--- a/exec/util.c
+++ b/exec/util.c
@@ -136,8 +136,6 @@ void _corosync_exit_error (
 	exit (err);
 }
 
-#define min(a,b) ((a) < (b) ? (a) : (b))
-
 char *getcs_name_t (cs_name_t *name)
 {
 	static char ret_name[CS_MAX_NAME_LENGTH];

--- a/exec/util.h
+++ b/exec/util.h
@@ -63,6 +63,7 @@ enum e_corosync_done {
 	COROSYNC_DONE_PLOAD = 99
 };
 
+#define min(a,b) ((a) < (b) ? (a) : (b))
 
 /**
  * Compare two names.  returns non-zero on match.


### PR DESCRIPTION
This is a bug I seem to have introduced in
429209f4aa3c55504a49833e0004489f241e7819 where we compare links
for changes. if a new node was added on an existing link then it
was compared against a non-existant one in the previous configuration.
We now only compare nodes that are in both interfaces.

As I needed min() for this function, I moved it from individual
.c files into util.h so we only have one copy.

And the error message was fixed.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>