### PR TITLE
qnetd: Check existence of NSS DB dir before fork

### DIFF
--- a/init/corosync-qnetd.service.in
+++ b/init/corosync-qnetd.service.in
@@ -7,8 +7,8 @@ After=network-online.target
 
 [Service]
 EnvironmentFile=-@INITCONFIGDIR@/corosync-qnetd
-ExecStart=@BINDIR@/corosync-qnetd -f $COROSYNC_QNETD_OPTIONS
-Type=simple
+ExecStart=@BINDIR@/corosync-qnetd $COROSYNC_QNETD_OPTIONS
+Type=forking
 Restart=on-abnormal
 # Uncomment and set user who should be used for executing qnetd
 #User=coroqnetd

--- a/qdevices/corosync-qnetd.c
+++ b/qdevices/corosync-qnetd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -541,6 +541,16 @@ main(int argc, char * const argv[])
 
 	qnetd_log_set_debug(debug_log);
 	qnetd_log_set_priority_bump(bump_log_priority);
+
+	/*
+	 * Check that it's possible to open NSS dir if needed
+	 */
+	if (nss_sock_check_db_dir((tls_supported != TLV_TLS_UNSUPPORTED ?
+	    advanced_settings.nss_db_dir : NULL)) != 0) {
+		qnetd_log_err(LOG_ERR, "Can't open NSS DB directory");
+
+		exit (1);
+	}
 
 	/*
 	 * Daemonize

--- a/qdevices/nss-sock.c
+++ b/qdevices/nss-sock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -32,6 +32,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sys/types.h>
+
+#include <dirent.h>
 #include <limits.h>
 
 #include "nss-sock.h"
@@ -52,6 +55,24 @@ nss_sock_init_nss(char *config_dir)
 	if (NSS_SetDomesticPolicy() != SECSuccess) {
 		return (-1);
 	}
+
+	return (0);
+}
+
+int
+nss_sock_check_db_dir(const char *config_dir)
+{
+	DIR *dirp;
+
+	if (config_dir == NULL) {
+		return (0);
+	}
+
+	if ((dirp = opendir(config_dir)) == NULL) {
+		return (-1);
+	}
+
+	(void)closedir(dirp);
 
 	return (0);
 }

--- a/qdevices/nss-sock.h
+++ b/qdevices/nss-sock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Red Hat, Inc.
+ * Copyright (c) 2015-2019 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -55,6 +55,8 @@ struct nss_sock_non_blocking_client {
 };
 
 extern int		nss_sock_init_nss(char *config_dir);
+
+extern int		nss_sock_check_db_dir(const char *config_dir);
 
 extern PRFileDesc	*nss_sock_create_listen_socket(const char *hostname, uint16_t port,
     PRIntn af);


### PR DESCRIPTION
Previously, when user tried start corosync-qnetd without
initialized NSS database in then generic (not very helpful
and misleading) NSS error was logged
"NSS error (-8015): The certificate/key database is in an old,
unsupported format.".

Solution is to check if it's possible to open NSS DB directory and
display (usually much more informative) result of strerror function.

Such check is called before fork, so init system can return error code
during start.

To make error reporting work with systemd it's also needed to change unit
type from simple to forking.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>