### PR TITLE
[needle] cmapctl: return EXIT_FAILURE on failure

### DIFF
--- a/tools/corosync-cmapctl.c
+++ b/tools/corosync-cmapctl.c
@@ -838,6 +838,7 @@ int main(int argc, char *argv[])
 				print_key(handle, argv[i], value_len, NULL, type);
 			} else {
 				fprintf(stderr, "Can't get key %s. Error %s\n", argv[i], cs_strerror(err));
+				return (EXIT_FAILURE);
 			}
 		}
 		break;
@@ -846,6 +847,7 @@ int main(int argc, char *argv[])
 			err = cmap_delete(handle, argv[i]);
 			if (err != CS_OK) {
 				fprintf(stderr, "Can't delete key %s. Error %s\n", argv[i], cs_strerror(err));
+				return (EXIT_FAILURE);
 			}
 		}
 		break;


### PR DESCRIPTION
Hi @jfriesse ,

This is backport pr from #577 