### PR TITLE
common_lib: Remove trailing spaces in cs_strerror

### DIFF
--- a/common_lib/error_conversion.c
+++ b/common_lib/error_conversion.c
@@ -154,7 +154,7 @@ const char * cs_strerror(cs_error_t err)
 		return "CS_ERR_NO_MEMORY";
 
 	case CS_ERR_NAME_TOO_LONG :
-		return "CS_ERR_NAME_TOO_LONG ";
+		return "CS_ERR_NAME_TOO_LONG";
 
 	case CS_ERR_TIMEOUT:
 		return "CS_ERR_TIMEOUT";
@@ -169,64 +169,64 @@ const char * cs_strerror(cs_error_t err)
 		return "CS_ERR_BAD_HANDLE";
 
 	case CS_ERR_BUSY :
-		return "CS_ERR_BUSY ";
+		return "CS_ERR_BUSY";
 
 	case CS_ERR_ACCESS :
-		return "CS_ERR_ACCESS ";
+		return "CS_ERR_ACCESS";
 
 	case CS_ERR_NOT_EXIST :
-		return "CS_ERR_NOT_EXIST ";
+		return "CS_ERR_NOT_EXIST";
 
 	case CS_ERR_EXIST :
-		return "CS_ERR_EXIST ";
+		return "CS_ERR_EXIST";
 
 	case CS_ERR_NO_SPACE :
-		return "CS_ERR_NO_SPACE ";
+		return "CS_ERR_NO_SPACE";
 
 	case CS_ERR_INTERRUPT :
-		return "CS_ERR_INTERRUPT ";
+		return "CS_ERR_INTERRUPT";
 
 	case CS_ERR_NAME_NOT_FOUND :
-		return "CS_ERR_NAME_NOT_FOUND ";
+		return "CS_ERR_NAME_NOT_FOUND";
 
 	case CS_ERR_NO_RESOURCES :
-		return "CS_ERR_NO_RESOURCES ";
+		return "CS_ERR_NO_RESOURCES";
 
 	case CS_ERR_NOT_SUPPORTED :
-		return "CS_ERR_NOT_SUPPORTED ";
+		return "CS_ERR_NOT_SUPPORTED";
 
 	case CS_ERR_BAD_OPERATION :
-		return "CS_ERR_BAD_OPERATION ";
+		return "CS_ERR_BAD_OPERATION";
 
 	case CS_ERR_FAILED_OPERATION :
-		return "CS_ERR_FAILED_OPERATION ";
+		return "CS_ERR_FAILED_OPERATION";
 
 	case CS_ERR_MESSAGE_ERROR :
-		return "CS_ERR_MESSAGE_ERROR ";
+		return "CS_ERR_MESSAGE_ERROR";
 
 	case CS_ERR_QUEUE_FULL :
-		return "CS_ERR_QUEUE_FULL ";
+		return "CS_ERR_QUEUE_FULL";
 
 	case CS_ERR_QUEUE_NOT_AVAILABLE :
-		return "CS_ERR_QUEUE_NOT_AVAILABLE ";
+		return "CS_ERR_QUEUE_NOT_AVAILABLE";
 
 	case CS_ERR_BAD_FLAGS :
-		return "CS_ERR_BAD_FLAGS ";
+		return "CS_ERR_BAD_FLAGS";
 
 	case CS_ERR_TOO_BIG :
-		return "CS_ERR_TOO_BIG ";
+		return "CS_ERR_TOO_BIG";
 
 	case CS_ERR_NO_SECTIONS :
-		return "CS_ERR_NO_SECTIONS ";
+		return "CS_ERR_NO_SECTIONS";
 
 	case CS_ERR_CONTEXT_NOT_FOUND :
-		return "CS_ERR_CONTEXT_NOT_FOUND ";
+		return "CS_ERR_CONTEXT_NOT_FOUND";
 
 	case CS_ERR_TOO_MANY_GROUPS :
-		return "CS_ERR_TOO_MANY_GROUPS ";
+		return "CS_ERR_TOO_MANY_GROUPS";
 
 	case CS_ERR_SECURITY :
-		return "CS_ERR_SECURITY ";
+		return "CS_ERR_SECURITY";
 
 	default:
 		return "unknown error";


### PR DESCRIPTION
Found this problem during reviewing #589 (message displayed when node doesn't exist - `Could not kill node (error = CS_ERR_NOT_EXIST )`).