### PR TITLE
main: Rename run_dir to state_dir

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -597,7 +597,7 @@ static void remove_ro_entries(icmap_map_t temp_map)
 	delete_and_notify_if_changed(temp_map, "system.sched_rr");
 	delete_and_notify_if_changed(temp_map, "system.priority");
 	delete_and_notify_if_changed(temp_map, "system.qb_ipc_type");
-	delete_and_notify_if_changed(temp_map, "system.run_dir");
+	delete_and_notify_if_changed(temp_map, "system.state_dir");
 }
 
 /*

--- a/exec/main.c
+++ b/exec/main.c
@@ -221,7 +221,7 @@ static void corosync_blackbox_write_to_file (void)
 
 	strftime(time_str, PATH_MAX, "%Y-%m-%dT%H:%M:%S", &cur_time_tm);
 	if (snprintf(fname, PATH_MAX, "%s/fdata-%s-%lld",
-	    get_run_dir(),
+	    get_state_dir(),
 	    time_str,
 	    (long long int)getpid()) >= PATH_MAX) {
 		log_printf(LOGSYS_LEVEL_ERROR, "Can't snprintf blackbox file name");
@@ -232,7 +232,7 @@ static void corosync_blackbox_write_to_file (void)
 		LOGSYS_PERROR(-res, LOGSYS_LEVEL_ERROR, "Can't store blackbox file");
 		return ;
 	}
-	snprintf(fdata_fname, sizeof(fdata_fname), "%s/fdata", get_run_dir());
+	snprintf(fdata_fname, sizeof(fdata_fname), "%s/fdata", get_state_dir());
 	unlink(fdata_fname);
 	if (symlink(fname, fdata_fname) == -1) {
 		log_printf(LOGSYS_LEVEL_ERROR, "Can't create symlink to '%s' for corosync blackbox file '%s'",
@@ -639,7 +639,7 @@ static void corosync_ring_id_create_or_load (
 	char filename[PATH_MAX];
 
 	snprintf (filename, sizeof(filename), "%s/ringid_%u",
-		get_run_dir(), nodeid);
+		get_state_dir(), nodeid);
 	fd = open (filename, O_RDONLY, 0700);
 	/*
 	 * If file can be opened and read, read the ring id
@@ -684,7 +684,7 @@ static void corosync_ring_id_store (
 	int res;
 
 	snprintf (filename, sizeof(filename), "%s/ringid_%u",
-		get_run_dir(), nodeid);
+		get_state_dir(), nodeid);
 
 	fd = open (filename, O_WRONLY, 0700);
 	if (fd == -1) {
@@ -1332,16 +1332,16 @@ int main (int argc, char **argv, char **envp)
 	/*
 	 * Make sure required directory is present
 	 */
-	res = stat (get_run_dir(), &stat_out);
+	res = stat (get_state_dir(), &stat_out);
 	if ((res == -1) || (res == 0 && !S_ISDIR(stat_out.st_mode))) {
-		log_printf (LOGSYS_LEVEL_ERROR, "Required directory not present %s.  Please create it.", get_run_dir());
+		log_printf (LOGSYS_LEVEL_ERROR, "Required directory not present %s.  Please create it.", get_state_dir());
 		corosync_exit_error (COROSYNC_DONE_DIR_NOT_PRESENT);
 	}
 
-	res = chdir(get_run_dir());
+	res = chdir(get_state_dir());
 	if (res == -1) {
-		log_printf (LOGSYS_LEVEL_ERROR, "Cannot chdir to run directory %s.  "
-		    "Please make sure it has correct context and rights.", get_run_dir());
+		log_printf (LOGSYS_LEVEL_ERROR, "Cannot chdir to state directory %s.  "
+		    "Please make sure it has correct context and rights.", get_state_dir());
 		corosync_exit_error (COROSYNC_DONE_DIR_NOT_PRESENT);
 	}
 

--- a/exec/util.c
+++ b/exec/util.c
@@ -169,16 +169,16 @@ int cs_name_tisEqual (cs_name_t *str1, char *str2) {
 	}
 }
 
-const char *get_run_dir(void)
+const char *get_state_dir(void)
 {
 	static char path[PATH_MAX] = {'\0'};
-	char *cmap_run_dir;
+	char *cmap_state_dir;
 	int res;
 
 	if (path[0] == '\0') {
-		if (icmap_get_string("system.run_dir", &cmap_run_dir) == CS_OK) {
-			res = snprintf(path, PATH_MAX, "%s", cmap_run_dir);
-			free(cmap_run_dir);
+		if (icmap_get_string("system.state_dir", &cmap_state_dir) == CS_OK) {
+			res = snprintf(path, PATH_MAX, "%s", cmap_state_dir);
+			free(cmap_state_dir);
 		} else {
 			res = snprintf(path, PATH_MAX, "%s/%s", LOCALSTATEDIR, "lib/corosync");
 		}

--- a/exec/util.h
+++ b/exec/util.h
@@ -83,8 +83,8 @@ const char * short_service_name_get(uint32_t service_id,
 				    char *buf, size_t buf_size);
 
 /*
- * Return run directory (ether icmap system.run_dir or LOCALSTATEDIR/lib/corosync)
+ * Return state directory (ether icmap system.state_dir or LOCALSTATEDIR/lib/corosync)
  */
-const char *get_run_dir(void);
+const char *get_state_dir(void);
 
 #endif /* UTIL_H_DEFINED */

--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -780,7 +780,7 @@ static int load_ev_tracking_barrier(void)
 
 	ENTER();
 
-	snprintf(filename, sizeof(filename) - 1, "%s/ev_tracking", get_run_dir());
+	snprintf(filename, sizeof(filename) - 1, "%s/ev_tracking", get_state_dir());
 
 	ev_tracking_fd = open(filename, O_RDWR, 0700);
 	if (ev_tracking_fd != -1) {

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC_CONF 5 2018-11-13 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH COROSYNC_CONF 5 2018-12-14 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 corosync.conf - corosync executive configuration file
 
@@ -762,7 +762,7 @@ cgroup. This feature is available only for systems with cgroups with RT
 sched enabled (Linux with CONFIG_RT_GROUP_SCHED kernel option).
 
 .TP
-run_dir
+state_dir
 Existing directory where corosync should chdir into. Corosync stores
 important state files and blackboxes there.
 

--- a/man/votequorum.5
+++ b/man/votequorum.5
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH VOTEQUORUM 5 2012-01-24 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH VOTEQUORUM 5 2018-12-14 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 votequorum \- Votequorum Configuration Overview
 .SH OVERVIEW
@@ -361,7 +361,8 @@ Note that even if the in-memory version of expected_votes is reduced, eg by remo
 or using corosync-quorumtool, the stored value will still be the highest value seen - it
 never gets reduced.
 .PP
-The value is held in the file /var/lib/corosync/ev_tracking which can be deleted if you 
+The value is held in the file ev_tracking (stored in the directory configured in system.state_dir
+or /var/lib/corosync/ when unset) which can be deleted if you
 really do need to reduce the expected votes for any reason, like the node has been moved 
 to a different cluster.
 .PP


### PR DESCRIPTION
system.run_dir was a little bit unfortunate and confusing name. Rename
to state_dir makes more evident what is content of this directory. To
keep setting consistent with code, get_run_dir is changed to
get_state_dir.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>