### PR TITLE
Message changes

### DIFF
--- a/conf/corosync.conf.example
+++ b/conf/corosync.conf.example
@@ -1,5 +1,7 @@
 # Please read the corosync.conf.5 manual page
 totem {
+	version: 2
+
 	# Set name of the cluster
 	cluster_name: ExampleCluster
 

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -1633,7 +1633,7 @@ static int read_config_file_into_icmap(
 		char error_str[100];
 		const char *error_ptr = qb_strerror_r(errno, error_str, sizeof(error_str));
 		snprintf (error_reason, sizeof(error_string_response),
-			"Can't read file %s reason = (%s)",
+			"Can't read file %s: %s",
 			 filename, error_ptr);
 		*error_string = error_reason;
 		return -1;

--- a/exec/main.c
+++ b/exec/main.c
@@ -1318,7 +1318,7 @@ int main (int argc, char **argv, char **envp)
 	}
 
 	if (!testonly) {
-		log_printf (LOGSYS_LEVEL_NOTICE, "Corosync Cluster Engine ('%s'): started and ready to provide service.", VERSION);
+		log_printf (LOGSYS_LEVEL_NOTICE, "Corosync Cluster Engine %s starting up", VERSION);
 		log_printf (LOGSYS_LEVEL_INFO, "Corosync built-in features:" PACKAGE_FEATURES "");
 	}
 

--- a/exec/main.c
+++ b/exec/main.c
@@ -1334,7 +1334,7 @@ int main (int argc, char **argv, char **envp)
 	 */
 	res = stat (get_state_dir(), &stat_out);
 	if ((res == -1) || (res == 0 && !S_ISDIR(stat_out.st_mode))) {
-		log_printf (LOGSYS_LEVEL_ERROR, "Required directory not present %s.  Please create it.", get_state_dir());
+		log_printf (LOGSYS_LEVEL_ERROR, "State directory %s not present.  Please create it.", get_state_dir());
 		corosync_exit_error (COROSYNC_DONE_DIR_NOT_PRESENT);
 	}
 

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1734,7 +1734,7 @@ extern int totem_config_read (
 				*warnings |= TOTEM_CONFIG_WARNING_TOTEM_NODEID_IGNORED;
 			}
 			if ((totem_config->transport_number == TOTEM_TRANSPORT_KNET) && (!totem_config->node_id)) {
-				*error_string = "With knet, you must specify nodeid for current node";
+				*error_string = "Knet requires an explicit nodeid for the local node";
 				return -1;
 			}
 


### PR DESCRIPTION
Just a couple of things I found strange experimenting with the configuration.
BTW is providing both `nodeid` and `name` for each node the best practice with KNET? http://people.redhat.com/ccaulfie/docs/KnetCorosync.pdf explains why `name` is useful, then `nodeid` unexpectedly appears in the text and gets even more useful: not only unique and stable against link changes, but defines the order of the nodes along the ring as well. So `name` does not seem that indispensable anymore. Except maybe it provides node names for Pacemaker?