### PR TITLE
knet: Fix a couple of errors when adding a new link

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1152,7 +1152,8 @@ static void check_things_have_not_changed(struct totem_config *totem_config)
 	int changed = 0;
 
 	for (i = 0; i<INTERFACE_MAX; i++) {
-		if (totem_config->interfaces[i].configured) {
+		if (totem_config->interfaces[i].configured &&
+		    totem_config->orig_interfaces[i].configured) {
 			if (totem_config->interfaces[i].knet_transport !=
 			    totem_config->orig_interfaces[i].knet_transport) {
 				log_printf(LOGSYS_LEVEL_ERROR,

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -1306,17 +1306,21 @@ int totemknet_member_add (
 		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_priority for nodeid %d, link %d failed", member->nodeid, link_no);
 	}
 
-	err = knet_link_set_ping_timers(instance->knet_handle, member->nodeid, link_no,
-				  instance->totem_config->interfaces[link_no].knet_ping_interval,
-				  instance->totem_config->interfaces[link_no].knet_ping_timeout,
-				  instance->totem_config->interfaces[link_no].knet_ping_precision);
-	if (err) {
-		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_ping_timers for nodeid %d, link %d failed", member->nodeid, link_no);
-	}
-	err = knet_link_set_pong_count(instance->knet_handle, member->nodeid, link_no,
-				       instance->totem_config->interfaces[link_no].knet_pong_count);
-	if (err) {
-		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_pong_count for nodeid %d, link %d failed", member->nodeid, link_no);
+	/* ping timeouts maybe 0 here for a newly added interface so we leave this till later, it will
+	   get done in totemknet_refresh_config */
+	if (instance->totem_config->interfaces[link_no].knet_ping_interval != 0) {
+		err = knet_link_set_ping_timers(instance->knet_handle, member->nodeid, link_no,
+						instance->totem_config->interfaces[link_no].knet_ping_interval,
+						instance->totem_config->interfaces[link_no].knet_ping_timeout,
+						instance->totem_config->interfaces[link_no].knet_ping_precision);
+		if (err) {
+			KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_ping_timers for nodeid %d, link %d failed", member->nodeid, link_no);
+		}
+		err = knet_link_set_pong_count(instance->knet_handle, member->nodeid, link_no,
+					       instance->totem_config->interfaces[link_no].knet_pong_count);
+		if (err) {
+			KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_pong_count for nodeid %d, link %d failed", member->nodeid, link_no);
+		}
 	}
 
 	err = knet_link_set_enable(instance->knet_handle, member->nodeid, link_no, 1);


### PR DESCRIPTION
When adding a new link for the first time you will often see:
1) knet_link_set_ping_timers for nodeid 1, link 1 failed: Invalid
argument (22)
2) New config has different knet transport for link 1. Internal value
was NOT changed. To reconfigure an interface it must be deleted and
recreated. A working interface needs to be available to corosync at all
times

1) is caused by setting the ping timers twice, once in
totemknet_member_add() and once in totemknet_refresh_config().
The first time we don't know the value
so it's zero and thus display an error. For this we simply check
for the zero and skip the knet API call. It's not ideal, but
totemconfig needs a lot of reconfiguring itself before we can
make this more sane.

2) was caused by simply comparing an unconfigured link with
a configured one, so OF COURSE, they are going to be different!