### PR TITLE
Pkgconfig fixes

### DIFF
--- a/include/corosync/cfg.h
+++ b/include/corosync/cfg.h
@@ -38,6 +38,12 @@
 #include <netinet/in.h>
 #include <corosync/corotypes.h>
 
+/*
+ * Too keep future ABI compatibility, this value
+ * is intentionaly bigger then INTERFACE_MAX
+ */
+#define CFG_MAX_INTERFACES			16
+
 typedef uint64_t corosync_cfg_handle_t;
 
 /**

--- a/include/corosync/ipc_cfg.h
+++ b/include/corosync/ipc_cfg.h
@@ -41,11 +41,6 @@
 
 #define CFG_INTERFACE_NAME_MAX_LEN		128
 #define CFG_INTERFACE_STATUS_MAX_LEN		512
-/*
- * Too keep future ABI compatibility, this value
- * is intentionaly bigger then INTERFACE_MAX
- */
-#define CFG_MAX_INTERFACES			16
 
 /**
  * @brief The req_lib_cfg_types enum

--- a/pkgconfig/Makefile.am
+++ b/pkgconfig/Makefile.am
@@ -30,7 +30,7 @@
 
 MAINTAINERCLEANFILES	= Makefile.in
 
-EXTRA_DIST		= libtemplate.pc.in corosync.pc.in
+EXTRA_DIST		= libtemplate.pc.in libcorosync_common.pc.in libsam.pc.in
 
 LIBS	= cfg cpg quorum \
 	  votequorum sam cmap corosync_common
@@ -39,11 +39,31 @@ pkgconfigdir = $(libdir)/pkgconfig
 
 target_LIBS = $(LIBS:%=lib%.pc)
 
-target_PACKAGE = corosync.pc
-
-pkgconfig_DATA = $(target_LIBS) $(target_PACKAGE)
+pkgconfig_DATA = $(target_LIBS)
 
 CLEANFILES = $(pkgconfig_DATA)
+
+libcorosync_common.pc: libcorosync_common.pc.in Makefile
+	rm -f $@-t $@
+	sed \
+		-e 's#@''PREFIX@#$(exec_prefix)#g' \
+		-e 's#@''LIBDIR@#$(libdir)#g' \
+		-e 's#@''LIBVERSION@#$(VERSION)#g' \
+		-e 's#@''LIB@#'$(@:lib%.pc=%)'#g' \
+	    $< > $@-t
+	chmod a-w $@-t
+	mv $@-t $@
+
+libsam.pc: libsam.pc.in Makefile
+	rm -f $@-t $@
+	sed \
+		-e 's#@''PREFIX@#$(exec_prefix)#g' \
+		-e 's#@''LIBDIR@#$(libdir)#g' \
+		-e 's#@''LIBVERSION@#$(VERSION)#g' \
+		-e 's#@''LIB@#'$(@:lib%.pc=%)'#g' \
+	    $< > $@-t
+	chmod a-w $@-t
+	mv $@-t $@
 
 lib%.pc: libtemplate.pc.in Makefile
 	rm -f $@-t $@
@@ -55,14 +75,3 @@ lib%.pc: libtemplate.pc.in Makefile
 	    $< > $@-t
 	chmod a-w $@-t
 	mv $@-t $@
-
-%: %.in Makefile
-	rm -f $@-t $@
-	sed \
-		-e 's#@''PREFIX@#$(exec_prefix)#g' \
-		-e 's#@''LIBDIR@#$(libdir)#g' \
-		-e 's#@''LIBVERSION@#$(VERSION)#g' \
-	    $< > $@-t
-	chmod a-w $@-t
-	mv $@-t $@
-

--- a/pkgconfig/libcorosync_common.pc.in
+++ b/pkgconfig/libcorosync_common.pc.in
@@ -5,7 +5,6 @@ includedir=${prefix}/include
 
 Name: @LIB@
 Version: @LIBVERSION@
-Description: Corosync @LIB@ library
-Requires.private: libcorosync_common libqb
+Description: Corosync common library
 Libs: -L${libdir} -l@LIB@
 Cflags: -I${includedir}

--- a/pkgconfig/libsam.pc.in
+++ b/pkgconfig/libsam.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: @LIB@
 Version: @LIBVERSION@
 Description: Corosync @LIB@ library
-Requires.private: libcorosync_common libqb
+Requires.private: libquorum libcmap
 Libs: -L${libdir} -l@LIB@
 Cflags: -I${includedir}

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -245,7 +245,7 @@ static void showaddrs_do(unsigned int nodeid)
 	corosync_cfg_callbacks_t callbacks;
 	int numaddrs;
 	int i;
-	corosync_cfg_node_address_t addrs[INTERFACE_MAX];
+	corosync_cfg_node_address_t addrs[CFG_MAX_INTERFACES];
 
 
 	result = corosync_cfg_initialize (&handle, &callbacks);
@@ -254,7 +254,7 @@ static void showaddrs_do(unsigned int nodeid)
 		exit (1);
 	}
 
-	if (corosync_cfg_get_node_addrs(handle, nodeid, INTERFACE_MAX, &numaddrs, addrs) == CS_OK) {
+	if (corosync_cfg_get_node_addrs(handle, nodeid, CFG_MAX_INTERFACES, &numaddrs, addrs) == CS_OK) {
 		for (i=0; i<numaddrs; i++) {
 			char buf[INET6_ADDRSTRLEN];
 			struct sockaddr_storage *ss = (struct sockaddr_storage *)addrs[i].address;

--- a/tools/corosync-cpgtool.c
+++ b/tools/corosync-cpgtool.c
@@ -65,9 +65,9 @@ static void fprint_addrs(FILE *f, unsigned int nodeid)
 {
 	int numaddrs;
 	int i;
-	corosync_cfg_node_address_t addrs[INTERFACE_MAX];
+	corosync_cfg_node_address_t addrs[CFG_MAX_INTERFACES];
 
-	if (corosync_cfg_get_node_addrs(cfg_handle, nodeid, INTERFACE_MAX, &numaddrs, addrs) == CS_OK) {
+	if (corosync_cfg_get_node_addrs(cfg_handle, nodeid, CFG_MAX_INTERFACES, &numaddrs, addrs) == CS_OK) {
 		for (i=0; i<numaddrs; i++) {
 			char buf[INET6_ADDRSTRLEN];
 			struct sockaddr_storage *ss = (struct sockaddr_storage *)addrs[i].address;

--- a/tools/corosync-quorumtool.c
+++ b/tools/corosync-quorumtool.c
@@ -314,8 +314,8 @@ static const char *node_name(uint32_t nodeid, name_format_t name_format)
 {
 	int err;
 	int numaddrs;
-	corosync_cfg_node_address_t addrs[INTERFACE_MAX];
-	static char buf[(INET6_ADDRSTRLEN + 1) * KNET_MAX_LINK];
+	corosync_cfg_node_address_t addrs[CFG_MAX_INTERFACES];
+	static char buf[(INET6_ADDRSTRLEN + 1) * CFG_MAX_INTERFACES];
 	const char *nodelist_name = NULL;
 	socklen_t addrlen;
 	struct sockaddr_storage *ss;
@@ -336,7 +336,7 @@ static const char *node_name(uint32_t nodeid, name_format_t name_format)
 		bufptr = strlen(buf);
 	}
 
-	err = corosync_cfg_get_node_addrs(c_handle, nodeid, INTERFACE_MAX, &numaddrs, addrs);
+	err = corosync_cfg_get_node_addrs(c_handle, nodeid, CFG_MAX_INTERFACES, &numaddrs, addrs);
 	if (err != CS_OK) {
 		fprintf(stderr, "Unable to get node address for nodeid %u: %s\n", nodeid, cs_strerror(err));
 		return "";


### PR DESCRIPTION
Tested by removing all system corosync libraries (libcpg.so, ...),configure corosync with `--enable-static --disable-shared` parameters and installed.  Then compiling tests/tools (with small modifications, like removal of `#include <config.h>`, ...) with command similar to:
```
 gcc `pkg-config --cflags libsam`  -pthread testsam.c  `pkg-config --libs --static libsam`
```

Second patch is result of compiling quorumtool. Not entirely needed, but IMHO user of libraries should have (to some level) similar constants available as programs linked in corosync tree.