### PR TITLE
config: Disallow corosync-cmapctl updates of nodelist

### DIFF
--- a/exec/main.c
+++ b/exec/main.c
@@ -1030,6 +1030,7 @@ static void set_icmap_ro_keys_flag (void)
 	icmap_set_ro_access("runtime.totem.", CS_TRUE, CS_TRUE);
 	icmap_set_ro_access("uidgid.config.", CS_TRUE, CS_TRUE);
 	icmap_set_ro_access("system.", CS_TRUE, CS_TRUE);
+	icmap_set_ro_access("nodelist.", CS_TRUE, CS_TRUE);
 
 	/*
 	 * Set RO flag for constrete keys of configuration which can't be changed

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1293,44 +1293,6 @@ static int put_nodelist_members_to_config(struct totem_config *totem_config, int
 	return 0;
 }
 
-static void nodelist_dynamic_notify(
-	int32_t event,
-	const char *key_name,
-	struct icmap_notify_value new_val,
-	struct icmap_notify_value old_val,
-	void *user_data)
-{
-	int res;
-	unsigned int ring_no;
-	unsigned int member_no;
-	char tmp_str[ICMAP_KEYNAME_MAXLEN];
-	uint8_t reloading;
-	const char *error_string;
-	struct totem_config *totem_config = (struct totem_config *)user_data;
-
-	/*
-	* If a full reload is in progress then don't do anything until it's done and
-	* can reconfigure it all atomically
-	*/
-	if (icmap_get_uint8("config.totemconfig_reload_in_progress", &reloading) == CS_OK && reloading) {
-		return ;
-	}
-
-	res = sscanf(key_name, "nodelist.node.%u.ring%u%s", &member_no, &ring_no, tmp_str);
-	if (res != 3)
-		return ;
-
-	if (strcmp(tmp_str, "_addr") != 0) {
-		return;
-	}
-
-	if (put_nodelist_members_to_config(totem_config, 1, &error_string)) {
-		log_printf (LOGSYS_LEVEL_ERROR, "%s", error_string);
-	}
-}
-
-
-
 static void config_convert_nodelist_to_interface(struct totem_config *totem_config)
 {
 	int res = 0;
@@ -2216,11 +2178,5 @@ static void add_totem_config_notification(struct totem_config *totem_config)
 		ICMAP_TRACK_ADD | ICMAP_TRACK_MODIFY,
 		totem_reload_notify,
 		totem_config,
-		&icmap_track);
-
-	icmap_track_add("nodelist.node.",
-		ICMAP_TRACK_ADD | ICMAP_TRACK_DELETE | ICMAP_TRACK_MODIFY | ICMAP_TRACK_PREFIX,
-		nodelist_dynamic_notify,
-		(void *)totem_config,
 		&icmap_track);
 }

--- a/man/cmap_keys.8
+++ b/man/cmap_keys.8
@@ -65,7 +65,8 @@ key is same as in the configuration file. All values are of string type.
 
 .TP
 nodelist.*
-Values read from the configuration file. Each node element in the configuration file gets
+Values are read from the configuration file only (dynamic updates are not allowed).
+Each node element in the configuration file gets
 assigned its position starting from zero. So the first node from the config file has
 nodelist.node.0. prefix. To be a valid entry, each node must have
 .B ring0_addr
@@ -389,53 +390,6 @@ For removal of permissions, simply delete the key
 .br
 # corosync-cmapctl -d uidgid.gid.500
 
