### PR TITLE
corosync-cfgtool: Fix -i matching

### DIFF
--- a/man/corosync-cfgtool.8
+++ b/man/corosync-cfgtool.8
@@ -31,7 +31,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH "COROSYNC-CFGTOOL" "8" "2018-10-15" "" ""
+.TH "COROSYNC-CFGTOOL" "8" "2019-02-13" "" ""
 .SH "NAME"
 corosync-cfgtool \- An administrative tool for corosync.
 .SH "SYNOPSIS"
@@ -42,10 +42,10 @@ A tool for displaying and configuring active parameters within corosync.
 .SH "OPTIONS"
 .TP
 .B -i
-Finds only information about the specified interface IP address with -s.
+Finds only information about the specified interface IP address or link id with -s.
 .TP 
 .B -s
-Displays the status of the current links on this node for UDP/UDPU, while extended status
+Displays the status of the current links on this node for UDP/UDPU, with extended status
 for KNET. If any interfaces are faulty, 1 is returned by the binary. If all interfaces are
 active 0 is returned to the shell.
 After each link, the nodes on that link are displayed in order with their status,

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2017 Red Hat, Inc.
+ * Copyright (c) 2006-2019 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -111,25 +111,29 @@ linkstatusget_do (char *interface_name, int brief)
 		printf ("Could not get the link status, the error is: %d\n", result);
 	} else {
 		for (i = 0; i < interface_count; i++) {
+			char *cur_iface_name_space = strchr(interface_names[i], ' ');
+			int show_current_iface;
+
 			s = 0;
-			if ( (interface_name &&
-			      interface_names[i][0] != '\0' &&
-			      (interface_name[0]=='\0' ||
-				strcasecmp (interface_name, interface_names[i]) == 0)) ||
-				!interface_name ) {
+			/*
+			 * Interface_name is "<linkid> <IP address>"
+			 * separate them out
+			 */
+			if (!cur_iface_name_space) {
+				continue;
+			}
+			*cur_iface_name_space = '\0';
 
-				/*
-				 * Interface_name is "<linkid> <IP address>"
-				 * separate them out
-				 */
-				char *space = strchr(interface_names[i], ' ');
-				if (!space) {
-					continue;
-				}
-				*space = '\0';
+			show_current_iface = 1;
+			if (interface_name != NULL && interface_name[0] != '\0' &&
+			    strcmp(interface_name, interface_names[i]) != 0 &&
+			    strcmp(interface_name, cur_iface_name_space + 1) != 0) {
+				show_current_iface = 0;
+			}
 
+			if (show_current_iface) {
 				printf ("LINK ID %s\n", interface_names[i]);
-				printf ("\taddr\t= %s\n", space+1);
+				printf ("\taddr\t= %s\n", cur_iface_name_space + 1);
 				if((!brief) && (strcmp(interface_status[i], "OK") != 0) &&
 					(!strstr(interface_status[i], "FAULTY"))) {
 					len = strlen(interface_status[i]);
@@ -309,8 +313,8 @@ static void usage_do (void)
 	printf ("corosync-cfgtool [[-i <interface ip>] [-b] -s] [-R] [-L] [-k nodeid] [-a nodeid] [-h] [-H]\n\n");
 	printf ("A tool for displaying and configuring active parameters within corosync.\n");
 	printf ("options:\n");
-	printf ("\t-i\tFinds only information about the specified interface IP address when used with -s..\n");
-	printf ("\t-s\tDisplays the status of the current links on this node(UDP/UDPU), while extended status for KNET.\n");
+	printf ("\t-i\tFinds only information about the specified interface IP address or link id when used with -s..\n");
+	printf ("\t-s\tDisplays the status of the current links on this node(UDP/UDPU), with extended status for KNET.\n");
 	printf ("\t-b\tDisplays the brief status of the current links on this node when used with -s.(KNET only)\n");
 	printf ("\t-R\tTell all instances of corosync in this cluster to reload corosync.conf.\n");
 	printf ("\t-L\tTell corosync to reopen all logging files.\n");


### PR DESCRIPTION
Previously it was required to use link id together with IP address (ex.
"0 127.0.0.1") as a -i parameter.

This was reported as not very user friendly. Solution is to split
returned interface name and try match link id and ip address
separately.

Also fix typo in description of parameter -s.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>