### PR TITLE
totemip: continue when sin6_scope_id not equal with interface_num

### DIFF
--- a/exec/totemip.c
+++ b/exec/totemip.c
@@ -573,6 +573,9 @@ int totemip_iface_check(struct totem_ip_address *bindnet,
 		if (addr_len == 0)
 			continue ;
 
+		if (bindnet->sin6_scope_id != 0 && bindnet->sin6_scope_id != if_addr->interface_num)
+			continue;
+
 		totemip_copy(&bn_netaddr, bindnet);
 		totemip_copy(&if_netaddr, &if_addr->ip_addr);
 


### PR DESCRIPTION
When user configure a specific interface like vlan with the same IPv6 link-local address,
corosync should compare sin6_scope_id with interface_num, to make sure got the right intrface to bind

For example:
I want corosync use `vlan0` interface
```
nodelist {
        node {
                ring0_addr: fe80::5054:ff:fe2f:f32%vlan0
                nodeid: 1
        }

        node {
                ring0_addr: fe80::5054:ff:fe68:4e97%vlan0
                nodeid: 2
        }

}
```
`ip a` output on second node
```
2: enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 52:54:00:68:4e:97 brd ff:ff:ff:ff:ff:ff
    inet 192.168.122.145/24 brd 192.168.122.255 scope global enp1s0
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:fe68:4e97/64 scope link 
       valid_lft forever preferred_lft forever
4: vlan0@enp1s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 52:54:00:68:4e:97 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::5054:ff:fe68:4e97/64 scope link 
       valid_lft forever preferred_lft forever
```
But corosync will always bind `enp1s0`