### PR TITLE
Limit range like quorum.two_node as 0 to 1

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -486,6 +486,7 @@ static int safe_atoq_range(icmap_value_types_t value_type, long long int *min_va
 	case ICMAP_VALUETYPE_UINT16: *min_val = 0; *max_val = UINT16_MAX; break;
 	case ICMAP_VALUETYPE_INT32: *min_val = INT32_MIN; *max_val = INT32_MAX; break;
 	case ICMAP_VALUETYPE_UINT32: *min_val = 0; *max_val = UINT32_MAX; break;
+	case ICMAP_VALUETYPE_BOOLEAN: *min_val = 0; *max_val = 1; break;
 	default:
 		return (-1);
 	}
@@ -645,7 +646,7 @@ static int main_config_parser_cb(const char *path,
 			    (strcmp(path, "quorum.wait_for_all") == 0) ||
 			    (strcmp(path, "quorum.auto_tie_breaker") == 0) ||
 			    (strcmp(path, "quorum.last_man_standing") == 0)) {
-				val_type = ICMAP_VALUETYPE_UINT8;
+				val_type = ICMAP_VALUETYPE_BOOLEAN;
 				if (safe_atoq(value, &val, val_type) != 0) {
 					goto atoi_error;
 				}

--- a/exec/icmap.c
+++ b/exec/icmap.c
@@ -320,6 +320,7 @@ size_t icmap_get_valuetype_len(icmap_value_types_t type)
 	case ICMAP_VALUETYPE_DOUBLE: res = sizeof(double); break;
 	case ICMAP_VALUETYPE_STRING:
 	case ICMAP_VALUETYPE_BINARY:
+	case ICMAP_VALUETYPE_BOOLEAN:
 		res = 0;
 		break;
 	}
@@ -969,6 +970,7 @@ cs_error_t icmap_adjust_int_r(
 	case ICMAP_VALUETYPE_DOUBLE:
 	case ICMAP_VALUETYPE_STRING:
 	case ICMAP_VALUETYPE_BINARY:
+	case ICMAP_VALUETYPE_BOOLEAN:
 		err = CS_ERR_INVALID_PARAM;
 		break;
 	}
@@ -1022,6 +1024,7 @@ cs_error_t icmap_fast_adjust_int_r(
 	case ICMAP_VALUETYPE_DOUBLE:
 	case ICMAP_VALUETYPE_STRING:
 	case ICMAP_VALUETYPE_BINARY:
+	case ICMAP_VALUETYPE_BOOLEAN:
 		err = CS_ERR_INVALID_PARAM;
 		break;
 	}

--- a/include/corosync/icmap.h
+++ b/include/corosync/icmap.h
@@ -68,6 +68,7 @@ typedef enum {
     ICMAP_VALUETYPE_DOUBLE	= 10,
     ICMAP_VALUETYPE_STRING	= 11,
     ICMAP_VALUETYPE_BINARY	= 12,
+    ICMAP_VALUETYPE_BOOLEAN	= 13,
 } icmap_value_types_t;
 
 /*


### PR DESCRIPTION
Hi @jfriesse ,

I found configure value like **quorum.two_node** always  0 or 1, perhaps limit its range to 0,1 will decrease mis-configure
Just for config validate, the actual value type still be `uint8`, so I don't think we need to create corresponding set/get interfaces for the new type ICMAP_VALUETYPE_BOOLEAN

Thanks for review!