### PR TITLE
cfgtool: Remove unused code

### DIFF
--- a/man/corosync-cfgtool.8
+++ b/man/corosync-cfgtool.8
@@ -31,7 +31,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH "COROSYNC-CFGTOOL" "8" "2019-02-13" "" ""
+.TH "COROSYNC-CFGTOOL" "8" "2019-07-04" "" ""
 .SH "NAME"
 corosync-cfgtool \- An administrative tool for corosync.
 .SH "SYNOPSIS"
@@ -46,8 +46,7 @@ Finds only information about the specified interface IP address or link id with 
 .TP 
 .B -s
 Displays the status of the current links on this node for UDP/UDPU, with extended status
-for KNET. If any interfaces are faulty, 1 is returned by the binary. If all interfaces are
-active 0 is returned to the shell.
+for KNET.
 After each link, the nodes on that link are displayed in order with their status,
 for example there are 3 nodes with KNET transportation:
 LINK ID 0:

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -187,8 +187,11 @@ linkstatusget_do (char *interface_name, int brief)
 			if (show_current_iface) {
 				printf ("LINK ID %s\n", interface_names[i]);
 				printf ("\taddr\t= %s\n", cur_iface_name_space + 1);
-				if((!brief) && (strcmp(interface_status[i], "OK") != 0) &&
-					(!strstr(interface_status[i], "FAULTY"))) {
+				/*
+				 * UDP(U) interface_status is always OK and doesn't contain
+				 * detailed information (only knet does).
+				 */
+				if ((!brief) && (strcmp(interface_status[i], "OK") != 0)) {
 					len = strlen(interface_status[i]);
 					printf ("\tstatus:\n");
 					while (s < len) {
@@ -201,9 +204,6 @@ linkstatusget_do (char *interface_name, int brief)
 					}
 				} else {
 					printf ("\tstatus\t= %s\n", interface_status[i]);
-					if (strstr(interface_status[i], "FAULTY")) {
-						rc = 1;
-					}
 				}
 			}
 		}


### PR DESCRIPTION
corosync_cfg_ring_status_get returns string status, which is always OK
for UDP(U) and detailed status for Knet transport. Previously also
FAULTY status was returned for UDP(U) and cfgtool used to return error
code back to shell when one of the interfaces was faulty.

Because FAULTY is now not returned, it's not needed to have code for
handling it.

Also man page was misleading, so it is fixed too.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>