### PR TITLE
Add support for local ipv6 - alternative

### DIFF
--- a/exec/totemudp.c
+++ b/exec/totemudp.c
@@ -834,8 +834,8 @@ static int totemudp_build_sockets_ip (
 		return (-1);
 	}
 
-	totemip_totemip_to_sockaddr_convert(bound_to, instance->totem_interface->ip_port - 1,
-		&sockaddr, &addrlen);
+	totemip_totemip_to_sockaddr_convert_with_scopeid(bound_to, instance->totem_interface->ip_port - 1,
+		&sockaddr, &addrlen, 1);
 
 	retries = 0;
 	while (1) {
@@ -890,7 +890,8 @@ static int totemudp_build_sockets_ip (
 	 * Bind to unicast socket used for token send/receives
 	 * This has the side effect of binding to the correct interface
 	 */
-	totemip_totemip_to_sockaddr_convert(bound_to, instance->totem_interface->ip_port, &sockaddr, &addrlen);
+	totemip_totemip_to_sockaddr_convert_with_scopeid(bound_to, instance->totem_interface->ip_port,
+	    &sockaddr, &addrlen, 1);
 
 	retries = 0;
 	while (1) {

--- a/exec/totemudpu.c
+++ b/exec/totemudpu.c
@@ -824,7 +824,9 @@ static int totemudpu_build_sockets_ip (
 	 * Bind to unicast socket used for token send/receives
 	 * This has the side effect of binding to the correct interface
 	 */
-	totemip_totemip_to_sockaddr_convert(bound_to, instance->totem_interface->ip_port, &sockaddr, &addrlen);
+	totemip_totemip_to_sockaddr_convert_with_scopeid(bound_to, instance->totem_interface->ip_port,
+	    &sockaddr, &addrlen, 1);
+
 	while (1) {
 		res = bind (instance->token_socket, (struct sockaddr *)&sockaddr, addrlen);
 		if (res == 0) {
@@ -1331,7 +1333,7 @@ static int totemudpu_create_sending_socket(
 	/*
 	 * Bind to sending interface
 	 */
-	totemip_totemip_to_sockaddr_convert(&instance->my_id, 0, &sockaddr, &addrlen);
+	totemip_totemip_to_sockaddr_convert_with_scopeid(&instance->my_id, 0, &sockaddr, &addrlen, 1);
 	res = bind (fd, (struct sockaddr *)&sockaddr, addrlen);
 	if (res == -1) {
 		LOGSYS_PERROR (errno, instance->totemudpu_log_level_warning,

--- a/include/corosync/totem/totemip.h
+++ b/include/corosync/totem/totemip.h
@@ -97,6 +97,10 @@ extern int totemip_totemip_to_sockaddr_convert(struct totem_ip_address *ip_addr,
 					       uint16_t port, struct sockaddr_storage *saddr, int *addrlen);
 extern int totemip_parse(struct totem_ip_address *totemip, const char *addr,
 			 int family);
+extern int totemip_totemip_to_sockaddr_convert_with_scopeid(const struct totem_ip_address *ip_addr,
+					        uint16_t port, struct sockaddr_storage *saddr, int *addrlen,
+					        int fill_scopeid);
+
 extern int totemip_iface_check(struct totem_ip_address *bindnet,
 			       struct totem_ip_address *boundto,
 			       int *interface_up,


### PR DESCRIPTION
sin6_scope_id is not present in totemip structure making impossible to
use link-local ipv6 address.

Patch adds new call totemip_totemip_to_sockaddr_convert_with_scopeid which
can be instructed to fill scope id. This function calls totemip_getif_scopeid
which walks local addresses and returns scope id if interface matches.

Main difference between this patch and
934c47e is fact, that totemip
structure keeps unchanged so corosync stays wire compatible.

This makes corosync work with link-local addresses fine for both UDPU
and UDP transport as long as there is only one matching interface with
this patch.

Big thanks to Aleksei Burlakov <aburlakov@suse.com> who brought idea
(and implementation) of using totemip_getif_scopeid.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>