### PR TITLE
[crypto] Allow runtime crypto reconfig

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,6 +187,8 @@ OLDLIBS="$LIBS"
 LIBS="$knet_LIBS $LIBS"
 AC_CHECK_LIB([knet],[knet_handle_enable_access_lists],
 	     [AC_DEFINE_UNQUOTED([HAVE_KNET_ACCESS_LIST], 1, [have knet access list])])
+AC_CHECK_LIB([knet],[knet_handle_crypto_set_config],
+	     [AC_DEFINE_UNQUOTED([HAVE_KNET_CRYPTO_RECONF], 1, [have knet crypto reconfig support])])
 LIBS="$OLDLIBS"
 
 # Checks for library functions.

--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -694,6 +694,9 @@ static void message_handler_req_exec_cfg_reload_config (
 	log_printf(LOGSYS_LEVEL_NOTICE, "Config reload requested by node " CS_PRI_NODE_ID, nodeid);
 
 	icmap_set_uint8("config.totemconfig_reload_in_progress", 1);
+
+	/* Make sure there is no rubbish in this that might be checked, even on error */
+	memset(&new_config, 0, sizeof(new_config));
 	/*
 	 * Set up a new hashtable as a staging area.
 	 */

--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -590,7 +590,13 @@ static void delete_and_notify_if_changed(icmap_map_t temp_map, const char *key_n
  */
 static void remove_ro_entries(icmap_map_t temp_map)
 {
+#ifndef HAVE_KNET_CRYPTO_RECONF
 	delete_and_notify_if_changed(temp_map, "totem.secauth");
+	delete_and_notify_if_changed(temp_map, "totem.crypto_hash");
+	delete_and_notify_if_changed(temp_map, "totem.crypto_cipher");
+	delete_and_notify_if_changed(temp_map, "totem.keyfile");
+	delete_and_notify_if_changed(temp_map, "totem.key");
+#endif
 	delete_and_notify_if_changed(temp_map, "totem.version");
 	delete_and_notify_if_changed(temp_map, "totem.threads");
 	delete_and_notify_if_changed(temp_map, "totem.ip_version");
@@ -767,7 +773,14 @@ static void message_handler_req_exec_cfg_reload_config (
 
 	/* Save this here so we can get at it for the later phases of crypto change */
 	if (new_config.crypto_changed) {
+#ifdef HAVE_KNET_CRYPTO_RECONF
 		icmap_set_uint32("config.crypto_changed", (uint32_t)1);
+#else
+		new_config.crypto_changed = 0;
+		log_printf (LOGSYS_LEVEL_ERROR, "Crypto reconfiguration is not supported by the linked version of knet\n");
+		res = CS_ERR_INVALID_PARAM;
+		goto reload_fini;
+#endif
 	}
 
 	/*

--- a/exec/main.c
+++ b/exec/main.c
@@ -1380,12 +1380,6 @@ int main (int argc, char **argv, char **envp)
 		log_printf (LOGSYS_LEVEL_WARNING, "Please migrate config file to nodelist.");
 	}
 
-	res = totem_config_keyread (&totem_config, &error_string);
-	if (res == -1) {
-		log_printf (LOGSYS_LEVEL_ERROR, "%s", error_string);
-		corosync_exit_error (COROSYNC_DONE_MAINCONFIGREAD);
-	}
-
 	res = totem_config_validate (&totem_config, &error_string);
 	if (res == -1) {
 		log_printf (LOGSYS_LEVEL_ERROR, "%s", error_string);

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -527,7 +527,7 @@ parse_error:
 
 }
 
-static int totem_get_crypto(struct totem_config *totem_config, const char **error_string)
+static int totem_get_crypto(struct totem_config *totem_config, icmap_map_t map, const char **error_string)
 {
 	char *str;
 	const char *tmp_cipher;
@@ -538,7 +538,7 @@ static int totem_get_crypto(struct totem_config *totem_config, const char **erro
 	tmp_cipher = "none";
 	tmp_model = "none";
 
-	if (icmap_get_string("totem.crypto_model", &str) == CS_OK) {
+	if (icmap_get_string_r(map, "totem.crypto_model", &str) == CS_OK) {
 		if (strcmp(str, "nss") == 0) {
 			tmp_model = "nss";
 		}
@@ -550,7 +550,7 @@ static int totem_get_crypto(struct totem_config *totem_config, const char **erro
 		tmp_model = "nss";
 	}
 
-	if (icmap_get_string("totem.secauth", &str) == CS_OK) {
+	if (icmap_get_string_r(map, "totem.secauth", &str) == CS_OK) {
 		if (strcmp(str, "on") == 0) {
 			tmp_cipher = "aes256";
 			tmp_hash = "sha256";
@@ -558,7 +558,7 @@ static int totem_get_crypto(struct totem_config *totem_config, const char **erro
 		free(str);
 	}
 
-	if (icmap_get_string("totem.crypto_cipher", &str) == CS_OK) {
+	if (icmap_get_string_r(map, "totem.crypto_cipher", &str) == CS_OK) {
 		if (strcmp(str, "none") == 0) {
 			tmp_cipher = "none";
 		}
@@ -574,7 +574,7 @@ static int totem_get_crypto(struct totem_config *totem_config, const char **erro
 		free(str);
 	}
 
-	if (icmap_get_string("totem.crypto_hash", &str) == CS_OK) {
+	if (icmap_get_string_r(map, "totem.crypto_hash", &str) == CS_OK) {
 		if (strcmp(str, "none") == 0) {
 			tmp_hash = "none";
 		}
@@ -606,6 +606,12 @@ static int totem_get_crypto(struct totem_config *totem_config, const char **erro
 		*error_string = "crypto_model should be 'nss' or 'openssl'";
 		return -1;
 	}
+
+	if (strcmp(tmp_cipher, totem_config->crypto_cipher_type) ||
+	    strcmp(tmp_hash, totem_config->crypto_hash_type) ||
+	    strcmp(tmp_model, totem_config->crypto_model)) {
+		totem_config->crypto_changed = 1;
+	    }
 
 	strncpy(totem_config->crypto_cipher_type, tmp_cipher, CONFIG_STRING_LEN_MAX);
 	strncpy(totem_config->crypto_hash_type, tmp_hash, CONFIG_STRING_LEN_MAX);
@@ -1761,9 +1767,16 @@ extern int totem_config_read (
 
 	icmap_get_uint32("totem.version", (uint32_t *)&totem_config->version);
 
-	if (totem_get_crypto(totem_config, error_string) != 0) {
+	/* initial crypto load */
+	if (totem_get_crypto(totem_config, icmap_get_global_map(), error_string) != 0) {
 		return -1;
 	}
+	if (totem_config_keyread(totem_config, icmap_get_global_map(), error_string) != 0) {
+		return -1;
+	}
+	icmap_set_uint32("config.crypto_changed", (uint32_t)0);
+	totem_config->crypto_index = 1;
+	totem_config->crypto_changed = 0;
 
 	if (icmap_get_string("totem.link_mode", &str) == CS_OK) {
 		if (strlen(str) >= TOTEM_LINK_MODE_BYTES) {
@@ -2134,12 +2147,19 @@ parse_error:
 
 int totem_config_keyread (
 	struct totem_config *totem_config,
+	icmap_map_t map,
 	const char **error_string)
 {
 	int got_key = 0;
 	char *key_location = NULL;
 	int res;
 	size_t key_len;
+	char old_key[TOTEM_PRIVATE_KEY_LEN_MAX];
+	size_t old_key_len;
+
+	/* Take a copy so we can see if it has changed */
+	memcpy(old_key, totem_config->private_key, sizeof(totem_config->private_key));
+	old_key_len = totem_config->private_key_len;
 
 	memset (totem_config->private_key, 0, sizeof(totem_config->private_key));
 	totem_config->private_key_len = 0;
@@ -2150,7 +2170,7 @@ int totem_config_keyread (
 	}
 
 	/* cmap may store the location of the key file */
-	if (icmap_get_string("totem.keyfile", &key_location) == CS_OK) {
+	if (icmap_get_string_r(map, "totem.keyfile", &key_location) == CS_OK) {
 		res = read_keyfile(key_location, totem_config, error_string);
 		free(key_location);
 		if (res)  {
@@ -2158,7 +2178,7 @@ int totem_config_keyread (
 		}
 		got_key = 1;
 	} else { /* Or the key itself may be in the cmap */
-		if (icmap_get("totem.key", NULL, &key_len, NULL) == CS_OK) {
+		if (icmap_get_r(map, "totem.key", NULL, &key_len, NULL) == CS_OK) {
 			if (key_len > sizeof(totem_config->private_key)) {
 				sprintf(error_string_response, "key is too long");
 				goto key_error;
@@ -2167,7 +2187,7 @@ int totem_config_keyread (
 				sprintf(error_string_response, "key is too short");
 				goto key_error;
 			}
-			if (icmap_get("totem.key", totem_config->private_key, &key_len, NULL) == CS_OK) {
+			if (icmap_get_r(map, "totem.key", totem_config->private_key, &key_len, NULL) == CS_OK) {
 				totem_config->private_key_len = key_len;
 				got_key = 1;
 			} else {
@@ -2184,12 +2204,28 @@ int totem_config_keyread (
 			goto key_error;
 	}
 
+	if (old_key_len != totem_config->private_key_len ||
+	    memcmp(old_key, totem_config->private_key, sizeof(totem_config->private_key))) {
+		totem_config->crypto_changed = 1;
+	}
+
 	return (0);
 
 key_error:
 	*error_string = error_string_response;
 	return (-1);
 
+}
+
+int totem_reread_crypto_config(struct totem_config *totem_config, icmap_map_t map, const char **error_string)
+{
+	if (totem_get_crypto(totem_config, map, error_string) != 0) {
+		return -1;
+	}
+	if (totem_config_keyread(totem_config, map, error_string) != 0) {
+		return -1;
+	}
+	return 0;
 }
 
 static void debug_dump_totem_config(const struct totem_config *totem_config)

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1774,7 +1774,6 @@ extern int totem_config_read (
 	if (totem_config_keyread(totem_config, icmap_get_global_map(), error_string) != 0) {
 		return -1;
 	}
-	icmap_set_uint32("config.crypto_changed", (uint32_t)0);
 	totem_config->crypto_index = 1;
 	totem_config->crypto_changed = 0;
 

--- a/exec/totemconfig.h
+++ b/exec/totemconfig.h
@@ -58,6 +58,7 @@ extern int totem_config_validate (
 
 extern int totem_config_keyread (
 	struct totem_config *totem_config,
+	icmap_map_t map,
 	const char **error_string);
 
 extern int totem_config_find_local_addr_in_nodelist(
@@ -65,11 +66,15 @@ extern int totem_config_find_local_addr_in_nodelist(
 	const char *ipaddr_key_prefix,
 	unsigned int *node_pos);
 
-
 extern void totem_volatile_config_read(
 	struct totem_config *totem_config,
 	icmap_map_t temp_map,
 	const char *deleted_key);
+
+extern int totem_reread_crypto_config(
+	struct totem_config *totem_config,
+	icmap_map_t map,
+	const char **error_string);
 
 extern int totem_volatile_config_validate(
 	struct totem_config *totem_config,

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -910,9 +910,10 @@ static int totemknet_set_knet_crypto(struct totemknet_instance *instance)
 	struct knet_handle_crypto_cfg crypto_cfg;
 	int res;
 
-	strcpy(crypto_cfg.crypto_model, instance->totem_config->crypto_model);
-	strcpy(crypto_cfg.crypto_cipher_type, instance->totem_config->crypto_cipher_type);
-	strcpy(crypto_cfg.crypto_hash_type, instance->totem_config->crypto_hash_type);
+	/* These have already been validated */
+	memcpy(crypto_cfg.crypto_model, instance->totem_config->crypto_model, sizeof(crypto_cfg.crypto_model));
+	memcpy(crypto_cfg.crypto_cipher_type, instance->totem_config->crypto_cipher_type, sizeof(crypto_cfg.crypto_model));
+	memcpy(crypto_cfg.crypto_hash_type, instance->totem_config->crypto_hash_type, sizeof(crypto_cfg.crypto_model));
 	memcpy(crypto_cfg.private_key, instance->totem_config->private_key, instance->totem_config->private_key_len);
 	crypto_cfg.private_key_len = instance->totem_config->private_key_len;
 

--- a/exec/totemknet.h
+++ b/exec/totemknet.h
@@ -143,10 +143,10 @@ extern int totemknet_reconfigure (
 	void *knet_context,
 	struct totem_config *totem_config);
 
-extern int totemknet_reconfigure_phase (
+extern int totemknet_crypto_reconfigure_phase (
 	void *knet_context,
 	struct totem_config *totem_config,
-	uint32_t phase);
+	cfg_message_crypto_reconfig_phase_t phase);
 
 extern void totemknet_stats_clear (
 	void *knet_context);

--- a/exec/totemknet.h
+++ b/exec/totemknet.h
@@ -143,6 +143,11 @@ extern int totemknet_reconfigure (
 	void *knet_context,
 	struct totem_config *totem_config);
 
+extern int totemknet_reconfigure_phase (
+	void *knet_context,
+	struct totem_config *totem_config,
+	uint32_t phase);
+
 extern void totemknet_stats_clear (
 	void *knet_context);
 

--- a/exec/totemnet.c
+++ b/exec/totemnet.c
@@ -153,10 +153,10 @@ struct transport {
 		void *net_context,
 		struct totem_config *totem_config);
 
-	int (*reconfigure_phase) (
+	int (*crypto_reconfigure_phase) (
 		void *net_context,
 		struct totem_config *totem_config,
-		uint32_t phase);
+		cfg_message_crypto_reconfig_phase_t phase);
 
 	void (*stats_clear) (
 		void *net_context);
@@ -185,7 +185,7 @@ struct transport transport_entries[] = {
 		.member_add = totemudp_member_add,
 		.member_remove = totemudp_member_remove,
 		.reconfigure = totemudp_reconfigure,
-		.reconfigure_phase = NULL
+		.crypto_reconfigure_phase = NULL
 	},
 	{
 		.name = "UDP/IP Unicast",
@@ -209,7 +209,7 @@ struct transport transport_entries[] = {
 		.member_add = totemudpu_member_add,
 		.member_remove = totemudpu_member_remove,
 		.reconfigure = totemudpu_reconfigure,
-		.reconfigure_phase = NULL
+		.crypto_reconfigure_phase = NULL
 	},
 	{
 		.name = "Kronosnet",
@@ -233,7 +233,7 @@ struct transport transport_entries[] = {
 		.member_add = totemknet_member_add,
 		.member_remove = totemknet_member_remove,
 		.reconfigure = totemknet_reconfigure,
-		.reconfigure_phase = totemknet_reconfigure_phase,
+		.crypto_reconfigure_phase = totemknet_crypto_reconfigure_phase,
 		.stats_clear = totemknet_stats_clear
 	}
 };
@@ -579,16 +579,16 @@ int totemnet_reconfigure (
 	return (res);
 }
 
-int totemnet_reconfigure_phase (
+int totemnet_crypto_reconfigure_phase (
 	void *net_context,
 	struct totem_config *totem_config,
-	uint32_t phase)
+	cfg_message_crypto_reconfig_phase_t phase)
 {
 	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
 	unsigned int res = 0;
 
-	if (instance->transport->reconfigure_phase) {
-		res = instance->transport->reconfigure_phase (
+	if (instance->transport->crypto_reconfigure_phase) {
+		res = instance->transport->crypto_reconfigure_phase (
 			instance->transport_context,
 			totem_config, phase);
 	}

--- a/exec/totemnet.c
+++ b/exec/totemnet.c
@@ -153,6 +153,11 @@ struct transport {
 		void *net_context,
 		struct totem_config *totem_config);
 
+	int (*reconfigure_phase) (
+		void *net_context,
+		struct totem_config *totem_config,
+		uint32_t phase);
+
 	void (*stats_clear) (
 		void *net_context);
 };
@@ -179,7 +184,8 @@ struct transport transport_entries[] = {
 		.recv_mcast_empty = totemudp_recv_mcast_empty,
 		.member_add = totemudp_member_add,
 		.member_remove = totemudp_member_remove,
-		.reconfigure = totemudp_reconfigure
+		.reconfigure = totemudp_reconfigure,
+		.reconfigure_phase = NULL
 	},
 	{
 		.name = "UDP/IP Unicast",
@@ -202,7 +208,8 @@ struct transport transport_entries[] = {
 		.recv_mcast_empty = totemudpu_recv_mcast_empty,
 		.member_add = totemudpu_member_add,
 		.member_remove = totemudpu_member_remove,
-		.reconfigure = totemudpu_reconfigure
+		.reconfigure = totemudpu_reconfigure,
+		.reconfigure_phase = NULL
 	},
 	{
 		.name = "Kronosnet",
@@ -226,6 +233,7 @@ struct transport transport_entries[] = {
 		.member_add = totemknet_member_add,
 		.member_remove = totemknet_member_remove,
 		.reconfigure = totemknet_reconfigure,
+		.reconfigure_phase = totemknet_reconfigure_phase,
 		.stats_clear = totemknet_stats_clear
 	}
 };
@@ -568,6 +576,22 @@ int totemnet_reconfigure (
 			instance->transport_context,
 			totem_config);
 
+	return (res);
+}
+
+int totemnet_reconfigure_phase (
+	void *net_context,
+	struct totem_config *totem_config,
+	uint32_t phase)
+{
+	struct totemnet_instance *instance = (struct totemnet_instance *)net_context;
+	unsigned int res = 0;
+
+	if (instance->transport->reconfigure_phase) {
+		res = instance->transport->reconfigure_phase (
+			instance->transport_context,
+			totem_config, phase);
+	}
 	return (res);
 }
 

--- a/exec/totemnet.h
+++ b/exec/totemnet.h
@@ -119,6 +119,8 @@ extern int totemnet_net_mtu_adjust (void *net_context, struct totem_config *tote
 
 extern int totemnet_reconfigure (void *net_context, struct totem_config *totem_config);
 
+extern int totemnet_reconfigure_phase (void *net_context, struct totem_config *totem_config, uint32_t phase);
+
 extern void totemnet_stats_clear (void *net_context);
 
 extern const char *totemnet_iface_print (void *net_context);

--- a/exec/totemnet.h
+++ b/exec/totemnet.h
@@ -119,7 +119,7 @@ extern int totemnet_net_mtu_adjust (void *net_context, struct totem_config *tote
 
 extern int totemnet_reconfigure (void *net_context, struct totem_config *totem_config);
 
-extern int totemnet_reconfigure_phase (void *net_context, struct totem_config *totem_config, uint32_t phase);
+extern int totemnet_crypto_reconfigure_phase (void *net_context, struct totem_config *totem_config, cfg_message_crypto_reconfig_phase_t phase);
 
 extern void totemnet_stats_clear (void *net_context);
 

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -1561,6 +1561,11 @@ extern int totempg_reconfigure (void)
 	return totemsrp_reconfigure (totemsrp_context, totempg_totem_config);
 }
 
+extern int totempg_reconfigure_phase (uint32_t phase)
+{
+	return totemsrp_reconfigure_phase (totemsrp_context, totempg_totem_config, phase);
+}
+
 extern void totempg_stats_clear (int flags)
 {
 	if (flags & TOTEMPG_STATS_CLEAR_TOTEM) {

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -1561,9 +1561,9 @@ extern int totempg_reconfigure (void)
 	return totemsrp_reconfigure (totemsrp_context, totempg_totem_config);
 }
 
-extern int totempg_reconfigure_phase (uint32_t phase)
+extern int totempg_crypto_reconfigure_phase (cfg_message_crypto_reconfig_phase_t phase)
 {
-	return totemsrp_reconfigure_phase (totemsrp_context, totempg_totem_config, phase);
+	return totemsrp_crypto_reconfigure_phase (totemsrp_context, totempg_totem_config, phase);
 }
 
 extern void totempg_stats_clear (int flags)

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -5181,6 +5181,15 @@ int totemsrp_reconfigure (void *context, struct totem_config *totem_config)
 	return (res);
 }
 
+int totemsrp_reconfigure_phase (void *context, struct totem_config *totem_config, uint32_t phase)
+{
+	struct totemsrp_instance *instance = (struct totemsrp_instance *)context;
+	int res;
+
+	res = totemnet_reconfigure_phase (instance->totemnet_context, totem_config, phase);
+	return (res);
+}
+
 void totemsrp_stats_clear (void *context, int flags)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)context;

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -5181,12 +5181,12 @@ int totemsrp_reconfigure (void *context, struct totem_config *totem_config)
 	return (res);
 }
 
-int totemsrp_reconfigure_phase (void *context, struct totem_config *totem_config, uint32_t phase)
+int totemsrp_crypto_reconfigure_phase (void *context, struct totem_config *totem_config, cfg_message_crypto_reconfig_phase_t phase)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)context;
 	int res;
 
-	res = totemnet_reconfigure_phase (instance->totemnet_context, totem_config, phase);
+	res = totemnet_crypto_reconfigure_phase (instance->totemnet_context, totem_config, phase);
 	return (res);
 }
 

--- a/exec/totemsrp.h
+++ b/exec/totemsrp.h
@@ -151,6 +151,11 @@ int totemsrp_reconfigure (
 	void *context,
 	struct totem_config *totem_config);
 
+int totemsrp_reconfigure_phase (
+	void *context,
+	struct totem_config *totem_config,
+	uint32_t phase);
+
 void totemsrp_stats_clear (
 	void *srp_context, int flags);
 

--- a/exec/totemsrp.h
+++ b/exec/totemsrp.h
@@ -151,10 +151,10 @@ int totemsrp_reconfigure (
 	void *context,
 	struct totem_config *totem_config);
 
-int totemsrp_reconfigure_phase (
+int totemsrp_crypto_reconfigure_phase (
 	void *context,
 	struct totem_config *totem_config,
-	uint32_t phase);
+	cfg_message_crypto_reconfig_phase_t phase);
 
 void totemsrp_stats_clear (
 	void *srp_context, int flags);

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -151,6 +151,11 @@ struct memb_ring_id {
 	unsigned long long seq;
 } __attribute__((packed));
 
+enum cfg_message_reload_phase {
+	RELOAD_PHASE_ACTIVATE = 1,
+	RELOAD_PHASE_CLEANUP = 2,
+};
+
 struct totem_config {
 	int version;
 
@@ -220,6 +225,10 @@ struct totem_config {
 	char crypto_cipher_type[CONFIG_STRING_LEN_MAX];
 
 	char crypto_hash_type[CONFIG_STRING_LEN_MAX];
+
+	int crypto_index; /* Num of crypto config currently loaded into knet ( 1 or 2 ) */
+
+	int crypto_changed; /* Has crypto changed since last time? (it's expensive to reload) */
 
 	char knet_compression_model[CONFIG_STRING_LEN_MAX];
 

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -151,10 +151,10 @@ struct memb_ring_id {
 	unsigned long long seq;
 } __attribute__((packed));
 
-enum cfg_message_reload_phase {
-	RELOAD_PHASE_ACTIVATE = 1,
-	RELOAD_PHASE_CLEANUP = 2,
-};
+typedef enum {
+	CRYPTO_RECONFIG_PHASE_ACTIVATE = 1,
+	CRYPTO_RECONFIG_PHASE_CLEANUP = 2,
+} cfg_message_crypto_reconfig_phase_t;
 
 struct totem_config {
 	int version;

--- a/include/corosync/totem/totempg.h
+++ b/include/corosync/totem/totempg.h
@@ -192,6 +192,8 @@ extern void totempg_trans_ack (void);
 
 extern int totempg_reconfigure (void);
 
+extern int totempg_reconfigure_phase (uint32_t phase);
+
 extern void totempg_force_gather (void);
 
 extern void totempg_get_config(struct totem_config *config);

--- a/include/corosync/totem/totempg.h
+++ b/include/corosync/totem/totempg.h
@@ -192,7 +192,7 @@ extern void totempg_trans_ack (void);
 
 extern int totempg_reconfigure (void);
 
-extern int totempg_reconfigure_phase (uint32_t phase);
+extern int totempg_crypto_reconfigure_phase (cfg_message_crypto_reconfig_phase_t phase);
 
 extern void totempg_force_gather (void);
 


### PR DESCRIPTION
This uses the new API in knet to reconfigure crypto options at runtime. If compiled against a knet that doesn't support this then the old API will be used and reconfiguration of crypto options is forbidden.

The reconfiguration is done in 3 phases, each happens after the token has circulated so we know all nodes are in sync.
0: Load the new configuration on all nodes
1: Activate the new configuration for sending (receiving will still accept the old encryption)
2: Deactivate the old configuration
