### PR TITLE
cfgtool: Improve link status display

### DIFF
--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Red Hat, Inc.
+ * Copyright (c) 2016-2020 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -531,6 +531,10 @@ int totemknet_ifaces_get (void *knet_context,
 		 * and knet orders things by host
 		 */
 		for (j=0; j<num_hosts; j++) {
+			if (own_idx != OWN_INDEX_NONE && j == own_idx) {
+				continue ;
+			}
+
 			res = knet_link_get_link_list(instance->knet_handle,
 						      host_list[j], link_list, &num_links);
 			if (res) {
@@ -560,6 +564,8 @@ int totemknet_ifaces_get (void *knet_context,
 							link_status.dynconnected<<2);
 				}
 				else {
+					knet_log_printf (LOGSYS_LEVEL_ERROR,
+					    "totemknet_ifaces_get: Cannot get link status: %s", strerror(errno));
 					ptr[j] = '?';
 				}
 			}

--- a/man/corosync-cfgtool.8
+++ b/man/corosync-cfgtool.8
@@ -1,5 +1,5 @@
 .\" 
-.\" * Copyright (C) 2010-2018 Red Hat, Inc.
+.\" * Copyright (C) 2010-2020 Red Hat, Inc.
 .\" *
 .\" * All rights reserved.
 .\" *
@@ -31,7 +31,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH "COROSYNC-CFGTOOL" "8" "2019-07-04" "" ""
+.TH "COROSYNC-CFGTOOL" "8" "2020-02-10" "" ""
 .SH "NAME"
 corosync-cfgtool \- An administrative tool for corosync.
 .SH "SYNOPSIS"
@@ -61,10 +61,13 @@ Displays the brief status of the current links on this node (KNET only) when use
 with "-s". If any interfaces are faulty, 1 is returned by the binary. If all interfaces
 are active 0 is returned to the shell.
 After each link, the nodes on that link are displayed in order with their status
-encoded into a single digit. 1=link enabled, 2=link connected, So a 3 in
-a node position indicates that the link is both enabled and connected.
-The local link (which will only ever be enabled on link 0) shows as enabled but
-not connected for internal reasons.
+encoded into a single digit, or characters 'n', 'd' and '?' with special meaning.
+1=link enabled, 2=link connected, So a 3 in a node position indicates that the
+link is both enabled and connected. Status represented by character 'n' is used for
+localhost link. Character '?' means that Crosync was unable to get status of link from knet (log
+should contain more information). Character 'd' shouldn't appear and it means that Corosync
+was unable to configure a link and it is result of some error which should have been logged.
+
 The output will be:
 LINK ID 0:
     id     = 192.168.100.80

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2019 Red Hat, Inc.
+ * Copyright (c) 2006-2020 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -105,6 +105,7 @@ linkstatusget_do (char *interface_name, int brief)
 	size_t value_len;
 	int rc = 0;
 	int len, s = 0, t;
+	char stat_ch;
 
 	printf ("Printing link status.\n");
 	result = corosync_cfg_initialize (&handle, NULL);
@@ -196,11 +197,23 @@ linkstatusget_do (char *interface_name, int brief)
 					printf ("\tstatus:\n");
 					while (s < len) {
 						nodeid = nodeid_list[s];
-						t = interface_status[i][s] - '0';
-						s++;
 						printf("\t\tnodeid %2d:\t", nodeid);
-						printf("link enabled:%d\t", t&1? 1 : 0);
-						printf("link connected:%d\n", t&2? 1: 0);
+						stat_ch = interface_status[i][s];
+
+						if (stat_ch >= '0' && stat_ch <= '9') {
+							t = stat_ch - '0';
+							printf("link enabled:%d\t", t&1? 1 : 0);
+							printf("link connected:%d\n", t&2? 1: 0);
+						} else if (stat_ch == 'n') {
+							printf("localhost\n");
+						} else if (stat_ch == '?') {
+							printf("knet error\n");
+						} else if (stat_ch == 'd') {
+							printf("config error\n");
+						} else {
+							printf("can't decode status character '%c'\n", stat_ch);
+						}
+						s++;
 					}
 				} else {
 					printf ("\tstatus\t= %s\n", interface_status[i]);


### PR DESCRIPTION
Totemknet is enhanced to use 'n' character for localhost and not adding
status, because it is safe to expect that localhost link is always
connectd. corosync-cfgtool is enhanced to properly decode 'n', '?' and 'd'
characters and display its meaning for extended status. Special
characters are also documented in man page.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>