### PR TITLE
[pkgconfig] make sure libqb dependency is visible across all libraries

### DIFF
--- a/pkgconfig/libtemplate.pc.in
+++ b/pkgconfig/libtemplate.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: @LIB@
 Version: @LIBVERSION@
 Description: @LIB@
-Requires:
+Requires: libqb
 Libs: -L${libdir} -l@LIB@
 Cflags: -I${includedir}


### PR DESCRIPTION
Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>