### PR TITLE
Don't lock all current and future memory if can't increase memlock rl…

### DIFF
--- a/exec/main.c
+++ b/exec/main.c
@@ -475,7 +475,12 @@ static void corosync_mlockall (void)
 #define RLIMIT_MEMLOCK RLIMIT_VMEM
 #endif
 
-	setrlimit (RLIMIT_MEMLOCK, &rlimit);
+	res = setrlimit (RLIMIT_MEMLOCK, &rlimit);
+	if (res == -1) {
+		LOGSYS_PERROR (errno, LOGSYS_LEVEL_WARNING,
+			"Could not increase RLIMIT_MEMLOCK, not locking memory");
+		return;
+	}
 
 	res = mlockall (MCL_CURRENT | MCL_FUTURE);
 	if (res == -1) {


### PR DESCRIPTION
…imit

If we fail to increase our RLIMIT_MEMLOCK, then locking all our current
and future memory is extremely dangerous; once our memory use reaches
our RLIMIT_MEMLOCK, memory allocations will start failing, very likely
leading to our entire process crashing.

This can happen if we aren't a privileged process, for example if
running as non-root user, or inside an unprivileged container.