### PR TITLE
logging: Add CS_PRI_NODE_ID and CS_PRI_RING_ID

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -514,11 +514,11 @@ static void message_handler_req_exec_cfg_killnode (
 	cs_name_t reason;
 
 	ENTER();
-	log_printf(LOGSYS_LEVEL_DEBUG, "request to kill node %d(us=%d)",
+	log_printf(LOGSYS_LEVEL_DEBUG, "request to kill node " CS_PRI_NODE_ID " (us=" CS_PRI_NODE_ID ")",
 		req_exec_cfg_killnode->nodeid, api->totem_nodeid_get());
         if (req_exec_cfg_killnode->nodeid == api->totem_nodeid_get()) {
 		marshall_from_mar_name_t(&reason, &req_exec_cfg_killnode->reason);
-		log_printf(LOGSYS_LEVEL_NOTICE, "Killed by node %d: %s",
+		log_printf(LOGSYS_LEVEL_NOTICE, "Killed by node " CS_PRI_NODE_ID " : %s",
 			   nodeid, reason.value);
 		corosync_fatal_error(COROSYNC_FATAL_ERROR_EXIT);
 	}
@@ -534,7 +534,7 @@ static void message_handler_req_exec_cfg_shutdown (
 {
 	ENTER();
 
-	log_printf(LOGSYS_LEVEL_NOTICE, "Node %d was shut down by sysadmin", nodeid);
+	log_printf(LOGSYS_LEVEL_NOTICE, "Node " CS_PRI_NODE_ID " was shut down by sysadmin", nodeid);
 	if (nodeid == api->totem_nodeid_get()) {
 		api->shutdown_request();
 	}
@@ -674,7 +674,7 @@ static void message_handler_req_exec_cfg_reload_config (
 
 	ENTER();
 
-	log_printf(LOGSYS_LEVEL_NOTICE, "Config reload requested by node %d", nodeid);
+	log_printf(LOGSYS_LEVEL_NOTICE, "Config reload requested by node " CS_PRI_NODE_ID, nodeid);
 
 	/*
 	 * Set up a new hashtable as a staging area.

--- a/exec/cmap.c
+++ b/exec/cmap.c
@@ -1050,7 +1050,7 @@ static void message_handler_req_exec_cmap_mcast_reason_sync_nv(
 		}
 	}
 
-	qb_log(LOG_TRACE, "Received config version %"PRIu64" from node %x", config_version, nodeid);
+	qb_log(LOG_TRACE, "Received config version %"PRIu64" from node " CS_PRI_NODE_ID, config_version, nodeid);
 
 	if (nodeid != api->totem_nodeid_get() &&
 	    config_version > cmap_highest_config_version_received) {

--- a/exec/cpg.c
+++ b/exec/cpg.c
@@ -1283,7 +1283,7 @@ static void message_handler_req_exec_cpg_downlist_old (
 	const void *message,
 	unsigned int nodeid)
 {
-	log_printf (LOGSYS_LEVEL_WARNING, "downlist OLD from node 0x%x",
+	log_printf (LOGSYS_LEVEL_WARNING, "downlist OLD from node " CS_PRI_NODE_ID,
 		nodeid);
 }
 
@@ -1304,7 +1304,7 @@ static void message_handler_req_exec_cpg_procjoin (
 {
 	const struct req_exec_cpg_procjoin *req_exec_cpg_procjoin = message;
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "got procjoin message from cluster node 0x%x (%s) for pid %u",
+	log_printf(LOGSYS_LEVEL_DEBUG, "got procjoin message from cluster node " CS_PRI_NODE_ID " (%s) for pid %u",
 		nodeid,
 		api->totem_ifaces_print(nodeid),
 		(unsigned int)req_exec_cpg_procjoin->pid);
@@ -1320,7 +1320,7 @@ static void message_handler_req_exec_cpg_procleave (
 {
 	const struct req_exec_cpg_procjoin *req_exec_cpg_procjoin = message;
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "got procleave message from cluster node 0x%x (%s) for pid %u",
+	log_printf(LOGSYS_LEVEL_DEBUG, "got procleave message from cluster node " CS_PRI_NODE_ID " (%s) for pid %u",
 		nodeid,
 		api->totem_ifaces_print(nodeid),
 		(unsigned int)req_exec_cpg_procjoin->pid);
@@ -1341,7 +1341,7 @@ static void message_handler_req_exec_cpg_joinlist (
 	const struct join_list_entry *jle = (const struct join_list_entry *)(message + sizeof(struct qb_ipc_response_header));
 	struct joinlist_msg *stored_msg;
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "got joinlist message from node 0x%x",
+	log_printf(LOGSYS_LEVEL_DEBUG, "got joinlist message from node " CS_PRI_NODE_ID,
 		nodeid);
 
 	while ((const char*)jle < message + res->size) {
@@ -1422,7 +1422,7 @@ static void message_handler_req_exec_cpg_partial_mcast (
 	struct iovec iovec[2];
 	int known_node = 0;
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "Got fragmented message from node %d, size = %d bytes\n", nodeid, msglen);
+	log_printf(LOGSYS_LEVEL_DEBUG, "Got fragmented message from node " CS_PRI_NODE_ID ", size = %d bytes\n", nodeid, msglen);
 
 	res_lib_cpg_mcast.header.id = MESSAGE_RES_CPG_PARTIAL_DELIVER_CALLBACK;
 	res_lib_cpg_mcast.header.size = sizeof(res_lib_cpg_mcast) + msglen;

--- a/exec/main.c
+++ b/exec/main.c
@@ -692,18 +692,18 @@ static void corosync_ring_id_store (
 	}
 	if (fd == -1) {
 		LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR,
-			"Couldn't store new ring id %llx to stable storage",
-			memb_ring_id->seq);
+			"Couldn't store new ring id " CS_PRI_RING_ID_SEQ " to stable storage",
+			    memb_ring_id->seq);
 
 		corosync_exit_error (COROSYNC_DONE_STORE_RINGID);
 	}
 	log_printf (LOGSYS_LEVEL_DEBUG,
-		"Storing new sequence id for ring %llx", memb_ring_id->seq);
+		"Storing new sequence id for ring " CS_PRI_RING_ID_SEQ, memb_ring_id->seq);
 	res = write (fd, &memb_ring_id->seq, sizeof(memb_ring_id->seq));
 	close (fd);
 	if (res != sizeof(memb_ring_id->seq)) {
 		LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR,
-			"Couldn't store new ring id %llx to stable storage",
+			"Couldn't store new ring id " CS_PRI_RING_ID_SEQ " to stable storage",
 			memb_ring_id->seq);
 
 		corosync_exit_error (COROSYNC_DONE_STORE_RINGID);

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1343,7 +1343,7 @@ static int put_nodelist_members_to_config(struct totem_config *totem_config, int
 					}
 
 					log_printf(LOGSYS_LEVEL_DEBUG,
-						   "Generated nodeid = 0x%x for %s", nodeid, str);
+						   "Generated nodeid = " CS_PRI_NODE_ID " for %s", nodeid, str);
 					free(str);
 				}
 			}

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -324,7 +324,7 @@ static void host_change_callback_fn(void *private_data, knet_node_id_t host_id, 
 	struct totemknet_instance *instance = (struct totemknet_instance *)private_data;
 
 	// TODO: what? if anything.
-	knet_log_printf (LOGSYS_LEVEL_DEBUG, "Knet host change callback. nodeid: %d reachable: %d", host_id, reachable);
+	knet_log_printf (LOGSYS_LEVEL_DEBUG, "Knet host change callback. nodeid: " CS_PRI_NODE_ID " reachable: %d", host_id, reachable);
 }
 
 static void pmtu_change_callback_fn(void *private_data, unsigned int data_mtu)
@@ -574,22 +574,22 @@ int totemknet_finalize (
 
 		res = knet_link_get_link_list(instance->knet_handle, nodes[i], links, &num_links);
 		if (res) {
-			knet_log_printf (LOGSYS_LEVEL_ERROR, "Cannot get knet link list for node %d: %s", nodes[i], strerror(errno));
+			knet_log_printf (LOGSYS_LEVEL_ERROR, "Cannot get knet link list for node " CS_PRI_NODE_ID ": %s", nodes[i], strerror(errno));
 			goto finalise_error;
 		}
 		for (j=0; j<num_links; j++) {
 			res = knet_link_set_enable(instance->knet_handle, nodes[i], links[j], 0);
 			if (res) {
-				knet_log_printf (LOGSYS_LEVEL_ERROR, "totemknet: knet_link_set_enable(node %d, link %d) failed: %s", nodes[i], links[j], strerror(errno));
+				knet_log_printf (LOGSYS_LEVEL_ERROR, "totemknet: knet_link_set_enable(node " CS_PRI_NODE_ID ", link %d) failed: %s", nodes[i], links[j], strerror(errno));
 			}
 			res = knet_link_clear_config(instance->knet_handle, nodes[i], links[j]);
 			if (res) {
-				knet_log_printf (LOGSYS_LEVEL_ERROR, "totemknet: knet_link_clear_config(node %d, link %d) failed: %s", nodes[i], links[j], strerror(errno));
+				knet_log_printf (LOGSYS_LEVEL_ERROR, "totemknet: knet_link_clear_config(node " CS_PRI_NODE_ID ", link %d) failed: %s", nodes[i], links[j], strerror(errno));
 			}
 		}
 		res = knet_host_remove(instance->knet_handle, nodes[i]);
 		if (res) {
-			knet_log_printf (LOGSYS_LEVEL_ERROR, "totemknet: knet_host_remove(node %d) failed: %s", nodes[i], strerror(errno));
+			knet_log_printf (LOGSYS_LEVEL_ERROR, "totemknet: knet_host_remove(node " CS_PRI_NODE_ID ") failed: %s", nodes[i], strerror(errno));
 		}
 	}
 
@@ -814,17 +814,17 @@ static void totemknet_refresh_config(
 							instance->totem_config->interfaces[link_no].knet_ping_timeout,
 							instance->totem_config->interfaces[link_no].knet_ping_precision);
 			if (err) {
-				KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_ping_timers for node %d link %d failed", host_ids[i], link_no);
+				KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_ping_timers for node " CS_PRI_NODE_ID " link %d failed", host_ids[i], link_no);
 			}
 			err = knet_link_set_pong_count(instance->knet_handle, host_ids[i], link_no,
 						       instance->totem_config->interfaces[link_no].knet_pong_count);
 			if (err) {
-				KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_pong_count for node %d link %d failed",host_ids[i], link_no);
+				KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_pong_count for node " CS_PRI_NODE_ID " link %d failed",host_ids[i], link_no);
 			}
 			err = knet_link_set_priority(instance->knet_handle, host_ids[i], link_no,
 						     instance->totem_config->interfaces[link_no].knet_link_priority);
 			if (err) {
-				KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_priority for node %d link %d failed", host_ids[i], link_no);
+				KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_priority for node " CS_PRI_NODE_ID " link %d failed", host_ids[i], link_no);
 			}
 
 		}
@@ -1267,8 +1267,8 @@ int totemknet_member_add (
 		}
 	}
 
-	knet_log_printf (LOGSYS_LEVEL_DEBUG, "knet: member_add: %d (%s), link=%d", member->nodeid, totemip_print(member), link_no);
-	knet_log_printf (LOGSYS_LEVEL_DEBUG, "knet:      local: %d (%s)", local->nodeid, totemip_print(local));
+	knet_log_printf (LOGSYS_LEVEL_DEBUG, "knet: member_add: " CS_PRI_NODE_ID " (%s), link=%d", member->nodeid, totemip_print(member), link_no);
+	knet_log_printf (LOGSYS_LEVEL_DEBUG, "knet:      local: " CS_PRI_NODE_ID " (%s)", local->nodeid, totemip_print(local));
 
 
 	/* Only add the host if it doesn't already exist in knet */
@@ -1290,7 +1290,7 @@ int totemknet_member_add (
 			return -1;
 		}
 	} else {
-		knet_log_printf (LOGSYS_LEVEL_DEBUG, "nodeid %d already added", member->nodeid);
+		knet_log_printf (LOGSYS_LEVEL_DEBUG, "nodeid " CS_PRI_NODE_ID " already added", member->nodeid);
 	}
 
 
@@ -1329,7 +1329,7 @@ int totemknet_member_add (
 	err = knet_link_set_priority(instance->knet_handle, member->nodeid, link_no,
 			       instance->totem_config->interfaces[link_no].knet_link_priority);
 	if (err) {
-		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_priority for nodeid %d, link %d failed", member->nodeid, link_no);
+		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_priority for nodeid " CS_PRI_NODE_ID ", link %d failed", member->nodeid, link_no);
 	}
 
 	/* ping timeouts maybe 0 here for a newly added interface so we leave this till later, it will
@@ -1340,18 +1340,18 @@ int totemknet_member_add (
 						instance->totem_config->interfaces[link_no].knet_ping_timeout,
 						instance->totem_config->interfaces[link_no].knet_ping_precision);
 		if (err) {
-			KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_ping_timers for nodeid %d, link %d failed", member->nodeid, link_no);
+			KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_ping_timers for nodeid " CS_PRI_NODE_ID ", link %d failed", member->nodeid, link_no);
 		}
 		err = knet_link_set_pong_count(instance->knet_handle, member->nodeid, link_no,
 					       instance->totem_config->interfaces[link_no].knet_pong_count);
 		if (err) {
-			KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_pong_count for nodeid %d, link %d failed", member->nodeid, link_no);
+			KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_pong_count for nodeid " CS_PRI_NODE_ID ", link %d failed", member->nodeid, link_no);
 		}
 	}
 
 	err = knet_link_set_enable(instance->knet_handle, member->nodeid, link_no, 1);
 	if (err) {
-		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_enable for nodeid %d, link %d failed", member->nodeid, link_no);
+		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set_enable for nodeid " CS_PRI_NODE_ID ", link %d failed", member->nodeid, link_no);
 		return -1;
 	}
 
@@ -1370,7 +1370,7 @@ int totemknet_member_remove (
 	uint8_t link_list[KNET_MAX_LINK];
 	size_t num_links;
 
-	knet_log_printf (LOGSYS_LEVEL_DEBUG, "knet: member_remove: %d, link=%d", token_target->nodeid, link_no);
+	knet_log_printf (LOGSYS_LEVEL_DEBUG, "knet: member_remove: " CS_PRI_NODE_ID ", link=%d", token_target->nodeid, link_no);
 
 	/* Don't remove the link with the loopback on it until we shut down */
 	if (token_target->nodeid == instance->our_nodeid) {
@@ -1383,13 +1383,13 @@ int totemknet_member_remove (
 	/* Remove the link first */
 	res = knet_link_set_enable(instance->knet_handle, token_target->nodeid, link_no, 0);
 	if (res != 0) {
-		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set enable(off) for nodeid %d, link %d failed", token_target->nodeid, link_no);
+		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_set enable(off) for nodeid " CS_PRI_NODE_ID ", link %d failed", token_target->nodeid, link_no);
 		return res;
 	}
 
 	res = knet_link_clear_config(instance->knet_handle, token_target->nodeid, link_no);
 	if (res != 0) {
-		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_clear_config for nodeid %d, link %d failed", token_target->nodeid, link_no);
+		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_ERROR, "knet_link_clear_config for nodeid " CS_PRI_NODE_ID ", link %d failed", token_target->nodeid, link_no);
 		return res;
 	}
 

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -1412,9 +1412,9 @@ static void memb_set_log(
 
 	for (i = 0; i < list_entries; i++) {
 		if (i == 0) {
-			snprintf(int_buf, sizeof(int_buf), "%u", list[i].nodeid);
+			snprintf(int_buf, sizeof(int_buf), CS_PRI_NODE_ID, list[i].nodeid);
 		} else {
-			snprintf(int_buf, sizeof(int_buf), ",%u", list[i].nodeid);
+			snprintf(int_buf, sizeof(int_buf), "," CS_PRI_NODE_ID, list[i].nodeid);
 		}
 
 		if (strlen(list_str) + strlen(int_buf) >= sizeof(list_str)) {
@@ -1468,7 +1468,7 @@ static void my_leave_memb_set(
                 instance->my_leave_memb_entries++;
         } else {
                 log_printf (instance->totemsrp_log_level_warning,
-                        "Cannot set LEAVE nodeid=%d", nodeid);
+                        "Cannot set LEAVE nodeid=" CS_PRI_NODE_ID, nodeid);
         }
 }
 
@@ -1868,8 +1868,8 @@ static void deliver_messages_from_recovery_to_regular (struct totemsrp_instance 
 		}
 
 		log_printf (instance->totemsrp_log_level_debug,
-			"comparing if ring id is for this processors old ring seqno %d",
-			 mcast->seq);
+			"comparing if ring id is for this processors old ring seqno " CS_PRI_RING_ID_SEQ,
+			 (uint64_t)mcast->seq);
 
 		/*
 		 * Only add this message to the regular sort
@@ -1889,7 +1889,7 @@ static void deliver_messages_from_recovery_to_regular (struct totemsrp_instance 
 			}
 		} else {
 			log_printf (instance->totemsrp_log_level_debug,
-				"-not adding msg with seq no %x", mcast->seq);
+				"-not adding msg with seq no " CS_PRI_RING_ID_SEQ, (uint64_t)mcast->seq);
 		}
 	}
 }
@@ -2053,7 +2053,7 @@ static void memb_state_operational_enter (struct totemsrp_instance *instance)
 		int sptr = 0;
 		sptr += snprintf(joined_node_msg, sizeof(joined_node_msg)-sptr, " joined:");
 		for (i=0; i< joined_list_entries; i++) {
-			sptr += snprintf(joined_node_msg+sptr, sizeof(joined_node_msg)-sptr, " %u", joined_list_totemip[i]);
+			sptr += snprintf(joined_node_msg+sptr, sizeof(joined_node_msg)-sptr, " " CS_PRI_NODE_ID, joined_list_totemip[i]);
 		}
 	}
 	else {
@@ -2065,14 +2065,14 @@ static void memb_state_operational_enter (struct totemsrp_instance *instance)
 		int sptr2 = 0;
 		sptr += snprintf(left_node_msg, sizeof(left_node_msg)-sptr, " left:");
 		for (i=0; i< instance->my_left_memb_entries; i++) {
-			sptr += snprintf(left_node_msg+sptr, sizeof(left_node_msg)-sptr, " %u", left_list[i]);
+			sptr += snprintf(left_node_msg+sptr, sizeof(left_node_msg)-sptr, " " CS_PRI_NODE_ID, left_list[i]);
 		}
 		for (i=0; i< instance->my_left_memb_entries; i++) {
 			if (my_leave_memb_match(instance, left_list[i]) == 0) {
 				if (sptr2 == 0) {
 					sptr2 += snprintf(failed_node_msg, sizeof(failed_node_msg)-sptr2, " failed:");
 				}
-				sptr2 += snprintf(failed_node_msg+sptr2, sizeof(left_node_msg)-sptr2, " %u", left_list[i]);
+				sptr2 += snprintf(failed_node_msg+sptr2, sizeof(left_node_msg)-sptr2, " " CS_PRI_NODE_ID, left_list[i]);
 			}
 		}
 		if (sptr2 == 0) {
@@ -2089,9 +2089,9 @@ static void memb_state_operational_enter (struct totemsrp_instance *instance)
 	log_printf (instance->totemsrp_log_level_debug,
 		"entering OPERATIONAL state.");
 	log_printf (instance->totemsrp_log_level_notice,
-		"A new membership (%u:%lld) was formed. Members%s%s",
+		"A new membership (" CS_PRI_RING_ID ") was formed. Members%s%s",
 		instance->my_ring_id.rep,
-		instance->my_ring_id.seq,
+		(uint64_t)instance->my_ring_id.seq,
 		joined_node_msg,
 		left_node_msg);
 
@@ -2310,15 +2310,14 @@ static void memb_state_recovery_enter (
 
 	for (i = 0; i < instance->my_trans_memb_entries; i++) {
 		log_printf (instance->totemsrp_log_level_debug,
-			"TRANS [%d] member %u:", i, instance->my_trans_memb_list[i].nodeid);
+			"TRANS [%d] member " CS_PRI_NODE_ID ":", i, instance->my_trans_memb_list[i].nodeid);
 	}
 	for (i = 0; i < instance->my_new_memb_entries; i++) {
 		log_printf (instance->totemsrp_log_level_debug,
-			"position [%d] member %u:", i, addr[i].nodeid);
+			"position [%d] member " CS_PRI_NODE_ID ":", i, addr[i].nodeid);
 		log_printf (instance->totemsrp_log_level_debug,
-			"previous ring seq %llx rep %u",
-			memb_list[i].ring_id.seq,
-			memb_list[i].ring_id.rep);
+			"previous ringid (" CS_PRI_RING_ID ")",
+			memb_list[i].ring_id.rep, (uint64_t)memb_list[i].ring_id.seq);
 
 		log_printf (instance->totemsrp_log_level_debug,
 			"aru %x high delivered %x received flag %d",
@@ -4294,9 +4293,9 @@ static int message_handler_mcast (
 	}
 
 	log_printf (instance->totemsrp_log_level_trace,
-		"Received ringid(%u:%lld) seq %x",
+		"Received ringid (" CS_PRI_RING_ID ") seq %x",
 		mcast_header.ring_id.rep,
-		mcast_header.ring_id.seq,
+		(uint64_t)mcast_header.ring_id.seq,
 		mcast_header.seq);
 
 	/*
@@ -4430,20 +4429,20 @@ static void memb_join_process (
 		if (instance->flushing) {
 			if (memb_join->header.nodeid == LEAVE_DUMMY_NODEID) {
 				log_printf (instance->totemsrp_log_level_warning,
-			    		"Discarding LEAVE message during flush, nodeid=%u",
+					"Discarding LEAVE message during flush, nodeid=" CS_PRI_NODE_ID,
 						memb_join->failed_list_entries > 0 ? failed_list[memb_join->failed_list_entries - 1 ].nodeid : LEAVE_DUMMY_NODEID);
 				if (memb_join->failed_list_entries > 0) {
 					my_leave_memb_set(instance, failed_list[memb_join->failed_list_entries - 1 ].nodeid);
 				}
 			} else {
 				log_printf (instance->totemsrp_log_level_warning,
-			    		"Discarding JOIN message during flush, nodeid=%d", memb_join->header.nodeid);
+					"Discarding JOIN message during flush, nodeid=" CS_PRI_NODE_ID, memb_join->header.nodeid);
 			}
 			return;
 		} else {
 			if (memb_join->header.nodeid == LEAVE_DUMMY_NODEID) {
 				log_printf (instance->totemsrp_log_level_debug,
-				    "Received LEAVE message from %u", memb_join->failed_list_entries > 0 ? failed_list[memb_join->failed_list_entries - 1 ].nodeid : LEAVE_DUMMY_NODEID);
+				    "Received LEAVE message from " CS_PRI_NODE_ID, memb_join->failed_list_entries > 0 ? failed_list[memb_join->failed_list_entries - 1 ].nodeid : LEAVE_DUMMY_NODEID);
 				if (memb_join->failed_list_entries > 0) {
 					my_leave_memb_set(instance, failed_list[memb_join->failed_list_entries - 1 ].nodeid);
 				}
@@ -5076,9 +5075,9 @@ void main_iface_change_fn (
 		instance->token_ring_id_seq = instance->my_ring_id.seq;
 		log_printf (
 			instance->totemsrp_log_level_debug,
-			"Created or loaded sequence id %llx.%u for this ring.",
-			instance->my_ring_id.seq,
-			instance->my_ring_id.rep);
+			"Created or loaded sequence id " CS_PRI_RING_ID " for this ring.",
+			instance->my_ring_id.rep,
+			(uint64_t)instance->my_ring_id.seq);
 
 		if (instance->totemsrp_service_ready_fn) {
 			instance->totemsrp_service_ready_fn ();

--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -475,7 +475,7 @@ static struct cluster_node *allocate_node(unsigned int nodeid)
 		 * this should never happen
 		 */
 		if (!cl) {
-			log_printf(LOGSYS_LEVEL_CRIT, "Unable to find memory for node %u data!!", nodeid);
+			log_printf(LOGSYS_LEVEL_CRIT, "Unable to find memory for node " CS_PRI_NODE_ID " data!!", nodeid);
 			goto out;
 		}
 		qb_list_del(tmp);
@@ -538,7 +538,7 @@ static void get_lowest_node_id(void)
 			lowest_node_id = node->node_id;
 		}
 	}
-	log_printf(LOGSYS_LEVEL_DEBUG, "lowest node id: %d us: %d", lowest_node_id, us->node_id);
+	log_printf(LOGSYS_LEVEL_DEBUG, "lowest node id: " CS_PRI_NODE_ID " us: " CS_PRI_NODE_ID, lowest_node_id, us->node_id);
 	icmap_set_uint32("runtime.votequorum.lowest_node_id", lowest_node_id);
 
 	LEAVE();
@@ -560,7 +560,7 @@ static void get_highest_node_id(void)
 			highest_node_id = node->node_id;
 		}
 	}
-	log_printf(LOGSYS_LEVEL_DEBUG, "highest node id: %d us: %d", highest_node_id, us->node_id);
+	log_printf(LOGSYS_LEVEL_DEBUG, "highest node id: " CS_PRI_NODE_ID " us: " CS_PRI_NODE_ID, highest_node_id, us->node_id);
 	icmap_set_uint32("runtime.votequorum.highest_node_id", highest_node_id);
 
 	LEAVE();
@@ -664,7 +664,7 @@ static int check_auto_tie_breaker(void)
 			 */
 			for (j=0; j<i; j++) {
 				if (is_in_nodelist(atb_nodelist[j], previous_quorum_members, previous_quorum_members_entries)) {
-					log_printf(LOGSYS_LEVEL_DEBUG, "ATB_LIST found node %d in previous partition but not here, quorum denied", atb_nodelist[j]);
+					log_printf(LOGSYS_LEVEL_DEBUG, "ATB_LIST found node " CS_PRI_NODE_ID " in previous partition but not here, quorum denied", atb_nodelist[j]);
 					LEAVE();
 					return 0;
 				}
@@ -674,7 +674,7 @@ static int check_auto_tie_breaker(void)
 			 * None of the other list nodes were in the previous partition, if there
 			 * are enough votes, we can be quorate
 			 */
-			log_printf(LOGSYS_LEVEL_DEBUG, "ATB_LIST found node %d in current partition, we can be quorate", atb_nodelist[i]);
+			log_printf(LOGSYS_LEVEL_DEBUG, "ATB_LIST found node " CS_PRI_NODE_ID " in current partition, we can be quorate", atb_nodelist[i]);
 			LEAVE();
 			return 1;
 		}
@@ -920,7 +920,7 @@ static int calculate_quorum(int allow_decrease, unsigned int max_expected, unsig
 	qb_list_for_each(nodelist, &cluster_members_list) {
 		node = qb_list_entry(nodelist, struct cluster_node, list);
 
-		log_printf(LOGSYS_LEVEL_DEBUG, "node %u state=%d, votes=%u, expected=%u",
+		log_printf(LOGSYS_LEVEL_DEBUG, "node " CS_PRI_NODE_ID " state=%d, votes=%u, expected=%u",
 			   node->node_id, node->state, node->votes, node->expected_votes);
 
 		if (node->state == NODESTATE_MEMBER) {
@@ -1819,7 +1819,7 @@ static int votequorum_exec_send_nodelist_notification(void *conn, uint64_t conte
 
 	ENTER();
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "Sending nodelist callback. ring_id = %d/%lld", quorum_ringid.nodeid, quorum_ringid.seq);
+	log_printf(LOGSYS_LEVEL_DEBUG, "Sending nodelist callback. ring_id = " CS_PRI_RING_ID, quorum_ringid.nodeid, quorum_ringid.seq);
 
 	size = sizeof(struct res_lib_votequorum_nodelist_notification) + sizeof(uint32_t) * quorum_members_entries;
 
@@ -1897,7 +1897,7 @@ static void message_handler_req_exec_votequorum_qdevice_reconfigure (
 
 	ENTER();
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "Received qdevice name change req from node %u [from: %s to: %s]",
+	log_printf(LOGSYS_LEVEL_DEBUG, "Received qdevice name change req from node " CS_PRI_NODE_ID " [from: %s to: %s]",
 		   nodeid,
 		   req_exec_quorum_qdevice_reconfigure->oldname,
 		   req_exec_quorum_qdevice_reconfigure->newname);
@@ -1940,7 +1940,7 @@ static void message_handler_req_exec_votequorum_qdevice_reg (
 
 	ENTER();
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "Received qdevice op %u req from node %u [%s]",
+	log_printf(LOGSYS_LEVEL_DEBUG, "Received qdevice op %u req from node " CS_PRI_NODE_ID " [%s]",
 		   req_exec_quorum_qdevice_reg->operation,
 		   nodeid, req_exec_quorum_qdevice_reg->qdevice_name);
 
@@ -2052,8 +2052,8 @@ static void message_handler_req_exec_votequorum_nodeinfo (
 
 	ENTER();
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "got nodeinfo message from cluster node %u", sender_nodeid);
-	log_printf(LOGSYS_LEVEL_DEBUG, "nodeinfo message[%u]: votes: %d, expected: %d flags: %d",
+	log_printf(LOGSYS_LEVEL_DEBUG, "got nodeinfo message from cluster node " CS_PRI_NODE_ID, sender_nodeid);
+	log_printf(LOGSYS_LEVEL_DEBUG, "nodeinfo message[" CS_PRI_NODE_ID "]: votes: %d, expected: %d flags: %d",
 					nodeid,
 					req_exec_quorum_nodeinfo->votes,
 					req_exec_quorum_nodeinfo->expected_votes,
@@ -2174,7 +2174,7 @@ static void message_handler_req_exec_votequorum_reconfigure (
 
 	ENTER();
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "got reconfigure message from cluster node %u for %u",
+	log_printf(LOGSYS_LEVEL_DEBUG, "got reconfigure message from cluster node " CS_PRI_NODE_ID " for " CS_PRI_NODE_ID,
 					nodeid, req_exec_quorum_reconfigure->nodeid);
 
 	switch(req_exec_quorum_reconfigure->param)
@@ -2201,7 +2201,7 @@ static void message_handler_req_exec_votequorum_reconfigure (
 
 	case VOTEQUORUM_RECONFIG_PARAM_CANCEL_WFA:
 	        update_wait_for_all_status(0);
-		log_printf(LOGSYS_LEVEL_INFO, "wait_for_all_status reset by user on node %d.",
+		log_printf(LOGSYS_LEVEL_INFO, "wait_for_all_status reset by user on node " CS_PRI_NODE_ID ".",
 			   req_exec_quorum_reconfigure->nodeid);
 		recalculate_quorum(0, 0);
 
@@ -2551,7 +2551,7 @@ static void message_handler_req_lib_votequorum_getinfo (void *conn, const void *
 
 	ENTER();
 
-	log_printf(LOGSYS_LEVEL_DEBUG, "got getinfo request on %p for node %u", conn, req_lib_votequorum_getinfo->nodeid);
+	log_printf(LOGSYS_LEVEL_DEBUG, "got getinfo request on %p for node " CS_PRI_NODE_ID, conn, req_lib_votequorum_getinfo->nodeid);
 
 	if (nodeid == VOTEQUORUM_QDEVICE_NODEID) {
 		nodeid = us->node_id;
@@ -2953,8 +2953,8 @@ static void message_handler_req_lib_votequorum_qdevice_poll (void *conn,
 	if (us->flags & NODE_FLAGS_QDEVICE_REGISTERED) {
 		if (!(req_lib_votequorum_qdevice_poll->ring_id.nodeid == quorum_ringid.nodeid &&
 		      req_lib_votequorum_qdevice_poll->ring_id.seq == quorum_ringid.seq)) {
-			log_printf(LOGSYS_LEVEL_DEBUG, "Received poll ring id (%u.%"PRIu64") != last sync "
-			    "ring id (%u.%"PRIu64"). Ignoring poll call.",
+			log_printf(LOGSYS_LEVEL_DEBUG, "Received poll ring id (" CS_PRI_RING_ID ") != last sync "
+			    "ring id (" CS_PRI_RING_ID "). Ignoring poll call.",
 			    req_lib_votequorum_qdevice_poll->ring_id.nodeid, req_lib_votequorum_qdevice_poll->ring_id.seq,
 			    quorum_ringid.nodeid, quorum_ringid.seq);
 			error = CS_ERR_MESSAGE_ERROR;

--- a/exec/vsf_quorum.c
+++ b/exec/vsf_quorum.c
@@ -122,7 +122,7 @@ static void log_view_list(const unsigned int *view_list, size_t view_list_entrie
 		memset(view_buf, 0, len);
 
 		for (; i < total; i++) {
-			ret = snprintf(view_buf + pos, len - pos, " %u", view_list[i]);
+			ret = snprintf(view_buf + pos, len - pos, " " CS_PRI_NODE_ID, view_list[i]);
 			if (ret >= len - pos)
 				break;
 			pos += ret;

--- a/include/corosync/corotypes.h
+++ b/include/corosync/corotypes.h
@@ -56,6 +56,9 @@ typedef int64_t cs_time_t;
 #define CS_TIME_END    ((cs_time_t)0x7FFFFFFFFFFFFFFFULL)
 #define CS_MAX(x, y) (((x) > (y)) ? (x) : (y))
 
+#define CS_PRI_NODE_ID		"%" PRIu32
+#define CS_PRI_RING_ID_SEQ	"%" PRIx64
+#define CS_PRI_RING_ID		"%" PRIx32 ".%" PRIx64
 /**
  * @brief The cs_name_t struct
  */

--- a/test/cpghum.c
+++ b/test/cpghum.c
@@ -44,6 +44,7 @@
 #include <ctype.h>
 #include <syslog.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -249,7 +250,7 @@ static void cpg_bm_deliver_fn (
 	unsigned int datalen;
 
 	if (nodeid > MAX_NODEID) {
-		cpgh_log_printf(CPGH_LOG_ERR, "Got message from invalid nodeid %d (too high for us). Quitting\n", nodeid);
+		cpgh_log_printf(CPGH_LOG_ERR, "Got message from invalid nodeid " CS_PRI_NODE_ID " (too high for us). Quitting\n", nodeid);
 		exit(1);
 	}
 
@@ -280,7 +281,7 @@ static void cpg_bm_deliver_fn (
 	// Basic check, packets should all be the right size
 	if (msg_len != header->size) {
 		length_errors++;
-		cpgh_log_printf(CPGH_LOG_ERR, "%s: message sizes don't match. got %zu, expected %u from node %d\n", group_name->value, msg_len, header->size, nodeid);
+		cpgh_log_printf(CPGH_LOG_ERR, "%s: message sizes don't match. got %zu, expected %u from node " CS_PRI_NODE_ID "\n", group_name->value, msg_len, header->size, nodeid);
 
 		if (abort_on_error) {
 			exit(2);
@@ -294,7 +295,7 @@ static void cpg_bm_deliver_fn (
 		/* Don't report the first mismatch or a newly restarted sender, we're just catching up */
 		if (g_recv_counter[nodeid] && header->counter) {
 			sequence_errors++;
-			cpgh_log_printf(CPGH_LOG_ERR, "%s: counters don't match. got %d, expected %d from node %d\n", group_name->value, header->counter, g_recv_counter[nodeid], nodeid);
+			cpgh_log_printf(CPGH_LOG_ERR, "%s: counters don't match. got %d, expected %d from node " CS_PRI_NODE_ID "\n", group_name->value, header->counter, g_recv_counter[nodeid], nodeid);
 
 			if (abort_on_error) {
 				exit(2);
@@ -316,7 +317,7 @@ static void cpg_bm_deliver_fn (
 	crc = crc32(crc, (Bytef *)dataint, datalen) & 0xFFFFFFFF;
 	if (crc != recv_crc) {
 		crc_errors++;
-		cpgh_log_printf(CPGH_LOG_ERR, "%s: CRCs don't match. got %lx, expected %lx from nodeid %d\n", group_name->value, recv_crc, crc, nodeid);
+		cpgh_log_printf(CPGH_LOG_ERR, "%s: CRCs don't match. got %lx, expected %lx from nodeid " CS_PRI_NODE_ID "\n", group_name->value, recv_crc, crc, nodeid);
 
 		if (abort_on_error) {
 			exit(2);
@@ -750,7 +751,7 @@ int main (int argc, char *argv[]) {
 				if (!machine_readable) {
 					for (i=1; i<MAX_NODEID; i++) {
 						if (g_recv_counter[i]) {
-							cpgh_log_printf(CPGH_LOG_INFO, "%s: %5d message%s of %d bytes received from node %d\n",
+							cpgh_log_printf(CPGH_LOG_INFO, "%s: %5d message%s of %d bytes received from node " CS_PRI_NODE_ID "\n",
 									group_name.value, g_recv_counter[i] - g_recv_start[i],
 									g_recv_counter[i]==1?"":"s",
 									g_recv_size[i], i);

--- a/test/testcpg.c
+++ b/test/testcpg.c
@@ -92,7 +92,7 @@ static char * node_pid_format(unsigned int nodeid, unsigned int pid) {
 		sprintf(buffer, "node/pid %s/%d", inet_ntoa(saddr),pid);
 	} 
 	else {
-		sprintf(buffer, "node/pid %d/%d", nodeid, pid);
+		sprintf(buffer, "node/pid " CS_PRI_NODE_ID "/%d", nodeid, pid);
 	} 
 	return buffer;
 }
@@ -193,17 +193,17 @@ static void ConfchgCallback (
 			/* report dynamic nature of nodeid returned from local_get */
 			/*  local get of nodeid might change identity from original! */
 			if(htonl((uint32_t)nodeid) == INADDR_LOOPBACK) {
-				printf("We probably left the building switched identity? start nodeid %d nodeid %d current nodeid %d pid %d\n", nodeidStart, left_list[0].nodeid, nodeid, left_list[0].pid);
+				printf("We probably left the building switched identity? start nodeid " CS_PRI_NODE_ID " nodeid " CS_PRI_NODE_ID " current nodeid " CS_PRI_NODE_ID " pid %d\n", nodeidStart, left_list[0].nodeid, nodeid, left_list[0].pid);
 			} else if(htonl((uint32_t)left_list[0].nodeid) == INADDR_LOOPBACK) {
-				printf("We probably left the building started alone? start nodeid %d nodeid %d current nodeid %d pid %d\n", nodeidStart, left_list[0].nodeid, nodeid, left_list[0].pid);
+				printf("We probably left the building started alone? start nodeid " CS_PRI_NODE_ID " nodeid " CS_PRI_NODE_ID " current nodeid " CS_PRI_NODE_ID " pid %d\n", nodeidStart, left_list[0].nodeid, nodeid, left_list[0].pid);
 			}
 			/* a possibly reliable way to check is based on original address */
 			if(left_list[0].nodeid == nodeidStart) {
-				printf("We have left the building direct match start nodeid %d nodeid %d local get current nodeid %d pid %d\n", nodeidStart, left_list[0].nodeid, nodeid, left_list[0].pid);
+				printf("We have left the building direct match start nodeid " CS_PRI_NODE_ID " nodeid " CS_PRI_NODE_ID " local get current nodeid " CS_PRI_NODE_ID " pid %d\n", nodeidStart, left_list[0].nodeid, nodeid, left_list[0].pid);
 				// quit = 1;
 				restart = 1;
 			} else {
-				printf("Probably another node with matching pid start nodeid %d nodeid %d current nodeid %d pid %d\n", nodeidStart, left_list[0].nodeid, nodeid, left_list[0].pid);
+				printf("Probably another node with matching pid start nodeid " CS_PRI_NODE_ID " nodeid " CS_PRI_NODE_ID " current nodeid " CS_PRI_NODE_ID " pid %d\n", nodeidStart, left_list[0].nodeid, nodeid, left_list[0].pid);
 			}
 		}
 	}
@@ -219,13 +219,13 @@ static void TotemConfchgCallback (
 
 	printf("\n");
 	print_time();
-	printf ("TotemConfchgCallback: ringid (%u.%"PRIu64")\n",
+	printf ("TotemConfchgCallback: ringid (" CS_PRI_RING_ID ")\n",
 		ring_id.nodeid, ring_id.seq);
 
 	printf("active processors %lu: ",
 	       (unsigned long int) member_list_entries);
 	for (i=0; i<member_list_entries; i++) {
-		printf("%d ", member_list[i]);
+		printf(CS_PRI_NODE_ID " ", member_list[i]);
 	}
 	printf ("\n");
 }
@@ -289,7 +289,7 @@ static void print_localnodeid(cpg_handle_t handle)
                            addrStr, (socklen_t)sizeof(addrStr)) == NULL) {
 		addrStr[0] = 0;
 	}
-	printf ("Local node id is %s/%x result %d\n", addrStr, nodeid, result);
+	printf ("Local node id is %s/" CS_PRI_NODE_ID " result %d\n", addrStr, nodeid, result);
 	}
 }
 
@@ -362,7 +362,7 @@ int main (int argc, char *argv[]) {
 				printf ("Could not get local node id\n");
 				retrybackoff(recnt);
 			}
-			printf ("Local node id is %x\n", nodeid);
+			printf ("Local node id is " CS_PRI_NODE_ID "\n", nodeid);
 			nodeidStart = nodeid;
 
 			retries = 0;
@@ -383,7 +383,7 @@ int main (int argc, char *argv[]) {
 
 			printf ("membership list\n");
 			for (i = 0; i < member_list_entries; i++) {
-				printf ("node id %d pid %d\n", member_list[i].nodeid,
+				printf ("node id " CS_PRI_NODE_ID " pid %d\n", member_list[i].nodeid,
 					member_list[i].pid);
 			}
 

--- a/test/testcpg2.c
+++ b/test/testcpg2.c
@@ -37,6 +37,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <poll.h>
+#include <inttypes.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
@@ -52,7 +53,7 @@ static void deliver(
 	void *msg,
 	size_t msg_len)
 {
-    printf("self delivered nodeid: %x\n", nodeid);
+    printf("self delivered nodeid: " CS_PRI_NODE_ID "\n", nodeid);
 }
 
 static void confch(
@@ -62,7 +63,7 @@ static void confch(
 	const struct cpg_address *left_list, size_t left_list_entries,
 	const struct cpg_address *joined_list, size_t joined_list_entries)
 {
-	printf("confchg nodeid %x\n", member_list[0].nodeid);
+	printf("confchg nodeid " CS_PRI_NODE_ID "\n", member_list[0].nodeid);
 }
 
 int main(int argc, char** argv) {
@@ -78,7 +79,7 @@ int main(int argc, char** argv) {
 	printf ("All of the nodeids should match on a single node configuration\n for the test to pass.");
 	assert(CS_OK==cpg_initialize(&handle, &cb));
 	assert(CS_OK==cpg_local_get(handle,&nodeid));
-	printf("local_get: %x\n", nodeid);
+	printf("local_get: " CS_PRI_NODE_ID "\n", nodeid);
 	assert(CS_OK==cpg_join(handle, &group));
 	assert(CS_OK==cpg_mcast_joined(handle,CPG_TYPE_AGREED,&msg,1));
 	cpg_fd_get (handle, &fd);

--- a/test/testcpgzc.c
+++ b/test/testcpgzc.c
@@ -39,6 +39,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>
+#include <inttypes.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/select.h>
@@ -80,7 +81,7 @@ static void DeliverCallback (
 		       inet_ntoa(saddr), pid, (const char *)msg);
 	}
 	else {
-		printf("DeliverCallback: message (len=%lu)from node/pid %d/%d: '%s'\n",
+		printf("DeliverCallback: message (len=%lu)from node/pid " CS_PRI_NODE_ID "/%d: '%s'\n",
 		       (unsigned long int) msg_len, nodeid, pid,
 		       (const char *)msg);
 	}
@@ -107,7 +108,7 @@ static void ConfchgCallback (
 			       joined_list[i].reason);
 		}
 		else {
-			printf("joined node/pid: %d/%d reason: %d\n",
+			printf("joined node/pid: " CS_PRI_NODE_ID "/%d reason: %d\n",
 			       joined_list[i].nodeid, joined_list[i].pid,
 			       joined_list[i].reason);
 		}
@@ -121,7 +122,7 @@ static void ConfchgCallback (
 			       left_list[i].reason);
 		}
 		else {
-			printf("left node/pid: %d/%d reason: %d\n",
+			printf("left node/pid: " CS_PRI_NODE_ID "/%d reason: %d\n",
 			       left_list[i].nodeid, left_list[i].pid,
 			       left_list[i].reason);
 		}
@@ -136,7 +137,7 @@ static void ConfchgCallback (
 			       inet_ntoa (saddr), member_list[i].pid);
 		}
 		else {
-			printf("node/pid: %d/%d\n",
+			printf("node/pid: " CS_PRI_NODE_ID "/%d\n",
 			       member_list[i].nodeid, member_list[i].pid);
 		}
 	}
@@ -204,7 +205,7 @@ int main (int argc, char *argv[]) {
 		exit (1);
 	}
 
-	printf ("Local node id is %x\n", nodeid);
+	printf ("Local node id is " CS_PRI_NODE_ID "\n", nodeid);
 	result = cpg_join(handle, &group_name);
 	if (result != CS_OK) {
 		printf ("Could not join process group, error %d\n", result);

--- a/test/testquorum.c
+++ b/test/testquorum.c
@@ -2,6 +2,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -21,11 +22,11 @@ static void quorum_notification_fn(
 
 	printf("quorum notification called \n");
 	printf("  quorate   = %lu\n", (long unsigned int) quorate);
-	printf("  ring id   = %llu\n", (long long unsigned int) ring_id);
+	printf("  ring id   = " CS_PRI_RING_ID_SEQ "\n", ring_id);
 	printf("  num nodes = %lu ", (long unsigned int) view_list_entries);
 
 	for (i=0; i<view_list_entries; i++) {
-		printf(" %d ", view_list[i]);
+		printf(" " CS_PRI_NODE_ID, view_list[i]);
 	}
 	printf("\n");
 }

--- a/test/testvotequorum1.c
+++ b/test/testvotequorum1.c
@@ -91,7 +91,7 @@ static void votequorum_quorum_notification_fn(
 	printf("  quorate         = %d\n", quorate);
 
 	for (i = 0; i< node_list_entries; i++) {
-		printf("      %d: %s\n", node_list[i].nodeid, node_state(node_list[i].state));
+		printf("      " CS_PRI_NODE_ID ": %s\n", node_list[i].nodeid, node_state(node_list[i].state));
 	}
 
 }
@@ -108,11 +108,11 @@ static void votequorum_nodelist_notification_fn(
 
 	printf("votequorum nodelist notification called \n");
 	printf("  number of nodes = %d\n", node_list_entries);
-	printf("  current ringid  = (%u.%"PRIu64")\n", ring_id.nodeid, ring_id.seq);
+	printf("  current ringid  = (" CS_PRI_RING_ID ")\n", ring_id.nodeid, ring_id.seq);
 	printf("  nodes: ");
 
 	for (i = 0; i< node_list_entries; i++) {
-		printf("%d ", node_list[i]);
+		printf(CS_PRI_NODE_ID " ", node_list[i]);
 	}
 	printf("\n\n");
 }

--- a/test/testvotequorum2.c
+++ b/test/testvotequorum2.c
@@ -85,7 +85,7 @@ static void votequorum_nodelist_notification_fn(
 {
 
 	printf("votequorum nodelist notification called \n");
-	printf("  current ringid  = (%u.%"PRIu64")\n", ring_id.nodeid, ring_id.seq);
+	printf("  current ringid  = (" CS_PRI_RING_ID ")\n", ring_id.nodeid, ring_id.seq);
 	printf("\n");
 
 	memcpy(&last_received_ring_id, &ring_id, sizeof(ring_id));

--- a/test/testzcgc.c
+++ b/test/testzcgc.c
@@ -39,6 +39,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <string.h>
+#include <inttypes.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/select.h>
@@ -77,7 +78,7 @@ static void DeliverCallback (
 		       inet_ntoa(saddr), pid, (const char *)msg);
 	}
 	else {
-		printf("DeliverCallback: message (len=%lu)from node/pid %d/%d: '%s'\n",
+		printf("DeliverCallback: message (len=%lu)from node/pid " CS_PRI_NODE_ID "/%d: '%s'\n",
 		       (unsigned long int) msg_len, nodeid, pid,
 		       (const char *)msg);
 	}
@@ -104,7 +105,7 @@ static void ConfchgCallback (
 			       joined_list[i].reason);
 		}
 		else {
-			printf("joined node/pid: %d/%d reason: %d\n",
+			printf("joined node/pid: " CS_PRI_NODE_ID "/%d reason: %d\n",
 			       joined_list[i].nodeid, joined_list[i].pid,
 			       joined_list[i].reason);
 		}
@@ -118,7 +119,7 @@ static void ConfchgCallback (
 			       left_list[i].reason);
 		}
 		else {
-			printf("left node/pid: %d/%d reason: %d\n",
+			printf("left node/pid: " CS_PRI_NODE_ID "/%d reason: %d\n",
 			       left_list[i].nodeid, left_list[i].pid,
 			       left_list[i].reason);
 		}
@@ -133,7 +134,7 @@ static void ConfchgCallback (
 			       inet_ntoa (saddr), member_list[i].pid);
 		}
 		else {
-			printf("node/pid: %d/%d\n",
+			printf("node/pid: " CS_PRI_NODE_ID "/%d\n",
 			       member_list[i].nodeid, member_list[i].pid);
 		}
 	}

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -153,7 +153,7 @@ linkstatusget_do (char *interface_name, int brief)
 		printf ("Could not get the local node id, the error is: %d\n", result);
 	}
 	else {
-		printf ("Local node ID %u\n", nodeid);
+		printf ("Local node ID " CS_PRI_NODE_ID "\n", nodeid);
 	}
 
 	result = corosync_cfg_ring_status_get (handle,
@@ -350,7 +350,7 @@ static void killnode_do(unsigned int nodeid)
 	cs_error_t result;
 	corosync_cfg_handle_t handle;
 
-	printf ("Killing node %d\n", nodeid);
+	printf ("Killing node " CS_PRI_NODE_ID "\n", nodeid);
 	result = corosync_cfg_initialize (&handle, NULL);
 	if (result != CS_OK) {
 		printf ("Could not initialize corosync configuration API error %d\n", result);

--- a/tools/corosync-notifyd.c
+++ b/tools/corosync-notifyd.c
@@ -250,7 +250,7 @@ static void _cs_cmap_members_key_changed (
 
 	res = snprintf(tmp_key, CMAP_KEYNAME_MAXLEN, "runtime.members.%u.ip", nodeid);
 	if (res <= 0 || res >= CMAP_KEYNAME_MAXLEN) {
-		qb_log(LOG_ERR, "temp_key: failed, res: %d, nodeid: %u", res, nodeid);
+		qb_log(LOG_ERR, "temp_key: failed, res: %d, nodeid: " CS_PRI_NODE_ID, res, nodeid);
 		return ;
 	}
 	no_retries = 0;
@@ -969,16 +969,16 @@ _cs_snmp_init(void)
 static void
 _cs_syslog_node_membership_event(char *nodename, uint32_t nodeid, char *state, char* ip)
 {
-	qb_log(LOG_NOTICE, "%s[%d] ip:%s %s", nodename, nodeid, ip, state);
+	qb_log(LOG_NOTICE, "%s[" CS_PRI_NODE_ID "] ip:%s %s", nodename, nodeid, ip, state);
 }
 
 static void
 _cs_syslog_node_quorum_event(char *nodename, uint32_t nodeid, const char *state)
 {
 	if (strcmp(state, "quorate") == 0) {
-		qb_log(LOG_NOTICE, "%s[%d] is now %s", nodename, nodeid, state);
+		qb_log(LOG_NOTICE, "%s[" CS_PRI_NODE_ID "] is now %s", nodename, nodeid, state);
 	} else {
-		qb_log(LOG_NOTICE, "%s[%d] has lost quorum", nodename, nodeid);
+		qb_log(LOG_NOTICE, "%s[" CS_PRI_NODE_ID "] has lost quorum", nodename, nodeid);
 	}
 }
 
@@ -986,16 +986,16 @@ static void
 _cs_syslog_application_connection_event(char *nodename, uint32_t nodeid, char* app_name, const char *state)
 {
 	if (strcmp(state, "connected") == 0) {
-		qb_log(LOG_NOTICE, "%s[%d] %s is now %s to corosync", nodename, nodeid, app_name, state);
+		qb_log(LOG_NOTICE, "%s[" CS_PRI_NODE_ID "] %s is now %s to corosync", nodename, nodeid, app_name, state);
 	} else {
-		qb_log(LOG_NOTICE, "%s[%d] %s is now %s from corosync", nodename, nodeid, app_name, state);
+		qb_log(LOG_NOTICE, "%s[" CS_PRI_NODE_ID "] %s is now %s from corosync", nodename, nodeid, app_name, state);
 	}
 }
 
 static void
 _cs_syslog_link_faulty_event(char *nodename, uint32_t our_nodeid, uint32_t nodeid, uint32_t iface_no, const char *state)
 {
-	qb_log(LOG_NOTICE, "%s[%d] link %u to node %u is now %s", nodename, our_nodeid, iface_no, nodeid, state);
+	qb_log(LOG_NOTICE, "%s[" CS_PRI_NODE_ID "] link %u to node " CS_PRI_NODE_ID " is now %s", nodename, our_nodeid, iface_no, nodeid, state);
 }
 
 static void

--- a/tools/corosync-quorumtool.c
+++ b/tools/corosync-quorumtool.c
@@ -236,7 +236,7 @@ static int set_votes(uint32_t nodeid, int votes)
 	int err;
 
 	if ((err=votequorum_setvotes(v_handle, nodeid, votes)) != CS_OK) {
-		fprintf(stderr, "Unable to set votes %d for nodeid: %u: %s\n",
+		fprintf(stderr, "Unable to set votes %d for nodeid: " CS_PRI_NODE_ID ": %s\n",
 			votes, nodeid, cs_strerror(err));
 	}
 
@@ -340,7 +340,7 @@ static const char *node_name(uint32_t nodeid, name_format_t name_format)
 
 	err = corosync_cfg_get_node_addrs(c_handle, nodeid, INTERFACE_MAX, &numaddrs, addrs);
 	if (err != CS_OK) {
-		fprintf(stderr, "Unable to get node address for nodeid %u: %s\n", nodeid, cs_strerror(err));
+		fprintf(stderr, "Unable to get node address for nodeid " CS_PRI_NODE_ID ": %s\n", nodeid, cs_strerror(err));
 		return "";
 	}
 
@@ -473,7 +473,7 @@ static void display_nodes_data(nodeid_format_t nodeid_format, name_format_t name
 	if (v_handle) {
 		for (i=0; i < g_view_list_entries; i++) {
 			if (votequorum_getinfo(v_handle, g_view_list[i].node_id, &info[i]) != CS_OK) {
-				printf("Unable to get node %u info\n", g_view_list[i].node_id);
+				printf("Unable to get node " CS_PRI_NODE_ID " info\n", g_view_list[i].node_id);
 			}
 			g_view_list[i].vq_info = &info[i];
 			if (info[i].flags & VOTEQUORUM_INFO_QDEVICE_REGISTERED) {
@@ -600,16 +600,16 @@ static int display_quorum_data(int is_quorate,
 	printf("Quorum provider:  %s\n", quorumtype);
 	printf("Nodes:            %d\n", g_view_list_entries);
 	if (nodeid_format == NODEID_FORMAT_DECIMAL) {
-		printf("Node ID:          %u\n", our_nodeid);
+		printf("Node ID:          " CS_PRI_NODE_ID "\n", our_nodeid);
 	} else {
 		printf("Node ID:          0x%08x\n", our_nodeid);
 	}
 
 	if (v_handle) {
-		printf("Ring ID:          %d/%" PRIu64 "\n", g_ring_id_rep_node, g_ring_id);
+		printf("Ring ID:          " CS_PRI_RING_ID "\n", g_ring_id_rep_node, g_ring_id);
 	}
 	else {
-		printf("Ring ID:          %" PRIu64 "\n", g_ring_id);
+		printf("Ring ID:          " CS_PRI_RING_ID_SEQ "\n", g_ring_id);
 	}
 	printf("Quorate:          %s\n", is_quorate?"Yes":"No");
 

--- a/vqsim/vqmain.c
+++ b/vqsim/vqmain.c
@@ -117,19 +117,19 @@ static void print_quorum_state(struct vq_node *node)
 	int i;
 
 	if (node->last_quorate < 0) {
-		fprintf(output_file, "%d:%02d: q=UNINITIALIZED\n",
+		fprintf(output_file, "%d:" CS_PRI_NODE_ID ": q=UNINITIALIZED\n",
 			node->partition->num, node->nodeid);
 		return;
 	}
 
-	fprintf(output_file, "%d:%02d: q=%d ring=[%d/%lld] ", node->partition->num, node->nodeid, node->last_quorate,
-		node->last_ring_id.nodeid, node->last_ring_id.seq);
+	fprintf(output_file, "%d:" CS_PRI_NODE_ID ": q=%d ring=[" CS_PRI_RING_ID "] ", node->partition->num, node->nodeid, node->last_quorate,
+		node->last_ring_id.nodeid, (uint64_t)node->last_ring_id.seq);
 	fprintf(output_file, "nodes=[");
 	for (i = 0; i < node->last_view_list_entries; i++) {
 		if (i) {
 			fprintf(output_file, " ");
 		}
-		fprintf(output_file, "%d", node->last_view_list[i]);
+		fprintf(output_file, CS_PRI_NODE_ID, node->last_view_list[i]);
 	}
 	fprintf(output_file, "]\n");
 
@@ -265,7 +265,7 @@ static int vq_parent_read_fn(int32_t fd, int32_t revents, void *data)
 		}
 	}
 	if (revents == POLLERR) {
-		fprintf(stderr, "pollerr on %d\n", vqn->nodeid);
+		fprintf(stderr, "pollerr on " CS_PRI_NODE_ID "\n", vqn->nodeid);
 	}
 	return 0;
 }
@@ -342,7 +342,7 @@ static int32_t sigchld_handler(int32_t sig, void *data)
 				sprintf(text, "(exit code %d)", WEXITSTATUS(status));
 				break;
 			}
-			printf("%d:%02d: Quit %s\n", vqn->partition->num, vqn->nodeid, exit_status);
+			printf("%d:" CS_PRI_NODE_ID ": Quit %s\n", vqn->partition->num, vqn->nodeid, exit_status);
 
 			remove_node(vqn);
 		}
@@ -353,7 +353,7 @@ static int32_t sigchld_handler(int32_t sig, void *data)
 	if (WIFSIGNALED(status)) {
 		vqn = find_by_pid(pid);
 		if (vqn) {
-			printf("%d:%02d exited on signal %d%s\n", vqn->partition->num, vqn->nodeid, WTERMSIG(status), WCOREDUMP(status)?" (core dumped)":"");
+			printf("%d:" CS_PRI_NODE_ID " exited on signal %d%s\n", vqn->partition->num, vqn->nodeid, WTERMSIG(status), WCOREDUMP(status)?" (core dumped)":"");
 			remove_node(vqn);
 		}
 		else {
@@ -411,7 +411,7 @@ static pid_t create_node(int nodeid, int partno)
 		newvq->instance = vq_create_instance(poll_loop, nodeid);
 		if (!newvq->instance) {
 			fprintf(stderr,
-			        "ERR: could not create vq instance nodeid %d\n",
+			        "ERR: could not create vq instance nodeid " CS_PRI_NODE_ID "\n",
 				nodeid);
 			free(newvq);
 			return (pid_t) -1;
@@ -467,7 +467,7 @@ static size_t create_nodes_from_config(void)
 			pid = create_node(nodeid, 0);
 			if (pid == (pid_t) -1) {
 				fprintf(stderr,
-					"ERR: nodeid %d could not be spawned\n",
+					"ERR: nodeid " CS_PRI_NODE_ID " could not be spawned\n",
 					nodeid);
 				exit(1);
 			}
@@ -537,7 +537,7 @@ int cmd_start_new_node(int nodeid, int partition)
 
 	node = find_node(nodeid);
 	if (node) {
-		fprintf(stderr, "ERR: nodeid %d already exists in partition %d\n", nodeid, node->partition->num);
+		fprintf(stderr, "ERR: nodeid " CS_PRI_NODE_ID " already exists in partition %d\n", nodeid, node->partition->num);
 		return -1;
 	}
 	if (create_node(nodeid, partition) == -1) {
@@ -577,7 +577,7 @@ int cmd_stop_node(int nodeid)
 
 	node = find_node(nodeid);
 	if (!node) {
-		fprintf(stderr, "ERR: nodeid %d is not up\n", nodeid);
+		fprintf(stderr, "ERR: nodeid " CS_PRI_NODE_ID " is not up\n", nodeid);
 		return -1;
 	}
 
@@ -613,7 +613,7 @@ void cmd_move_nodes(int partition, int num_nodes, int *nodelist)
 			node->partition = &partitions[partition];
 		}
 		else {
-			printf("ERR: node %d does not exist\n", nodelist[i]);
+			printf("ERR: node " CS_PRI_NODE_ID " does not exist\n", nodelist[i]);
 		}
 	}
 }

--- a/vqsim/vqsim_vq_engine.c
+++ b/vqsim/vqsim_vq_engine.c
@@ -313,7 +313,7 @@ static int poll_qdevice(int onoff)
 
 	res = send_lib_msg(MESSAGE_REQ_VOTEQUORUM_QDEVICE_POLL, &pollmsg);
 	if (res != CS_OK) {
-		fprintf(stderr, "%d: qdevice poll failed: %d\n", our_nodeid, res);
+		fprintf(stderr, CS_PRI_NODE_ID ": qdevice poll failed: %d\n", our_nodeid, res);
 	}
 	return res;
 }
@@ -362,7 +362,7 @@ static void do_qdevice(int onoff)
 				start_qdevice_poll(1);
 			}
 			else {
-				fprintf(stderr, "%d: qdevice registration failed: %d\n", our_nodeid, res);
+				fprintf(stderr, CS_PRI_NODE_ID ": qdevice registration failed: %d\n", our_nodeid, res);
 			}
 		}
 		else {


### PR DESCRIPTION
Previously node id was logged ether as a %d (most often), %u, %x or
PRI.32 and ring id ether as %lld, %llx with various separators (., :, /)
between rep nodeid and seq. This seems to cause confusion.

This patch adds macros CS_PRI_NODE_ID, CS_PRI_RING_ID and
CS_PRI_RING_ID_SEQ (CS prefix = corosync, PRI modeled in spirit of
inttypes.h PRIx32) and makes code use them.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>