### PR TITLE
Low: cpg: Change log level.

### DIFF
--- a/exec/cpg.c
+++ b/exec/cpg.c
@@ -1295,7 +1295,7 @@ static void message_handler_req_exec_cpg_downlist(
 {
 	const struct req_exec_cpg_downlist *req_exec_cpg_downlist = message;
 
-	log_printf (LOGSYS_LEVEL_WARNING, "downlist left_list: %d received",
+	log_printf (LOGSYS_LEVEL_INFO, "downlist left_list: %d received",
 			req_exec_cpg_downlist->left_nodes);
 }
 


### PR DESCRIPTION
Hi All,

For corosync3.x, the following message is output when the cluster starts or when a node leaves.

```
(snip)
corosync warning [CPG   ] downlist left_list: 0 received
(snip)
corosync warning [CPG   ] downlist left_list: 1 received
(snip)
```

Because the log level is a warning, users can be confused.

I think that it is better to change the log level to INFO in line with the 2.x system.

Best Regards,
Hideo Yamauchi.