### PR TITLE
main: Make schedmiss in cmap and log equal

### DIFF
--- a/exec/main.c
+++ b/exec/main.c
@@ -858,7 +858,7 @@ static void timer_function_scheduler_timeout (void *data)
 		    (float)tv_diff / QB_TIME_NS_IN_MSEC, (float)timeout_data->max_tv_diff / QB_TIME_NS_IN_MSEC);
 
 		icmap_set_float("runtime.schedmiss.delay", (float)tv_diff / QB_TIME_NS_IN_MSEC);
-		icmap_set_uint64("runtime.schedmiss.timestamp", qb_util_nano_from_epoch_get() / QB_TIME_NS_IN_MSEC);
+		icmap_set_uint64("runtime.schedmiss.timestamp", schedmiss_event_tstamp);
 	}
 
 	/*

--- a/man/cmap_keys.8
+++ b/man/cmap_keys.8
@@ -256,13 +256,15 @@ Status of the processor. Can be one of joined and left.
 Config version of the member node.
 
 .TP
-runtime.schedmiss.timestamp
-The timestamp of the last time when corosync failed to be scheduled
-for the required amount of time. The even is warned in syslog but this
-is easier to find. The time is milli-seconds since the epoch.
+runtime.schedmiss.*
+If corosync is not scheduled after the required period of time it will
+log this event and also write an entry to cmap under following keys:
 
-.B
-runtime.schedmiss.delay
+.B timestamp
+The timestamp of the last time when corosync failed to be scheduled
+for the required amount of time. The time is milli-seconds since the epoch.
+
+.B delay
 The amount of time (milliseconds as a float) that corosync was delayed.
 
 .TP


### PR DESCRIPTION
Second call of qb_util_nano_from_epoch_get may differ a bit. Solution is
to use previously stored timestamp (similarly as in master branch).

Also fix man page to follow similar style as other keys.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>