### PR TITLE
set totem.keyfile and totem.key to RO

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -578,6 +578,8 @@ static void remove_ro_entries(icmap_map_t temp_map)
 	delete_and_notify_if_changed(temp_map, "totem.secauth");
 	delete_and_notify_if_changed(temp_map, "totem.crypto_hash");
 	delete_and_notify_if_changed(temp_map, "totem.crypto_cipher");
+	delete_and_notify_if_changed(temp_map, "totem.keyfile");
+	delete_and_notify_if_changed(temp_map, "totem.key");
 	delete_and_notify_if_changed(temp_map, "totem.version");
 	delete_and_notify_if_changed(temp_map, "totem.threads");
 	delete_and_notify_if_changed(temp_map, "totem.ip_version");

--- a/exec/main.c
+++ b/exec/main.c
@@ -1036,6 +1036,8 @@ static void set_icmap_ro_keys_flag (void)
 	 */
 	icmap_set_ro_access("totem.crypto_cipher", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.crypto_hash", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.keyfile", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.key", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.secauth", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.ip_version", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.rrp_mode", CS_FALSE, CS_TRUE);


### PR DESCRIPTION
so that we get the nice log message when attempting to modify them at
runtime, just like for totem.crypto_* and co.

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>