### PR TITLE
config: Look up hostnames in a defined order

### DIFF
--- a/exec/totemip.c
+++ b/exec/totemip.c
@@ -295,8 +295,17 @@ int totemip_parse(struct totem_ip_address *totemip, const char *addr, int family
 	ahints.ai_protocol = IPPROTO_UDP;
 	ahints.ai_family   = family;
 
-	/* Lookup the nodename address */
-	ret = getaddrinfo(addr, NULL, &ahints, &ainfo);
+	/* If no address family specified then try IPv6 first then IPv4 */
+	if (family == AF_UNSPEC) {
+		ahints.ai_family = AF_INET6;
+		ret = getaddrinfo(addr, NULL, &ahints, &ainfo);
+		if (ret) {
+			ahints.ai_family = AF_INET;
+			ret = getaddrinfo(addr, NULL, &ahints, &ainfo);
+		}
+	} else {
+		ret = getaddrinfo(addr, NULL, &ahints, &ainfo);
+	}
 	if (ret)
 		return -1;
 


### PR DESCRIPTION
Current practice is to let getaddrinfo() decide which address we get
but this is not necessarily deterministic as DNS servers won't
always return addresses in the same order if a node has
several. While this doesn't deal with node names that have
multiple IP addresses of the same family (that's an installation issue
IMHO) we can, at least, force a definite order for IPv6/IPv4 name
resolution.

I've chosen IPv6 then IPv4 as that's what happens on my test system (
using /etc/hosts) and it also seems more 'future proof'.