### PR TITLE
totemknet: Changing the initial value of the status area.

### DIFF
--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -479,6 +479,10 @@ static int node_compare(const void *aptr, const void *bptr)
 	return a > b;
 }
 
+#ifndef OWN_INDEX_NONE
+#define OWN_INDEX_NONE -1
+#endif
+
 int totemknet_ifaces_get (void *knet_context,
 	char ***status,
 	unsigned int *iface_count)
@@ -499,6 +503,7 @@ int totemknet_ifaces_get (void *knet_context,
 	 * a count of interfaces.
 	 */
 	if (status) {
+		int own_idx = OWN_INDEX_NONE;
 
 		res = knet_host_get_host_list(instance->knet_handle,
 					      host_list, &num_hosts);
@@ -507,8 +512,18 @@ int totemknet_ifaces_get (void *knet_context,
 		}
 		qsort(host_list, num_hosts, sizeof(uint16_t), node_compare);
 
+		for (j=0; j<num_hosts; j++) {
+			if (host_list[j] == instance->our_nodeid) {
+				own_idx = j;
+				break;
+			}
+		}
+
 		for (i=0; i<INTERFACE_MAX; i++) {
-			memset(instance->link_status[i], 'n', CFG_INTERFACE_STATUS_MAX_LEN-1);
+			memset(instance->link_status[i], 'd', CFG_INTERFACE_STATUS_MAX_LEN-1);
+			if (own_idx != OWN_INDEX_NONE) {
+				instance->link_status[i][own_idx] = 'n';
+			}
 			instance->link_status[i][num_hosts] = '\0';
 		}
 


### PR DESCRIPTION
Hi All,

I was testing the status where enabled of other nodes was displayed as 0 in the s option of corosync-cfgtools.

Although it is an operation mistake, enabled can be displayed as 0 in the following procedure.

```
[root@rh80-test01 corosync]# corosync-cfgtool -s
Printing link status.
Local node ID 1
LINK ID 0
        addr    = 192.168.106.155
        status:
                nodeid  1:      link enabled:1  link connected:1
                nodeid  2:      link enabled:1  link connected:0
LINK ID 1
        addr    = 192.168.107.155
        status:
                nodeid  1:      link enabled:0  link connected:1
                nodeid  2:      link enabled:1  link connected:0

```

Step1) Edit corosync.conf and comment the address of ring1 of the partner node.

```
(snip)
nodelist {
    node {
        ring0_addr: 192.168.106.155
        ring1_addr: 192.168.107.155
        name: rh80-test01
        nodeid: 1
    }

    node {
        ring0_addr: 192.168.106.156
#        ring1_addr: 192.168.107.156
        name: rh80-test02
        nodeid: 2
    }
}
(snip)
```

Step2) Execute corosync-cfgtool -R.

Then, the other node's enabled is displayed as 0, but connected is displayed as 1.

```
[root@rh80-test01 exec]# corosync-cfgtool -s
Printing link status.
Local node ID 1
LINK ID 0
        addr    = 192.168.106.155
        status:
                nodeid  1:      link enabled:1  link connected:1
                nodeid  2:      link enabled:1  link connected:0
LINK ID 1
        addr    = 192.168.107.155
        status:
                nodeid  1:      link enabled:0  link connected:1
                nodeid  2:      link enabled:0  link connected:1
```

This is just an operation mistake, and the following log is output.

```
Feb 06 11:54:09 [23665] rh80-test01 corosync error   [TOTEM ] parse error in config: Not all nodes have the same number of links
Feb 06 11:54:09 [23665] rh80-test01 corosync error   [TOTEM ] knet_link_set_ping_timers for node 2 link 1 failed: Invalid argument (22)
Feb 06 11:54:09 [23665] rh80-test01 corosync error   [TOTEM ] knet_link_set_pong_count for node 2 link 1 failed: Invalid argument (22)
[23665] rh80-test01 corosyncerror   [TOTEM ] knet_link_set_priority for node 2 link 1 failed: Invalid argument (22)
```

However, it is very strange that the other node's connected is changed from 0 to 1 and displayed.

I changed the initialization of the status display area to d, changed only the own node to n, and confirmed that the display was improved as follows.

```
[root@rh80-test01 corosync]# corosync-cfgtool -s
Printing link status.
Local node ID 1
LINK ID 0
        addr    = 192.168.106.155
        status:
                nodeid  1:      link enabled:1  link connected:1
                nodeid  2:      link enabled:1  link connected:0
LINK ID 1
        addr    = 192.168.107.155
        status:
                nodeid  1:      link enabled:0  link connected:1
                nodeid  2:      link enabled:0  link connected:0
```

It is not a big problem because it was originally due to a mistake in editing corosync.conf.
However, weird display can be improved with this patch.






Best Regards,
Hideo Yamauchi.