### PR TITLE
Initialize stack allocated memory

### DIFF
--- a/exec/cpg.c
+++ b/exec/cpg.c
@@ -1086,6 +1086,8 @@ static int cpg_node_joinleave_send (unsigned int pid, const mar_cpg_name_t *grou
 	struct iovec req_exec_cpg_iovec;
 	int result;
 
+	memset(&req_exec_cpg_procjoin, 0, sizeof(req_exec_cpg_procjoin));
+
 	memcpy(&req_exec_cpg_procjoin.group_name, group_name, sizeof(mar_cpg_name_t));
 	req_exec_cpg_procjoin.pid = pid;
 	req_exec_cpg_procjoin.reason = reason;
@@ -1490,7 +1492,8 @@ static int cpg_exec_send_joinlist(void)
 	int count = 0;
 	struct qb_list_head *iter;
 	struct qb_ipc_response_header *res;
- 	char *buf;
+	char *buf;
+	size_t buf_size;
 	struct join_list_entry *jle;
 	struct iovec req_exec_cpg_iovec;
 
@@ -1506,11 +1509,13 @@ static int cpg_exec_send_joinlist(void)
 	if (!count)
 		return 0;
 
-	buf = alloca(sizeof(struct qb_ipc_response_header) + sizeof(struct join_list_entry) * count);
+	buf_size = sizeof(struct qb_ipc_response_header) + sizeof(struct join_list_entry) * count;
+	buf = alloca(buf_size);
 	if (!buf) {
 		log_printf(LOGSYS_LEVEL_WARNING, "Unable to allocate joinlist buffer");
 		return -1;
 	}
+	memset(buf, 0, buf_size);
 
 	jle = (struct join_list_entry *)(buf + sizeof(struct qb_ipc_response_header));
 	res = (struct qb_ipc_response_header *)buf;
@@ -1977,6 +1982,8 @@ static void message_handler_req_lib_cpg_mcast (void *conn, const void *message)
 	}
 
 	if (error == CS_OK) {
+		memset(&req_exec_cpg_mcast, 0, sizeof(req_exec_cpg_mcast));
+
 		req_exec_cpg_mcast.header.size = sizeof(req_exec_cpg_mcast) + msglen;
 		req_exec_cpg_mcast.header.id = SERVICE_ID_MAKE(CPG_SERVICE,
 			MESSAGE_REQ_EXEC_CPG_MCAST);

--- a/exec/sync.c
+++ b/exec/sync.c
@@ -335,6 +335,8 @@ static void barrier_message_transmit (void)
 	struct iovec iovec;
 	struct req_exec_barrier_message req_exec_barrier_message;
 
+	memset(&req_exec_barrier_message, 0, sizeof(req_exec_barrier_message));
+
 	req_exec_barrier_message.header.size = sizeof (struct req_exec_barrier_message);
 	req_exec_barrier_message.header.id = MESSAGE_REQ_SYNC_BARRIER;
 
@@ -435,6 +437,8 @@ static void sync_servicelist_build_enter (
 	int i;
 	int res;
 	struct sync_callbacks sync_callbacks;
+
+	memset(&service_build, 0, sizeof(service_build));
 
 	my_state = SYNC_SERVICELIST_BUILD;
 	for (i = 0; i < member_list_entries; i++) {

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -1326,6 +1326,7 @@ int totemknet_member_add (
 	}
 
 	memset(&local_ss, 0, sizeof(local_ss));
+	memset(&remote_ss, 0, sizeof(remote_ss));
 	/* Casts to remove const */
 	totemip_totemip_to_sockaddr_convert((struct totem_ip_address *)member, port, &remote_ss, &addrlen);
 	totemip_totemip_to_sockaddr_convert((struct totem_ip_address *)local, port, &local_ss, &addrlen);

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -920,6 +920,8 @@ static int mcast_msg (
 		return(-1);
 	}
 
+	memset(&mcast, 0, sizeof(mcast));
+
 	mcast.header.version = 0;
 	for (i = 0; i < iov_len; ) {
 		mcast.fragmented = 0;

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -2401,6 +2401,7 @@ static void memb_state_recovery_enter (
 	// TODO	 LEAK
 		message_item.mcast = totemsrp_buffer_alloc (instance);
 		assert (message_item.mcast);
+		memset(message_item.mcast, 0, sizeof (struct mcast));
 		message_item.mcast->header.magic = TOTEM_MH_MAGIC;
 		message_item.mcast->header.version = TOTEM_MH_VERSION;
 		message_item.mcast->header.type = MESSAGE_TYPE_MCAST;

--- a/exec/votequorum.c
+++ b/exec/votequorum.c
@@ -1682,6 +1682,7 @@ static int votequorum_exec_send_nodeinfo(uint32_t nodeid)
 		return -1;
 	}
 
+	memset(&req_exec_quorum_nodeinfo, 0, sizeof(req_exec_quorum_nodeinfo));
 	req_exec_quorum_nodeinfo.nodeid = nodeid;
 	req_exec_quorum_nodeinfo.votes = node->votes;
 	req_exec_quorum_nodeinfo.expected_votes = node->expected_votes;


### PR DESCRIPTION
Some functions allocated memory on stack without clearing memory and
then send them on wire. This is not an issue, but valgrind reports this
as a problem so it is easy to miss real problem then.

Solution is to clear stack memory.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>