### PR TITLE
test: Fix cpgtest to cope with the correct max number of group members

### DIFF
--- a/test/testcpg.c
+++ b/test/testcpg.c
@@ -303,7 +303,7 @@ int main (int argc, char *argv[]) {
 	int opt;
 	unsigned int nodeid;
 	char *fgets_res;
-	struct cpg_address member_list[64];
+	struct cpg_address member_list[CPG_MEMBERS_MAX];
 	int member_list_entries;
 	int i;
 	int recnt;


### PR DESCRIPTION
cpgtest would crash when trying to connect 128 instances. This is why