### PR TITLE
[knet] allow corosync to enable/disable knet access lists

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,15 @@ AC_CHECK_LIB([z], [crc32],
     AM_CONDITIONAL([HAVE_CRC32], true),
     AM_CONDITIONAL([HAVE_CRC32], false))
 
+# this hack is necessary to check for symbols on out of tree builds
+# but it is as horrible as it gets and in theory users should be
+# invoking ./configure with proper LIBRARY_PATH set.
+OLDLIBS="$LIBS"
+LIBS="$knet_LIBS $LIBS"
+AC_CHECK_LIB([knet],[knet_handle_enable_access_lists],
+	     [AC_DEFINE_UNQUOTED([HAVE_KNET_ACCESS_LIST], 1, [have knet access list])])
+LIBS="$OLDLIBS"
+
 # Checks for library functions.
 AC_FUNC_ALLOCA
 AC_FUNC_CLOSEDIR_VOID

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -708,6 +708,9 @@ static int main_config_parser_cb(const char *path,
 			    (strcmp(path, "totem.miss_count_const") == 0) ||
 			    (strcmp(path, "totem.knet_pmtud_interval") == 0) ||
 			    (strcmp(path, "totem.knet_compression_threshold") == 0) ||
+#ifdef HAVE_KNET_ACCESS_LIST
+			    (strcmp(path, "totem.knet_enable_access_lists") == 0) ||
+#endif
 			    (strcmp(path, "totem.netmtu") == 0)) {
 				val_type = ICMAP_VALUETYPE_UINT32;
 				if (safe_atoq(value, &val, val_type) != 0) {

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -764,6 +764,16 @@ static void totemknet_refresh_config(
 		return;
 	}
 
+#ifdef HAVE_KNET_ACCESS_LIST
+	if (icmap_get_uint32("totem.knet_enable_access_lists", &value) == CS_OK) {
+		knet_log_printf (LOGSYS_LEVEL_DEBUG, "knet_enable access list: %d", value);
+		err = knet_handle_enable_access_lists(instance->knet_handle, value);
+		if (err) {
+			KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_WARNING, "knet_handle_enable_access_lists failed");
+		}
+	}
+#endif
+
 	if (icmap_get_uint32("totem.knet_pmtud_interval", &value) == CS_OK) {
 
 		instance->totem_config->knet_pmtud_interval = value;

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC_CONF 5 2019-01-16 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH COROSYNC_CONF 5 2019-03-10 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 corosync.conf - corosync executive configuration file
 
@@ -553,6 +553,11 @@ The default is 5 messages.
 knet_pmtud_interval
 How often the knet PMTUd runs to look for network MTU changes.
 Value in seconds, default: 30
+
+.TP
+knet_enable_access_lists
+Allow knet to drop packets from IP addresses that are not known to corosync.
+Value is 0 (off) and 1 (on). Default: 0.
 
 .PP
 Within the


### PR DESCRIPTION
currently knet acl are only available on master but they might be backported
to stable1 as they don´t break onwire protocol.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>