### PR TITLE
totemconfig: Remove support for 3des

### DIFF
--- a/conf/lenses/corosync.aug
+++ b/conf/lenses/corosync.aug
@@ -51,8 +51,8 @@ let totem =
     |kv "rrp_mode" /none|active|passive/
     |kv "vsftype" /none|ykd/
     |kv "secauth" /on|off/
-    |kv "crypto_type" /nss|aes256|aes192|aes128|3des/
-    |kv "crypto_cipher" /none|nss|aes256|aes192|aes128|3des/
+    |kv "crypto_model" /nss|openssl/
+    |kv "crypto_cipher" /none|nss|aes256|aes192|aes128/
     |kv "crypto_hash" /none|md5|sha1|sha256|sha384|sha512/
     |kv "transport" /udp|iba|udpu/
     |kv "version" Rx.integer

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2018 Red Hat, Inc.
+ * Copyright (c) 2006-2019 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -747,13 +747,11 @@ static int main_config_parser_cb(const char *path,
 					return (0);
 				}
 			}
-			if (strcmp(path, "totem.crypto_type") == 0) {
+			if (strcmp(path, "totem.crypto_model") == 0) {
 				if ((strcmp(value, "nss") != 0) &&
-				    (strcmp(value, "aes256") != 0) &&
-				    (strcmp(value, "aes192") != 0) &&
-				    (strcmp(value, "aes128") != 0) &&
-				    (strcmp(value, "3des") != 0)) {
-					*error_string = "Invalid crypto type";
+				    (strcmp(value, "openssl") != 0)) {
+					*error_string = "Invalid crypto model. "
+					    "Should be nss or openssl";
 
 					return (0);
 				}
@@ -762,9 +760,9 @@ static int main_config_parser_cb(const char *path,
 				if ((strcmp(value, "none") != 0) &&
 				    (strcmp(value, "aes256") != 0) &&
 				    (strcmp(value, "aes192") != 0) &&
-				    (strcmp(value, "aes128") != 0) &&
-				    (strcmp(value, "3des") != 0)) {
-					*error_string = "Invalid cipher type";
+				    (strcmp(value, "aes128") != 0)) {
+					*error_string = "Invalid cipher type. "
+					    "Should be none, aes256, aes192 or aes128";
 
 					return (0);
 				}
@@ -776,7 +774,8 @@ static int main_config_parser_cb(const char *path,
 				    (strcmp(value, "sha256") != 0) &&
 				    (strcmp(value, "sha384") != 0) &&
 				    (strcmp(value, "sha512") != 0)) {
-					*error_string = "Invalid hash type";
+					*error_string = "Invalid hash type. "
+					    "Should be none, md5, sha1, sha256, sha384 or sha512";
 
 					return (0);
 				}

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -463,9 +463,6 @@ static int totem_get_crypto(struct totem_config *totem_config, const char **erro
 		if (strcmp(str, "aes128") == 0) {
 			tmp_cipher = "aes128";
 		}
-		if (strcmp(str, "3des") == 0) {
-			tmp_cipher = "3des";
-		}
 		free(str);
 	}
 

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -1,6 +1,6 @@
 .\"/*
 .\" * Copyright (c) 2005 MontaVista Software, Inc.
-.\" * Copyright (c) 2006-2018 Red Hat, Inc.
+.\" * Copyright (c) 2006-2019 Red Hat, Inc.
 .\" *
 .\" * All rights reserved.
 .\" *
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC_CONF 5 2019-01-16 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH COROSYNC_CONF 5 2019-04-11 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 corosync.conf - corosync executive configuration file
 
@@ -221,7 +221,7 @@ The default is none.
 .TP
 crypto_cipher
 This specifies which cipher should be used to encrypt all messages.
-Valid values are none (no encryption), aes256, aes192, aes128 and 3des.
+Valid values are none (no encryption), aes256, aes192 and aes128.
 Enabling crypto_cipher, requires also enabling of crypto_hash. Encrypted
 transmission is only supported for the knet transport.
 


### PR DESCRIPTION
Triple DES is considered as a "weak cipher" since 2016 so there is
really no need to support it in the corosync. Thanks to bug in
Corosync/Knet/NSS which caused 3des to not work at all,
no matter what library was used, we can just remove support for 3des
without braking the compatibility.

Also fix coroparse so:
- totem.crypto_type is removed (this is 1.x construct which was not used
even in 2.x)
- Add checking of totem.crypto_model.
- Enumarate possible values for crypto_model, crypto_cipher and
crypto_hash error messages

Signed-off-by: Jan Friesse <jfriesse@redhat.com>