### PR TITLE
tools: use util_strtonum to check nodeid option and strict checking condition

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -42,11 +42,17 @@ if INSTALL_XMLCONF
 bin_SCRIPTS		+= corosync-xmlproc
 endif
 
+noinst_HEADERS          = util.h
+
 AM_CFLAGS		= $(knet_CFLAGS)
 
 EXTRA_DIST		= corosync-xmlproc.sh \
 			  corosync-notifyd.sysconfig.example \
                           corosync-blackbox.sh
+
+corosync_cfgtool_SOURCES = corosync-cfgtool.c util.c
+
+corosync_quorumtool_SOURCES = corosync-quorumtool.c util.c
 
 corosync-xmlproc: corosync-xmlproc.sh
 	$(SED) -e 's#@''DATADIR@#${datadir}#g' \

--- a/tools/corosync-cfgtool.c
+++ b/tools/corosync-cfgtool.c
@@ -46,11 +46,13 @@
 #include <sys/un.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <limits.h>
 
 #include <corosync/corotypes.h>
 #include <corosync/totem/totem.h>
 #include <corosync/cfg.h>
 #include <corosync/cmap.h>
+#include "util.h"
 
 #define cs_repeat(result, max, code)				\
 	do {							\
@@ -447,6 +449,7 @@ int main (int argc, char *argv[]) {
 	int rc = EXIT_SUCCESS;
 	enum user_action action = ACTION_NOOP;
 	int brief = 0;
+	long long int l;
 
 	while ( (opt = getopt(argc, argv, options)) != -1 ) {
 		switch (opt) {
@@ -467,14 +470,22 @@ int main (int argc, char *argv[]) {
 			action = ACTION_REOPEN_LOG_FILES;
 			break;
 		case 'k':
-			nodeid = atoi (optarg);
+			if (util_strtonum(optarg, 1, UINT_MAX, &l) == -1) {
+				fprintf(stderr, "The nodeid was not valid, try a positive number\n");
+				exit(EXIT_FAILURE);
+			}
+			nodeid = l;
 			action = ACTION_KILL_NODE;
 			break;
 		case 'H':
 			action = ACTION_SHUTDOW;
 			break;
 		case 'a':
-			nodeid = atoi (optarg);
+			if (util_strtonum(optarg, 1, UINT_MAX, &l) == -1) {
+				fprintf(stderr, "The nodeid was not valid, try a positive number\n");
+				exit(EXIT_FAILURE);
+			}
+			nodeid = l;
 			action = ACTION_SHOWADDR;
 			break;
 		case '?':

--- a/tools/corosync-quorumtool.c
+++ b/tools/corosync-quorumtool.c
@@ -48,6 +48,7 @@
 #include <corosync/cmap.h>
 #include <corosync/quorum.h>
 #include <corosync/votequorum.h>
+#include "util.h"
 
 typedef enum {
 	NODEID_FORMAT_DECIMAL,
@@ -883,7 +884,6 @@ static void close_all(void) {
 
 int main (int argc, char *argv[]) {
 	const char *options = "VHaslpmfe:v:hin:o:";
-	char *endptr;
 	int opt;
 	int votes = 0;
 	int ret = 0;
@@ -894,7 +894,7 @@ int main (int argc, char *argv[]) {
 	command_t command_opt = CMD_SHOWSTATUS;
 	sorttype_t sort_opt = SORT_ADDR;
 	char sortchar;
-	long int l;
+	long long int l;
 
 	if (init_all()) {
 		close_all();
@@ -934,11 +934,11 @@ int main (int argc, char *argv[]) {
 			break;
 		case 'e':
 			if (using_votequorum() > 0) {
-				votes = strtol(optarg, &endptr, 0);
-				if ((votes == 0 && endptr == optarg) || votes <= 0) {
+				if (util_strtonum(optarg, 1, INT_MAX, &l) == -1) {
 					fprintf(stderr, "New expected votes value was not valid, try a positive number\n");
 					exit(EXIT_FAILURE);
 				} else {
+					votes = l;
 					command_opt = CMD_SETEXPECTED;
 				}
 			} else {
@@ -947,8 +947,7 @@ int main (int argc, char *argv[]) {
 			}
 			break;
 		case 'n':
-			l = strtol(optarg, &endptr, 0);
-			if ((l == 0 && endptr == optarg) || l < 0) {
+			if (util_strtonum(optarg, 1, UINT_MAX, &l) == -1) {
 				fprintf(stderr, "The nodeid was not valid, try a positive number\n");
 				exit(EXIT_FAILURE);
 			}
@@ -957,11 +956,11 @@ int main (int argc, char *argv[]) {
 			break;
 		case 'v':
 			if (using_votequorum() > 0) {
-				votes = strtol(optarg, &endptr, 0);
-				if ((votes == 0 && endptr == optarg) || votes < 0) {
+				if (util_strtonum(optarg, 0, INT_MAX, &l) == -1) {
 					fprintf(stderr, "New votes value was not valid, try a positive number or zero\n");
 					exit(EXIT_FAILURE);
 				} else {
+					votes = l;
 					command_opt = CMD_SETVOTES;
 				}
 			}

--- a/tools/util.c
+++ b/tools/util.c
@@ -1,0 +1,35 @@
+#include <stdlib.h>
+#include <errno.h>
+
+#include "util.h"
+
+/*
+ * Safer wrapper of strtoll. Return 0 on success, otherwise -1.
+ * Idea from corosync-qdevice project
+ */
+int
+util_strtonum(const char *str, long long int min_val, long long int max_val,
+    long long int *res)
+{
+        long long int tmp_ll;
+        char *ep;
+
+        if (min_val > max_val) {
+                return (-1);
+        }
+
+        errno = 0;
+
+        tmp_ll = strtoll(str, &ep, 10);
+        if (ep == str || *ep != '\0' || errno != 0) {
+                return (-1);
+        }
+
+        if (tmp_ll < min_val || tmp_ll > max_val) {
+                return (-1);
+        }
+
+        *res = tmp_ll;
+
+        return (0);
+}

--- a/tools/util.h
+++ b/tools/util.h
@@ -1,0 +1,15 @@
+#ifndef COROSYNC_TOOLS_UTIL_H_DEFINED
+#define COROSYNC_TOOLS_UTIL_H_DEFINED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int              util_strtonum(const char *str, long long int min_val,
+    long long int max_val, long long int *res);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COROSYNC_TOOLS_UTIL_H_DEFINED */


### PR DESCRIPTION
Hi,

I was trying to use `util_strtonum` to replace `atoi`, since `util_strtonum` can do some validation jobs.

Changes in this PR include:
#### 1. Use util_strtonum to check nodeid in cfgtool(-k and -a option)
As mentioned in `man corosync.conf`, nodeid should be a positive number, so after applying this patch:
```
# corosync-cfgtool -a -1
The nodeid was not valid, try a positive number

# corosync-cfgtool -a 0
The nodeid was not valid, try a positive number

# corosync-cfgtool -a 1sf
The nodeid was not valid, try a positive number

# corosync-cfgtool -a xxx
The nodeid was not valid, try a positive number

# corosync-cfgtool -a 1
10.10.10.26
```
#### 2. Check condition more strict in quorumtool
As long as containing any invalid characters, that value of option will be considered invalid
The current code:
```
# corosync-quorumtool -e 12sf
# Would not complain anything
```
Now apply this patch:
```
# corosync-quorumtool -e 12sf
New expected votes value was not valid, try a positive number
```
#### Empty case and overflow case
```
# empty case
# corosync-quorumtool -v ""
New votes value was not valid, try a positive number or zero

# overflow case
# corosync-cfgtool -a 12345678901234567890
The nodeid was not valid, try a positive number
```