### PR TITLE
Refrain from plain "virtual synchrony" term that's overloaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,11 @@
 <li>A simple availability manager that restarts the application process when it has failed.</li>
 <li>A configuration and statistics in-memory database that provide the ability to set, retrieve, and receive change notifications of information.</li>
 <li>A quorum system that notifies applications when quorum is achieved or lost.</li>
-</ul><p>Our project is used as a High Availability framework by projects such as Apache Qpid and Pacemaker.</p>
+</ul>
+<p>Our project is used as a High Availability foundation in projects such as
+   <a href="https://clusterlabs.org/pacemaker/">Pacemaker</a> (as a prerequisite)
+   or <a href="https://wiki.asterisk.org/wiki/display/AST/Corosync">Asterisk</a>
+   (optionally).</p>
 
 <p>We are always looking for developers or users interested in clustering or participating in our project.</p>
 

--- a/index.html
+++ b/index.html
@@ -33,7 +33,8 @@
 <p>The Corosync Cluster Engine is a Group Communication System with additional features for implementing high availability within applications. The project provides four C Application Programming Interface features:</p>
 
 <ul>
-<li>A closed process group communication model with virtual synchrony guarantees for creating replicated state machines.</li>
+<li>A closed process group communication model with extended virtual synchrony guarantees
+    (excluding its strongest notion for the time being) for creating replicated state machines.</li>
 <li>A simple availability manager that restarts the application process when it has failed.</li>
 <li>A configuration and statistics in-memory database that provide the ability to set, retrieve, and receive change notifications of information.</li>
 <li>A quorum system that notifies applications when quorum is achieved or lost.</li>


### PR DESCRIPTION
Corosync doesn't implement Virtual synchrony, the concrete algorithm
implementing the notion of (virtual) synchronicity within the
distributed system (where this notion itself can be, apparently
ambiguously, referred to as a virtual synchrony).

Regarding the specific algorithm in question, corosync implements
(substantial portion of) Extended virtual synchrony, so let's state
that explicitly, to prevent confusion.