### PR TITLE
totemconfig: check whether linknumber larger than INTERFACE_MAX

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1369,6 +1369,16 @@ static int put_nodelist_members_to_config(struct totem_config *totem_config, icm
 			if (res != 3 || strcmp(tmp_key2, "_addr") != 0) {
 				continue;
 			}
+			if (linknumber >= INTERFACE_MAX) {
+				snprintf (error_string_response, sizeof(error_string_response),
+						"parse error in config: interface ring number %u is bigger than allowed maximum %u\n",
+						linknumber, INTERFACE_MAX - 1);
+				*error_string = error_string_response;
+
+				icmap_iter_finalize(iter2);
+				icmap_iter_finalize(iter);
+				return (-1);
+			}
 
 			if (icmap_get_string_r(map, iter_key2, &node_addr_str) != CS_OK) {
 				continue;


### PR DESCRIPTION
Hi @jfriesse ,

When configure large wrong number in `ringX_addr` like:
```
node {
        ring0_addr: 10.10.10.142
        ring13_addr: 20.20.20.142
        name: f32-2
        nodeid: 2
    }
```
Core dump will happen:
```
#0  0x00005567dff64787 put_nodelist_members_to_config (corosync + 0x2e787)
#1  0x00005567dff66ae8 totem_config_read (corosync + 0x30ae8)
#2  0x00005567dff486c0 main (corosync + 0x126c0)
#3  0x00007f79d3364042 __libc_start_main (libc.so.6 + 0x27042)
#4  0x00005567dff4953e _start (corosync + 0x1353e)
```

So I created this PR to fix this issue

Thanks for review!