### PR TITLE
vqsim: Fix vqsim for corosync 3.0

### DIFF
--- a/vqsim/vqmain.c
+++ b/vqsim/vqmain.c
@@ -667,14 +667,12 @@ int main(int argc, char **argv)
 {
 	qb_loop_signal_handle sigchld_qb_handle;
 	int ch;
-	char *config_file_name = NULL;
 	char *output_file_name = NULL;
-	char envstring[PATH_MAX];
 
 	while ((ch = getopt (argc, argv, "f:o:nh")) != EOF) {
 		switch (ch) {
 		case 'f':
-			config_file_name = optarg;
+			strncpy(corosync_config_file, optarg, sizeof(corosync_config_file));
 			break;
 		case 'o':
 			output_file_name = optarg;
@@ -688,10 +686,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (config_file_name) {
-		sprintf(envstring, "COROSYNC_MAIN_CONFIG_FILE=%s", config_file_name);
-		putenv(envstring);
-	}
 	if (output_file_name) {
 		output_file = fopen(output_file_name, "w");
 		if (!output_file) {


### PR DESCRIPTION
A couple of small internal changes in corosync 3.0 broke vqsim, this brings it back into line.

1) A custom config file is specified directly not in an environment  variable
2) votequorum now needs to know our_node_pos. Which is a lot easier to work out here
because we already know the nodeid.