### PR TITLE
totemip: Use AF_UNSPEC for ipv4-6 and ipv6-4

### DIFF
--- a/include/corosync/totem/totemip.h
+++ b/include/corosync/totem/totemip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005-2010 Red Hat, Inc.
+ * Copyright (c) 2005-2019 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -70,8 +70,8 @@ struct totem_ip_address
 enum totem_ip_version_enum {
 	TOTEM_IP_VERSION_4,		/* Use only AF_INET */
 	TOTEM_IP_VERSION_6,		/* Use only AF_INET6 */
-	TOTEM_IP_VERSION_4_6,		/* Use AF_INET and if it fails, use AF_INET6 */
-	TOTEM_IP_VERSION_6_4		/* Use AF_INET6 and if it fails, use AF_INET */
+	TOTEM_IP_VERSION_4_6,		/* Use AF_UNSPEC and filter result preferring AF_INET */
+	TOTEM_IP_VERSION_6_4		/* Use AF_UNSPEC and filter result preferring AF_INET6 */
 };
 
 struct totem_ip_if_address

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC_CONF 5 2018-12-14 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH COROSYNC_CONF 5 2019-01-10 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 corosync.conf - corosync executive configuration file
 
@@ -314,9 +314,11 @@ The value can be one of
 (check only IPv6 address)
 ,
 .B ipv4-6
-(first check IPv4 address, if that fails then look for an IPv6 address) and
+(look for all address families and use first IPv4 address found in the list if there is such address,
+otherwise use first IPv6 address) and
 .B ipv6-4
-(first check IPv6 address, if that fails then look for an IPv4 address).
+(look for all address families and use first IPv6 address found in the list if there is such address,
+otherwise use first IPv4 address).
 
 Default (if unspecified) is ipv6-4 for knet and udpu transports and ipv4 for udp.
 


### PR DESCRIPTION
AF_UNSPEC returns different results than AF_INET/AF_INET6, because of
nsswitch.conf search is in order and it stops asking other
modules once current module success.

Example of difference between previous and new code when ipv6-4 is used:
- /etc/hosts contains test_name with an ipv4
- previous code called AF_INET6 where /etc/hosts failed so other methods
were used which may return IPv6 addr -> result was ether fail or IPv6
address.
- new code calls AF_UNSPEC returning IPv4 defined in /etc/hosts ->
result is IPv4 address

New code behavior should solve problems caused by nss-myhostname.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>