### PR TITLE
init: Use cpgtool instead of cfgtool

### DIFF
--- a/init/corosync.in
+++ b/init/corosync.in
@@ -37,6 +37,11 @@ failure()
 	echo -ne "[FAILED]\r"
 }
 
+warning()
+{
+	echo -ne "[WARNING]\r"
+}
+
 # pid_var_run pid_file
 # Echo pid from given pid_file.
 # Returns LSB exit code for the 'status' action.
@@ -124,7 +129,7 @@ wait_for_ipc()
 	[ "$max_try" -le "0" ] && max_try=120
 
 	while [ "$try" -le "$max_try" ]; do
-		if corosync-cfgtool -s > /dev/null 2>&1; then
+		if corosync-cpgtool > /dev/null 2>&1; then
 			return 0
 		fi
 		sleep 0.5
@@ -156,7 +161,11 @@ start()
 			rtrn=1
 		else
 			touch $LOCK_FILE
-			success
+			if corosync-cfgtool -s > /dev/null 2>&1; then
+				success
+			else
+				warning
+			fi
 		fi
 	fi
 	echo


### PR DESCRIPTION
Init script used to use corosync-cfgtool -s to wait till
corosync accepts ipc connection. Problem with this approach
is that error code is returned not only if ipc cannot be initialized,
but also when one of the ring is marked as failed, making corosync
service not to start. Corosync with one failed ring can work just
fine and there is no need to fail startup.

Patch is changing call of corosync-cfgtool to corosync-cpgtool. Also to
make spotting of broken ring easier, corosync-cfgtool -s is called after
successful return of the cpgtool, and warning is issued if cfgtool fails.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>