-.SH DYNAMIC ADD/REMOVE OF UDPU NODE
-Eg. To add the node with address 10.34.38.108
-and nodeid 3. This node is called NEW and it's not running corosync yet.
-
-.PP
-* Find a node position in the node list which is not used yet. It's recommended that you
-use highest_number + 1. Let's say output of corosync-cmapctl looks like:
-
-.br
-nodelist.local_node_pos (u32) = 1
-.br
-nodelist.node.0.nodeid (u32) = 1
-.br
-nodelist.node.0.ring0_addr (str) = 10.34.38.106
-.br
-nodelist.node.1.nodeid (u32) = 2
-.br
-nodelist.node.1.ring0_addr (str) = 10.34.38.107
-
-So next node position will be 2.
-.PP
-* Add all entries needed for the node on all running nodes, as:
-
-.br
-# corosync-cmapctl -s nodelist.node.2.nodeid u32 3
-.br
-# corosync-cmapctl -s nodelist.node.2.ring0_addr str 10.34.38.108
-
-Always add the ring0_addr key last. The Corosync engine on all nodes should reply
-with
-.I notice  [TOTEM ] adding new UDPU member {10.34.38.108}
-message.
-.PP
-* Add node information to the configuration file on all nodes so that it
-will survive a restart of corosync.
-.PP
-* Copy and edit configuration file to the NEW node.
-.PP
-* Start corosync on the NEW node.
-
-Removal of a UDPU node is a very similar, slightly reversed action, so
-.PP
-* Stop corosync on the OLD node.
-.PP
-* Remove the relevant entries from cmap on all nodes.
-.PP
-* Change the configuration file on all nodes.
 
 .SH "SEE ALSO"
 .BR corosync_overview (7),

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -775,6 +775,96 @@ potentially breaking down membership.  IPMI watchdogs are particularly
 notorious in this regard: read about kipmid_max_busy_us in IPMI.txt in
 the Linux kernel documentation.
 
+.SH "TO ADD A NEW NODE TO THE CLUSTER"
+For example to add a node with address 10.24.38.108 with nodeid 3. The node has the name NEW 
+(in DNS or /etc/hosts) and is not currently running corosync. The current corosync.conf nodelist 
+looks like this:
+.PP
+.nf
+.RS
+nodelist {
+    node {
+        nodeid: 1
+        ring0_addr: 10.24.38.101
+        name: node1
+    }
+    node {
+        nodeid: 2
+        ring0_addr: 10.24.38.102
+        name: node2
+
+    }
+}
+.RE
+.fi
+.PP
+Add a new entry for the node below the existing nodes. Node entries don't have
+to be in nodeid order, but it will help keep you sane. So the nodelist now looks like this:
+.PP
+.nf
+.RS
+nodelist {
+    node {
+        nodeid: 1
+        ring0_addr: 10.24.38.101
+        name: node1
+    }
+    node {
+        nodeid: 2
+        ring0_addr: 10.24.38.102
+        name: node2
+
+    }
+    node {
+        nodeid: 3
+        ring0_addr: 10.24.38.108
+        name: NEW
+
+    }
+}
+.RE
+.fi
+.PP
+
+.PP
+This file must then be copied onto all three nodes -  the existing two nodes, and the new one.
+On one of the existing corosync nodes, tell corosync to re-read the updated config file into memory:
+.PP
+.nf
+.RS
+corosync-cfgtool -R
+.RE
+.fi
+.PP
+This command only needs to be run on one node in the cluster. You may then start corosync on the NEW node 
+and it should join the cluster. If this doesn't work as expected then check the communications between all
+three nodes is working, and check the syslog files on all nodes for more information. It's important to note
+that the key bit of information about a node failing to join might be on a different node than you expect.
+
+.SH "TO REMOVE A NODE FROM THE CLUSTER"
+This is the reverse procedure to 'Adding a node' above. First you need to shut down the node you will
+be removing from the cluster.
+.PP
+.nf
+.RS
+corosync-cfgtool -H
+.RE
+.fi
+
+
+.PP
+Then delete the nodelist stanza from corosync.conf and finally update corosync on the remaining nodes by
+running
+.PP
+.nf
+.RS
+corosync-cfgtool -R
+.RE
+.fi
+.TP
+on one of them.
+
+
 .SH "FILES"
 .TP
 /etc/corosync/corosync.conf


### PR DESCRIPTION
It didn't work anyway (the config system requires whole links
to be configured at once) and caused crashes.