### PR TITLE
fix corosync.conf manpage knet pong count default value

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -81,7 +81,7 @@
 #define MISS_COUNT_CONST			5
 #define BLOCK_UNLISTED_IPS			1
 
-/* These currently match the defaults in libknet.h */
+/* Currently all but PONG_COUNT match the defaults in libknet.h */
 #define KNET_PING_INTERVAL                      1000
 #define KNET_PING_TIMEOUT                       2000
 #define KNET_PING_PRECISION                     2048

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -112,7 +112,7 @@ the average link latency. (default 2048 samples)
 
 .TP
 knet_pong_count
-How many valid ping/pongs before a link is marked UP. (default 5)
+How many valid ping/pongs before a link is marked UP. (default 2)
 .TP
 
 knet_transport


### PR DESCRIPTION
commit 029b8ebad60314d3daa285eb945c55355fade389 changed the default
of the KNET_PONG_COUNT from the kronosnet default of 5 to 2, as
corosync bring up was deemed to slow.

The documentation, and the comment stating that the totem config
default values match the knet ones were not updated, and thus now out
of date.

Fixhis by noting the correct default of 2 for KNET_PONG_COUNT and
note that all but that one are in sync with the korosync defaults in
the comment.

Signed-off-by: Thomas Lamprecht <t.lamprecht@proxmox.com>