### PR TITLE
man: fix a typo in cpg_model_initialize.3

### DIFF
--- a/man/cpg_model_initialize.3.in
+++ b/man/cpg_model_initialize.3.in
@@ -202,7 +202,7 @@ struct cpg_ring_id {
 .PP
 where
 .I nodeid
-is if of node of current Totem leader and seq is increasing number.
+is a 32 bit unique node identifier pertaining the current Totem leader and seq is increasing number.
 
 .PP
 .SH RETURN VALUE


### PR DESCRIPTION
Naively, I'd translate `Totem Leader` as a node currently in
possession of the token.  If that's incorrect, transcription of
that might also be in order.