### PR TITLE
corosync-notifyd: Delete the registered tracking key - master (and fix cmap/stats.c)

### DIFF
--- a/exec/cmap.c
+++ b/exec/cmap.c
@@ -848,7 +848,8 @@ static void message_handler_req_lib_cmap_track_delete(void *conn, const void *me
 		goto reply_send;
 	}
 
-	track_inst_handle = ((struct cmap_track_user_data *)icmap_track_get_user_data(*track))->track_inst_handle;
+	track_inst_handle = ((struct cmap_track_user_data *)
+	    conn_info->map_fns.map_track_get_user_data(*track))->track_inst_handle;
 
 	free(conn_info->map_fns.map_track_get_user_data(*track));
 

--- a/exec/stats.c
+++ b/exec/stats.c
@@ -543,6 +543,7 @@ cs_error_t stats_map_track_add(const char *key_name,
 
 	tracker->notify_fn = notify_fn;
 	tracker->user_data = user_data;
+	tracker->events = track_type;
 	if (key_name) {
 		tracker->key_name = strdup(key_name);
 		if (!tracker->key_name) {
@@ -572,7 +573,6 @@ cs_error_t stats_map_track_add(const char *key_name,
 			free(tracker);
 			return (qb_to_cs_error(err));
 		}
-		tracker->events = track_type;
 	}
 
 	qb_list_add (&tracker->list, &stats_tracker_list_head);


### PR DESCRIPTION
@chrissie-c Careful review is needed specially for first patch. I have no doubts about first part (= call proper function to get user data), but I'm not sure about second part (maybe there was a reason why tracker->events was initialized only for add/delete)?
