### PR TITLE
man: move cmap_keys man page from section 8 to 7

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -217,7 +217,7 @@ fi
 %{_mandir}/man8/corosync-quorumtool.8*
 %{_mandir}/man5/corosync.conf.5*
 %{_mandir}/man5/votequorum.5*
-%{_mandir}/man8/cmap_keys.8*
+%{_mandir}/man7/cmap_keys.7*
 
 # library
 #

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -140,7 +140,7 @@ dist_man_MANS 		= corosync.conf.5 \
 			  votequorum_overview.3 \
 			  sam_overview.3 \
 			  cmap_overview.3 \
-			  cmap_keys.8
+			  cmap_keys.7
 
 if BUILD_VQSIM
 dist_man_MANS		+= $(corosync_vqsim_man)

--- a/man/cmap_keys.7
+++ b/man/cmap_keys.7
@@ -31,7 +31,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH "CMAP_KEYS" 8 "2018-10-08" "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH "CMAP_KEYS" 7 "2018-10-08" "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 
 .SH NAME
 .P

--- a/man/cmap_overview.3
+++ b/man/cmap_overview.3
@@ -54,7 +54,7 @@ The library provides a mechanism to:
 .PP
 * Track changes on keys
 
-Description of most keys created by corosync itself can be found in cmap_keys (8).
+Description of most keys created by corosync itself can be found in cmap_keys (7).
 
 .SH BUGS
 .SH "SEE ALSO"
@@ -75,4 +75,4 @@ Description of most keys created by corosync itself can be found in cmap_keys (8
 .BR cmap_iter_finalize (3),
 .BR cmap_track_add (3),
 .BR cmap_track_delete (3),
-.BR cmap_keys (8)
+.BR cmap_keys (7)

--- a/man/corosync-cmapctl.8
+++ b/man/corosync-cmapctl.8
@@ -96,4 +96,4 @@ corosync\-cmapctl \fB\-C\fR [ipc|totem|knet|all]
 
 .SH "SEE ALSO"
 .BR cmap_overview (3),
-.BR cmap_keys (8)
+.BR cmap_keys (7)

--- a/man/index.html
+++ b/man/index.html
@@ -63,7 +63,7 @@
       Description of corosync-cmapctl tool.
       <br>
 
-      <a href="cmap_keys.8.html">cmap_keys(8)</a>:
+      <a href="cmap_keys.7.html">cmap_keys(7)</a>:
       Overview of keys stored in the Configuration Map.
       <br>
 


### PR DESCRIPTION
Section 8 is for "System administration commands", 7 is "Miscellaneous".