### PR TITLE
Low: tools: Correct return code of corosync-cfgtools -s.

### DIFF
--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -200,6 +200,13 @@ linkstatusget_do (char *interface_name, int brief)
 						printf("\t\tnodeid %2d:\t", nodeid);
 						stat_ch = interface_status[i][s];
 
+						/* Set return code to 1 if status is not localhost or connected. */
+						if (rc == 0) {
+							if ((stat_ch != 'n') && (stat_ch != '3')) {
+								rc = 1;
+							}
+						}
+
 						if (stat_ch >= '0' && stat_ch <= '9') {
 							t = stat_ch - '0';
 
@@ -231,6 +238,19 @@ linkstatusget_do (char *interface_name, int brief)
 					}
 				} else {
 					printf ("\tstatus\t= %s\n", interface_status[i]);
+
+					/* Set return code to 1 if status is not localhost or connected. */
+					if (rc == 0) {
+						len = strlen(interface_status[i]);
+						while (s < len) {
+							stat_ch = interface_status[i][s];
+							if ((stat_ch != 'n') && (stat_ch != '3')) {
+								rc = 1;
+								break;
+							}
+							s++;
+						}
+					}
 				}
 			}
 		}

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -130,7 +130,7 @@ linkstatusget_do (char *interface_name, int brief)
 			transport_number = TOTEM_TRANSPORT_UDP;
 		}
 		free(str);
-        }
+	}
 
 	/* Get a list of nodes. We do it this way rather than using votequorum as cfgtool
 	 * needs to be independent of quorum type


### PR DESCRIPTION
Hi All,

This fix causes the value of the execution result of corosync-cfgtool to return 0 or 1 from the interface status.

Returns 1 if any of the cluster members are not "localhost" or "connected".

```
[root@rh80-test01 ~]# corosync-cfgtool -s 
Printing link status.
Local node ID 1
LINK ID 0
        addr    = 192.168.106.155
        status:
                nodeid  1:      localhost
                nodeid  2:      disconnected
LINK ID 1
        addr    = 192.168.107.155
        status:
                nodeid  1:      localhost
                nodeid  2:      disconnected
[root@rh80-test01 ~]# echo $?
1
[root@rh80-test01 ~]# corosync-cfgtool -s -b
Printing link status.
Local node ID 1
LINK ID 0
        addr    = 192.168.106.155
        status  = n1
LINK ID 1
        addr    = 192.168.107.155
        status  = n1
[root@rh80-test01 ~]# echo $?
1
```


Returns 0 if the cluster members are only "localhost" or "connected".
```
[root@rh80-test01 ~]# corosync-cfgtool -s 
Printing link status.
Local node ID 1
LINK ID 0
        addr    = 192.168.106.155
        status:
                nodeid  1:      localhost
                nodeid  2:      connected
LINK ID 1
        addr    = 192.168.107.155
        status:
                nodeid  1:      localhost
                nodeid  2:      connected
[root@rh80-test01 ~]# echo $?
0
[root@rh80-test01 ~]# corosync-cfgtool -s -b
Printing link status.
Local node ID 1
LINK ID 0
        addr    = 192.168.106.155
        status  = n3
LINK ID 1
        addr    = 192.168.107.155
        status  = n3
[root@rh80-test01 ~]# echo $?
0

```


Best Regards,
Hideo Yamauchi.
