### PR TITLE
quorumtool: Fix exit status codes

### DIFF
--- a/man/corosync-quorumtool.8
+++ b/man/corosync-quorumtool.8
@@ -31,7 +31,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC-QUORUMTOOL 8 2012-01-12
+.TH COROSYNC-QUORUMTOOL 8 2019-02-14
 .SH NAME
 corosync-quorumtool \- Set and display quorum settings.
 .SH SYNOPSIS
@@ -89,6 +89,21 @@ show this help text
 show version and exit
 .PP
 * Starred items only work if votequorum is the quorum provider for corosync
+.SH EXIT STATUS
+corosync-quorumtool may return one of several error codes if it encounters problems.
+.TP
+0
+No problems occurred (quorate for
+.B -s
+operation).
+.TP
+1
+Generic error code.
+.TP
+2
+Not quorate (returned only for
+.B -s
+operation).
 .SH SEE ALSO
 .BR corosync_overview (7),
 .BR votequorum_overview (3),

--- a/tools/corosync-quorumtool.c
+++ b/tools/corosync-quorumtool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2014 Red Hat, Inc.
+ * Copyright (c) 2009-2019 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -74,6 +74,8 @@ typedef enum {
 	SORT_NODEID,
 	SORT_NODENAME
 } sorttype_t;
+
+#define EXIT_NOT_QUORATE	2
 
 /*
  * global vars
@@ -238,7 +240,7 @@ static int set_votes(uint32_t nodeid, int votes)
 			votes, nodeid, cs_strerror(err));
 	}
 
-	return err==CS_OK?0:err;
+	return (err == CS_OK ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
 static int set_expected(int expected_votes)
@@ -249,7 +251,7 @@ static int set_expected(int expected_votes)
 		fprintf(stderr, "Unable to set expected votes: %s\n", cs_strerror(err));
 	}
 
-	return err==CS_OK?0:err;
+	return (err == CS_OK ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
 /*
@@ -642,9 +644,9 @@ static int display_quorum_data(int is_quorate,
 }
 
 /*
- * return  1 if quorate
- *         0 if not quorate
- *        -1 on error
+ * return EXIT_SUCCESS if quorate
+ *        EXIT_NOT_QUORATE if not quorate
+ *        EXIT_FAILURE on error
  */
 static int show_status(nodeid_format_t nodeid_format, name_format_t name_format, sorttype_t sort_type)
 {
@@ -693,15 +695,15 @@ static int show_status(nodeid_format_t nodeid_format, name_format_t name_format,
 
 quorum_err:
 	if (err != CS_OK) {
-		return -1;
+		return EXIT_FAILURE;
 	}
 
 	err = display_quorum_data(is_quorate, nodeid_format, name_format, sort_type, 0);
 	if (err != CS_OK) {
-		return -1;
+		return EXIT_FAILURE;
 	}
 
-	return is_quorate;
+	return (is_quorate ? EXIT_SUCCESS : EXIT_NOT_QUORATE);
 }
 
 static int monitor_status(nodeid_format_t nodeid_format, name_format_t name_format, sorttype_t sort_type) {
@@ -754,7 +756,7 @@ static int monitor_status(nodeid_format_t nodeid_format, name_format_t name_form
 	}
 
 quorum_err:
-	return -1;
+	return EXIT_FAILURE;
 }
 
 static int show_nodes(nodeid_format_t nodeid_format, name_format_t name_format, sorttype_t sort_type)
@@ -788,23 +790,30 @@ static int unregister_qdevice(void)
 {
 	int err;
 	struct votequorum_info info;
+	int result;
+
+	result = EXIT_FAILURE;
 
 	err = votequorum_getinfo(v_handle, our_nodeid, &info);
 	if (err != CS_OK) {
 		fprintf(stderr, "Unable to get quorum device info: %s\n", cs_strerror(err));
-		return -1;
+		goto err_exit;
 	}
 
 	if (!(info.flags & VOTEQUORUM_INFO_QDEVICE_REGISTERED)) {
-		return 0;
+		result = EXIT_SUCCESS;
+		goto err_exit;
 	}
 
 	err = votequorum_qdevice_unregister(v_handle, info.qdevice_name);
 	if (err != CS_OK) {
 		fprintf(stderr, "Unable to unregister quorum device: %s\n", cs_strerror(err));
-		return -1;
+		goto err_exit;
 	}
-	return 0;
+
+	result = EXIT_SUCCESS;
+err_exit:
+	return result;
 }
 
 /*
@@ -888,7 +897,7 @@ int main (int argc, char *argv[]) {
 
 	if (init_all()) {
 		close_all();
-		exit(1);
+		exit(EXIT_FAILURE);
 	}
 
 	while ( (opt = getopt(argc, argv, options)) != -1 ) {
@@ -898,7 +907,7 @@ int main (int argc, char *argv[]) {
 				command_opt = CMD_UNREGISTER_QDEVICE;
 			} else {
 				fprintf(stderr, "You cannot unregister quorum device, corosync is not using votequorum\n");
-				exit(2);
+				exit(EXIT_FAILURE);
 			}
 			break;
 		case 's':
@@ -932,14 +941,14 @@ int main (int argc, char *argv[]) {
 				}
 			} else {
 				fprintf(stderr, "You cannot change expected votes, corosync is not using votequorum\n");
-				exit(2);
+				exit(EXIT_FAILURE);
 			}
 			break;
 		case 'n':
 			l = strtol(optarg, &endptr, 0);
 			if ((l == 0 && endptr == optarg) || l < 0) {
 				fprintf(stderr, "The nodeid was not valid, try a positive number\n");
-				exit(2);
+				exit(EXIT_FAILURE);
 			}
 			nodeid = l;
 			nodeid_set = 1;
@@ -949,14 +958,14 @@ int main (int argc, char *argv[]) {
 				votes = strtol(optarg, &endptr, 0);
 				if ((votes == 0 && endptr == optarg) || votes < 0) {
 					fprintf(stderr, "New votes value was not valid, try a positive number or zero\n");
-					exit(2);
+					exit(EXIT_FAILURE);
 				} else {
 					command_opt = CMD_SETVOTES;
 				}
 			}
 			else {
 				fprintf(stderr, "You cannot change node votes, corosync is not using votequorum\n");
-				exit(2);
+				exit(EXIT_FAILURE);
 			}
 			break;
 		case 'o':
@@ -970,7 +979,7 @@ int main (int argc, char *argv[]) {
 					break;
 			        default:
 					fprintf(stderr, "Invalid ordering option. valid orders are a(address), i(node ID) or n(name)\n");
-					exit(2);
+					exit(EXIT_FAILURE);
 					break;
 			}
 			break;
@@ -989,7 +998,7 @@ int main (int argc, char *argv[]) {
 	switch (command_opt) {
 	case CMD_UNKNOWN:
 		show_usage(argv[0]);
-		ret = -1;
+		ret = EXIT_FAILURE;
 		break;
 	case CMD_SHOWNODES:
 		ret = show_nodes(nodeid_format, address_format, sort_opt);


### PR DESCRIPTION
1. Use EXIT_SUCCESS and EXIT_FAILURE when possible
2. For -s option return EXIT_SUCCESS when no problem appeared and node
   is quorate, EXIT_FAILURE if problem appeared and exit code 2
   (EXIT_NOT_QUORATE) when no problem appeared but node is not quorate.
3. Document exit codes in the man page

Signed-off-by: Jan Friesse <jfriesse@redhat.com>