### PR TITLE
[devel] export LOGDIR in corosync.pc

### DIFF
--- a/pkgconfig/Makefile.am
+++ b/pkgconfig/Makefile.am
@@ -62,6 +62,7 @@ lib%.pc: libtemplate.pc.in Makefile
 		-e 's#@''PREFIX@#$(exec_prefix)#g' \
 		-e 's#@''LIBDIR@#$(libdir)#g' \
 		-e 's#@''LIBVERSION@#$(VERSION)#g' \
+		-e 's#@''LOGDIR@#$(LOGDIR)#g' \
 	    $< > $@-t
 	chmod a-w $@-t
 	mv $@-t $@

--- a/pkgconfig/corosync.pc.in
+++ b/pkgconfig/corosync.pc.in
@@ -2,6 +2,7 @@ prefix=@PREFIX@
 exec_prefix=${prefix}
 libdir=@LIBDIR@
 includedir=${prefix}/include
+logdir=@LOGDIR@
 
 Name: corosync
 Version: @LIBVERSION@


### PR DESCRIPTION
logdir is configurable at build time and can change from distro to distro.
export the path for pcs to use.

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>