### PR TITLE
Add support for sin6_scope_id

### DIFF
--- a/exec/totemip.c
+++ b/exec/totemip.c
@@ -297,7 +297,7 @@ int totemip_totemip_to_sockaddr_convert(struct totem_ip_address *ip_addr,
 #endif
 		sin->sin6_family = ip_addr->family;
 		sin->sin6_port = ntohs(port);
-		sin->sin6_scope_id = 2;
+		sin->sin6_scope_id = ip_addr->sin6_scope_id;
 		memcpy(&sin->sin6_addr, ip_addr->addr, sizeof(struct in6_addr));
 
 		*addrlen = sizeof(struct sockaddr_in6);
@@ -409,10 +409,12 @@ int totemip_parse(struct totem_ip_address *totemip, const char *addr,
 	if (ainfo_final->ai_family == AF_INET) {
 		sa = (struct sockaddr_in *)ainfo_final->ai_addr;
 		memcpy(totemip->addr, &sa->sin_addr, sizeof(struct in_addr));
+		totemip->sin6_scope_id = 0;
 		debug_ip_family = 4;
 	} else {
 		sa6 = (struct sockaddr_in6 *)ainfo_final->ai_addr;
 		memcpy(totemip->addr, &sa6->sin6_addr, sizeof(struct in6_addr));
+		totemip->sin6_scope_id = sa6->sin6_scope_id;
 		debug_ip_family = 6;
 	}
 
@@ -437,6 +439,7 @@ int totemip_sockaddr_to_totemip_convert(const struct sockaddr_storage *saddr,
 		const struct sockaddr_in *sin = (const struct sockaddr_in *)saddr;
 
 		memcpy(ip_addr->addr, &sin->sin_addr, sizeof(struct in_addr));
+		ip_addr->sin6_scope_id = 0;
 		ret = 0;
 	}
 
@@ -445,6 +448,7 @@ int totemip_sockaddr_to_totemip_convert(const struct sockaddr_storage *saddr,
 		  = (const struct sockaddr_in6 *)saddr;
 
 		memcpy(ip_addr->addr, &sin->sin6_addr, sizeof(struct in6_addr));
+		ip_addr->sin6_scope_id = sin->sin6_scope_id;
 
 		ret = 0;
 	}

--- a/exec/totemip.c
+++ b/exec/totemip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005-2019 Red Hat, Inc.
+ * Copyright (c) 2005-2020 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -124,14 +124,6 @@ void totemip_copy(struct totem_ip_address *addr1,
 		  const struct totem_ip_address *addr2)
 {
 	memcpy(addr1, addr2, sizeof(struct totem_ip_address));
-}
-
-void totemip_copy_endian_convert(struct totem_ip_address *addr1,
-				 const struct totem_ip_address *addr2)
-{
-	addr1->nodeid = swab32(addr2->nodeid);
-	addr1->family = swab16(addr2->family);
-	memcpy(addr1->addr, addr2->addr, TOTEMIP_ADDRLEN);
 }
 
 /*

--- a/include/corosync/coroapi.h
+++ b/include/corosync/coroapi.h
@@ -112,6 +112,7 @@ struct totem_ip_address {
 	unsigned int   nodeid;
 	unsigned short family;
 	unsigned char  addr[TOTEMIP_ADDRLEN];
+	unsigned int   sin6_scope_id;
 } __attribute__((packed));
 #endif
 

--- a/include/corosync/totem/totemip.h
+++ b/include/corosync/totem/totemip.h
@@ -65,6 +65,7 @@ struct totem_ip_address
 	unsigned int   nodeid;
 	unsigned short family;
 	unsigned char  addr[TOTEMIP_ADDRLEN];
+	unsigned int   sin6_scope_id;
 } __attribute__((packed));
 
 enum totem_ip_version_enum {


### PR DESCRIPTION
sin6_scope_id was not present in totemip structure making impossible to use link-local ipv6 address.
    
Patch adds sin6_scope_id and changes convert/copy functions to use it
(formally also comparator functions should be changed, but it seems to
cause more harm and it is not really needed).
    
This makes corosync work with link-local addresses fine for both UDPU
and Knet transport as long as interface specification is used (so
fe80::xxxx:xxxx:xxxx:xxxx%eth0).