### PR TITLE
configure.ac: fix pkgconfig issue of rdma

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -459,8 +459,8 @@ if test "x${enable_testagents}" = xyes; then
 fi
 
 if test "x${enable_rdma}" = xyes; then
-	PKG_CHECK_MODULES([rdmacm],[rdmacm])
-	PKG_CHECK_MODULES([ibverbs],[ibverbs])
+	PKG_CHECK_MODULES([rdmacm],[librdmacm])
+	PKG_CHECK_MODULES([ibverbs],[libibverbs])
 	AC_DEFINE_UNQUOTED([HAVE_RDMA], 1, [have rdmacm])
 	PACKAGE_FEATURES="$PACKAGE_FEATURES rdma"
 	WITH_LIST="$WITH_LIST --with rdma"


### PR DESCRIPTION
pkgconfig files from rdma-core(https://github.com/linux-rdma/rdma-core)
are named start with lib, such as librdmacm.pc and libibverbs.pc. When
rdma support is enabled, it fails to find rdma related libraries. Update
configure.ac to the issue.

Signed-off-by: Kai Kang <kai.kang@windriver.com>