### PR TITLE
configure: move to AC_COMPILE_IFELSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,7 @@ LIB_MSG_RESULT(m4_shift(m4_shift($@)))dnl
 AC_MSG_CHECKING([whether $CC supports -Wunknown-warning-option -Werror])
 BACKUP="$CPPFLAGS"
 CPPFLAGS="$CPPFLAGS -Werror -Wunknown-warning-option"
-AC_PREPROC_IFELSE([AC_LANG_PROGRAM([])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
 		  [unknown_warnings_as_errors='-Wunknown-warning-option -Werror'; AC_MSG_RESULT([yes])],
 		  [unknown_warnings_as_errors=''; AC_MSG_RESULT([no])])
 CPPFLAGS="$BACKUP"
@@ -264,7 +264,7 @@ cc_supports_flag() {
 	BACKUP="$CPPFLAGS"
 	CPPFLAGS="$CPPFLAGS $@ $unknown_warnings_as_errors"
 	AC_MSG_CHECKING([whether $CC supports "$@"])
-	AC_PREPROC_IFELSE([AC_LANG_PROGRAM([])],
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
 			  [RC=0; AC_MSG_RESULT([yes])],
 			  [RC=1; AC_MSG_RESULT([no])])
 	CPPFLAGS="$BACKUP"


### PR DESCRIPTION
from AC_PREPROC_IFELSE which is strongly discouraged.

Our detection system was very weak and recent versions of clang did
show that PREPROC_IFELFE (cpp) would enable warning options that
the compiler does not support (clang).

Use a full compilation test to detect what works and what doesn't.

Based on knet patch 88491f27375a9e8aceb946853a1abf4d23ebb8f3.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>