### PR TITLE
totem: Increase ring_id seq after load

### DIFF
--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -5072,6 +5072,14 @@ void main_iface_change_fn (
 
 	if (instance->iface_changes++ == 0) {
 		instance->memb_ring_id_create_or_load (&instance->my_ring_id, instance->my_id.nodeid);
+		/*
+		 * Increase the ring_id sequence number. This doesn't follow specification.
+		 * Solves problem with restarted leader node (node with lowest nodeid) before
+		 * rest of the cluster forms new membership and guarantees unique ring_id for
+		 * new singleton configuration.
+		 */
+		instance->my_ring_id.seq++;
+
 		instance->token_ring_id_seq = instance->my_ring_id.seq;
 		log_printf (
 			instance->totemsrp_log_level_debug,


### PR DESCRIPTION
Patch handles situation when leader node (node with lowest node_id)
crashed and was started again before token timeout of the rest of the
cluster. Newly started node restored ringid of old ring from stable
storage, so it had a same ringid as rest of the nodes, but zero
aru. If node was able to create singleton membership before receiving
the join list from rest of the cluster, everything worked as expected,
because ring id increased.

But when node received joinlist originated from other nodes before
its own joinlist, then it continued as it would never disjoined. This is
not correct, because new node should always create singleton
configuration. During the recovery phase, aru
was compared and because it differed (aru of leader was 0), other nodes
tried to sent all previous messages. Such behavior is not correct,
because other nodes already freed most of the messages
implementation is using assert to limit maximum number of messages sent
during recovery (that would be fixable).

Solution is to increase ring_id sequence number by 1 after load. During
create of commit token it is increased by 4, so no collision happens.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>