### PR TITLE
crypto: re-introduce secauth parameter

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -450,6 +450,14 @@ static int totem_get_crypto(struct totem_config *totem_config, const char **erro
 		tmp_model = "nss";
 	}
 
+	if (icmap_get_string("totem.secauth", &str) == CS_OK) {
+		if (strcmp(str, "on") == 0) {
+			tmp_cipher = "aes256";
+			tmp_hash = "sha256";
+		}
+		free(str);
+	}
+
 	if (icmap_get_string("totem.crypto_cipher", &str) == CS_OK) {
 		if (strcmp(str, "none") == 0) {
 			tmp_cipher = "none";

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -228,6 +228,14 @@ transmission is only supported for the knet transport.
 The default is none.
 
 .TP
+secauth
+This implies crypto_cipher=aes256 and crypto_hash=sha256, unless those options
+are explicitly set. Encrypted transmission is only supported for the knet
+transport.
+
+The default is off.
+
+.TP
 keyfile
 This specifies the fully qualified path to the shared key used to
 authenticate and encrypt data used within the Totem protocol.


### PR DESCRIPTION
with the following semantics:
- default off
- implies crypto_hash SHA256 and crypto_cipher AES256
- crypto_* have higher precedence
- only applicable for knet, like crypto_*

this should make upgrading from Corosync 2.x less painful for users that
have an explicit secauth=on in their configuration.

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>