### PR TITLE
notifyd: improve to wait for corosync to start

### DIFF
--- a/init/corosync-notifyd.service.in
+++ b/init/corosync-notifyd.service.in
@@ -1,8 +1,6 @@
 [Unit]
 Description=Corosync Dbus and snmp notifier
 Documentation=man:corosync-notifyd
-Requires=corosync.service
-After=corosync.service
 
 [Service]
 EnvironmentFile=-@INITCONFIGDIR@/corosync-notifyd


### PR DESCRIPTION
This patch will make corosync-notifyd wait for corosync to start, saving the user the trouble of starting notifyd.

Currently, users need to start notifyd after starting the cluster (corosync).
```
# pcs cluster start --all
rhel83-1: Starting Cluster...
rhel83-2: Starting Cluster...
rhel83-3: Starting Cluster...

# ssh rhel83-1 systemctl start corosync-notifyd
# ssh rhel83-2 systemctl start corosync-notifyd
# ssh rhel83-3 systemctl start corosync-notifyd
```
By setting auto-start of patched notifyd,
```
# systemctl enable corosync-notifyd
# systemctl start corosync-notifyd
# ps -ef | grep -e corosync -e pacemaker
root        4866       1  0 14:18 ?        00:00:00 /usr/sbin/corosync-notifyd -f -l -s -m 192.168.122.160
```
there is no need to start after starting the cluster.
```
# pcs cluster start --all
# ps -ef | grep -e corosync -e pacemaker
root        4866       1  0 14:18 ?        00:00:00 /usr/sbin/corosync-notifyd -f -l -s -m 192.168.122.160
root        4884       1 33 14:19 ?        00:00:01 /usr/sbin/corosync -f
root        4897       1  0 14:19 ?        00:00:00 /usr/sbin/pacemakerd -f
haclust+    4898    4897  1 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-based
root        4899    4897  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-fenced
root        4900    4897  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-execd
haclust+    4901    4897  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-attrd
haclust+    4902    4897  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-schedulerd
haclust+    4903    4897  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-controld
```
Of course, there is no need to start after re-starting the cluster too.
```
# pcs cluster stop --all
# pcs cluster start --all
# ps -ef | grep -e corosync -e pacemaker
root        4866       1  0 14:18 ?        00:00:00 /usr/sbin/corosync-notifyd -f -l -s -m 192.168.122.160
root        4955       1 51 14:19 ?        00:00:02 /usr/sbin/corosync -f
root        4967       1  0 14:19 ?        00:00:00 /usr/sbin/pacemakerd -f
haclust+    4968    4967  1 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-based
root        4969    4967  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-fenced
root        4970    4967  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-execd
haclust+    4971    4967  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-attrd
haclust+    4972    4967  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-schedulerd
haclust+    4973    4967  0 14:19 ?        00:00:00 /usr/libexec/pacemaker/pacemaker-controld
```