### PR TITLE
crypto: keep defaults identical to Corosync 2.x

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -434,8 +434,8 @@ static int totem_get_crypto(struct totem_config *totem_config, const char **erro
 	const char *tmp_hash;
 	const char *tmp_model;
 
-	tmp_hash = "none";
-	tmp_cipher = "none";
+	tmp_hash = "sha1";
+	tmp_cipher = "aes256";
 	tmp_model = "none";
 
 	if (icmap_get_string("totem.crypto_model", &str) == CS_OK) {

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -216,7 +216,7 @@ messages. Valid values are none (no authentication), md5, sha1, sha256,
 sha384 and sha512. Encrypted transmission is only supported for
 the knet transport.
 
-The default is none.
+The default is sha1.
 
 .TP
 crypto_cipher
@@ -225,7 +225,7 @@ Valid values are none (no encryption), aes256, aes192, aes128 and 3des.
 Enabling crypto_cipher, requires also enabling of crypto_hash. Encrypted
 transmission is only supported for the knet transport.
 
-The default is none.
+The default is aes256.
 
 .TP
 keyfile


### PR DESCRIPTION
otherwise upgrades will silently be converted to unauthenticated,
plain text communication.

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>