### PR TITLE
config: Increase default token timeout to 3000 ms

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -66,7 +66,7 @@
 #include "totemconfig.h"
 
 #define TOKEN_RETRANSMITS_BEFORE_LOSS_CONST	4
-#define TOKEN_TIMEOUT				1000
+#define TOKEN_TIMEOUT				3000
 #define TOKEN_WARNING				75
 #define TOKEN_COEFFICIENT			650
 #define JOIN_TIMEOUT				50

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC_CONF 5 2020-02-25 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH COROSYNC_CONF 5 2020-10-12 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 corosync.conf - corosync executive configuration file
 
@@ -365,7 +365,7 @@ key.
 Be careful to use the same timeout values on each of the nodes in the cluster
 or unpredictable results may occur.
 
-The default is 1000 milliseconds.
+The default is 3000 milliseconds.
 
 .TP
 token_warning


### PR DESCRIPTION
Default token timeout of 1000 ms was often changed by users because of
other workloads on machine which may make corosync responding a bit
later than needed and resulting in token loss.

3000 ms was chosen as a compromise between token timeout increase
and allow live cluster upgrade (other nodes should receive token
by node with new default on time).

It doesn't affect token token_coefficient so final token timeout still
depends on number of configured nodes (just base is higher).

This change slows down failover a bit so for clusters where failover
times are important, please change the token timeout in configuration
file corosync.conf as a:

totem {
    version: 2
    token: 1000
...

Signed-off-by: Jan Friesse <jfriesse@redhat.com>