### PR TITLE
cmapctl: return EXIT_FAILURE for -g and -d option while error

### DIFF
--- a/tools/corosync-cmapctl.c
+++ b/tools/corosync-cmapctl.c
@@ -932,6 +932,7 @@ int main(int argc, char *argv[])
 				print_key(handle, argv[i], value_len, NULL, type);
 			} else {
 				fprintf(stderr, "Can't get key %s. Error %s\n", argv[i], cs_strerror(err));
+				return (EXIT_FAILURE);
 			}
 		}
 		break;
@@ -940,6 +941,7 @@ int main(int argc, char *argv[])
 			err = cmap_delete(handle, argv[i]);
 			if (err != CS_OK) {
 				fprintf(stderr, "Can't delete key %s. Error %s\n", argv[i], cs_strerror(err));
+				return (EXIT_FAILURE);
 			}
 		}
 		break;


### PR DESCRIPTION
Hi @jfriesse ,

I think it's better to return EXIT_FAILURE while can't get or can't delete key for -g and -d options.

What do you think?

Thanks!