### PR TITLE
systemd: corosync makes little sense as free standing service under init

### DIFF
--- a/init/corosync.service.in
+++ b/init/corosync.service.in
@@ -4,6 +4,7 @@ Documentation=man:corosync man:corosync.conf man:corosync_overview
 ConditionKernelCommandLine=!nocluster
 Requires=network-online.target
 After=network-online.target
+StopWhenUnneeded=yes
 
 [Service]
 EnvironmentFile=-@INITCONFIGDIR@/corosync


### PR DESCRIPTION
It shall be a rule of thumb not to combine "application stack"
components run under particular init/supervision mechanism and
run by whatever other means (without transitive relationships
like when corosync's client runs from other pacemaker that is
itself started through systemd) when there's a directed graph
of reliance between them (sans constrained corner cases like
when of such components is a kernel module).

And corosync on its own is just a service provider that only
appears useful when utilized as a basic building block for
application specific distributed environments.

Therefore, we may assume whenever corosync gets started by the
means of systemd, it's because of a mechanized attempt to satisfy
declared dependency of some such corosync's client that is about
to be started under the service manager realms (directly or, by
induction, through the same triggering mechanism indirectly).
Hence, when there's no such client around anymore (unless
this dependant is being restarted at the moment, see below)
corosync shall rather shutdown as well.

In the past, there was an issue with systemd regarding said
inflicted restart of the dependant/client, but that's resolved
as of v236:
https://github.com/systemd/systemd/commit/deb4e7080db9dcd2a1d51ccf7c357f88ea863e54