### PR TITLE
spec: Add support for user-flags configure option

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -14,6 +14,7 @@
 %bcond_with nozzle
 %bcond_with vqsim
 %bcond_with runautogen
+%bcond_with userflags
 
 %global gitver %{?numcomm:.%{numcomm}}%{?alphatag:.%{alphatag}}%{?dirty:.%{dirty}}
 %global gittarver %{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}
@@ -107,6 +108,9 @@ BuildRequires: readline-devel
 %endif
 %if %{with vqsim}
 	--enable-vqsim \
+%endif
+%if %{with userflags}
+	--enable-user-flags \
 %endif
 	--with-initddir=%{_initrddir} \
 	--with-systemddir=%{_unitdir} \


### PR DESCRIPTION
spec: Add support for user-flags configure option
    
Passing -ggdb3 (or -g3) during compiler may result in corrupted debuginfo files (bug in debugedit - for Fedora filed as a https://bugzilla.redhat.com/show_bug.cgi?id=1708786). Until the bug is fixed it's possible to ether change configure to add -ggdb2/-g2 or use already existing --enable-user-flags option and rely on environment set by rpmbuild.
    
Patch implements second option so RPM distros without broken debugedit are not affected.