### PR TITLE
[needle] man: corosync.conf: provider should inside the paragraph

### DIFF
--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -661,9 +661,7 @@ required.
 Within the
 .B quorum
 directive it is possible to specify the quorum algorithm to use with the
-
-.TP
-provider
+.B provider
 directive. At the time of writing only corosync_votequorum is supported.
 See votequorum(5) for configuration options.
 


### PR DESCRIPTION
Following the consistent style of this man page, I think it will be better to put `provider` inside the paragraph