### PR TITLE
cfgtool: Fix link status display

### DIFF
--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -100,7 +100,7 @@ linkstatusget_do (char *interface_name, int brief)
 	unsigned int i;
 	cmap_iter_handle_t iter;
 	unsigned int nodeid;
-	unsigned int node_pos;
+	int nodeid_match_guard;
 	cmap_value_types_t type;
 	size_t value_len;
 	int rc = 0;
@@ -128,8 +128,12 @@ linkstatusget_do (char *interface_name, int brief)
 	}
 
 	while ((cmap_iter_next(cmap_handle, iter, iter_key, &value_len, &type)) == CS_OK) {
-		result = sscanf(iter_key, "nodelist.node.%u.nodeid", &node_pos);
-		if (result != 1) {
+		nodeid_match_guard = 0;
+		if (sscanf(iter_key, "nodelist.node.%*u.nodeid%n", &nodeid_match_guard) != 0) {
+			continue;
+		}
+		/* check for exact match */
+		if (nodeid_match_guard != strlen(iter_key)) {
 			continue;
 		}
 		if (cmap_get_uint32(cmap_handle, iter_key, &nodeid) == CS_OK) {


### PR DESCRIPTION
instead of the nodeid, this displayed arbitrary values (usually '1')
from other cmap keys under nodelist.node.XX.

sscanf returns the number of conversions even on mismatch, e.g. it also
returns 1 for

nodelist.node.2.quorum_votes
nodelist.node.2.ring0_addr
nodelist.node.2.name
...

instead of just

nodelist.node.2.nodeid

which leads to the value of (at least) quorum_votes being stored in
nodeid_list in addition to the actual nodeid.

storing the returned int in a cs_error_t enum also potentially masks
errors, so just compare the result with the expectation directly.

this approach is a bit hacky, and some sort of glob/RE matching would
probably be better suited (if already used elsewhere in the code base).

Fixes: c0d14485c3ebdeb2332f7c48acd155163e5b7fc1

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>