### PR TITLE
cmapctl: return EXIT_FAILURE if no result print for ACTION_PRINT_PREFIX

### DIFF
--- a/tools/corosync-cmapctl.c
+++ b/tools/corosync-cmapctl.c
@@ -417,13 +417,14 @@ static void print_key(cmap_handle_t handle,
 	printf("\n");
 }
 
-static void print_iter(cmap_handle_t handle, const char *prefix)
+static int print_iter(cmap_handle_t handle, const char *prefix)
 {
 	cmap_iter_handle_t iter_handle;
 	char key_name[CMAP_KEYNAME_MAXLEN + 1];
 	size_t value_len;
 	cmap_value_types_t type;
 	cs_error_t err;
+	int no_result = 1;
 
 	err = cmap_iter_init(handle, prefix, &iter_handle);
 	if (err != CS_OK) {
@@ -432,9 +433,12 @@ static void print_iter(cmap_handle_t handle, const char *prefix)
 	}
 
 	while ((err = cmap_iter_next(handle, iter_handle, key_name, &value_len, &type)) == CS_OK) {
+		no_result = 0;
 		print_key(handle, key_name, value_len, NULL, type);
 	}
+
 	cmap_iter_finalize(handle, iter_handle);
+	return no_result;
 }
 
 static void delete_with_prefix(cmap_handle_t handle, const char *prefix)
@@ -814,6 +818,7 @@ int main(int argc, char *argv[])
 	int no_retries;
 	char * clear_opt = NULL;
 	char * settings_file = NULL;
+	int count_of_no_result = 0;
 
 	action = ACTION_PRINT_PREFIX;
 	track_prefix = 1;
@@ -918,11 +923,15 @@ int main(int argc, char *argv[])
 	switch (action) {
 	case ACTION_PRINT_PREFIX:
 		if (argc == 0) {
-			print_iter(handle, NULL);
+			count_of_no_result = print_iter(handle, NULL);
 		} else {
 			for (i = 0; i < argc; i++) {
-				print_iter(handle, argv[i]);
+				count_of_no_result += print_iter(handle, argv[i]);
 			}
+		}
+
+		if (count_of_no_result > 0 && count_of_no_result >= argc) {
+			return (EXIT_FAILURE);
 		}
 		break;
 	case ACTION_GET:


### PR DESCRIPTION
Hi @jfriesse ,

Consider this case:
```
corosync-cmapctl no_such_key
```
I prefer on this time, return code should be `1`, similar like no result print when using `grep` command

While:
```
corosync-cmapctl no_such_key totem
```
Since it can print all results starts with totem, return code should still be `0`