### PR TITLE
totemknet: retry knet_handle_new without privileged operations if it …

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -640,6 +640,7 @@ static void remove_ro_entries(icmap_map_t temp_map)
 	delete_and_notify_if_changed(temp_map, "totem.cluster_name");
 	delete_and_notify_if_changed(temp_map, "quorum.provider");
 	delete_and_notify_if_changed(temp_map, "system.move_to_root_cgroup");
+	delete_and_notify_if_changed(temp_map, "system.allow_knet_handle_fallback");
 	delete_and_notify_if_changed(temp_map, "system.sched_rr");
 	delete_and_notify_if_changed(temp_map, "system.priority");
 	delete_and_notify_if_changed(temp_map, "system.qb_ipc_type");

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -808,6 +808,14 @@ static int main_config_parser_cb(const char *path,
 					return (0);
 				}
 			}
+			if (strcmp(path, "system.allow_knet_handle_fallback") == 0) {
+				if ((strcmp(value, "yes") != 0) &&
+				    (strcmp(value, "no") != 0)) {
+					*error_string = "Invalid system.allow_knet_handle_fallback";
+
+					return (0);
+				}
+			}
 			break;
 
 		case MAIN_CP_CB_DATA_STATE_INTERFACE:

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -802,6 +802,17 @@ cgroup. This feature is available only for systems with cgroups with RT
 sched enabled (Linux with CONFIG_RT_GROUP_SCHED kernel option).
 
 .TP
+allow_knet_handle_fallback
+If knet handle creation fails using privileged operations, allow fallback to
+creating knet handle using unprivileged operations. Defaults to no, meaning
+if privileged knet handle creation fails, corosync will refuse to start.
+
+The knet handle will always be created using privileged operations if possible,
+setting this to yes only allows fallback to unprivileged operations. This fallback
+may result in performance issues, but if running in an unprivileged environment,
+e.g. as a normal user or in unprivileged container, this may be required.
+
+.TP
 state_dir
 Existing directory where corosync should chdir into. Corosync stores
 important state files and blackboxes there.


### PR DESCRIPTION
…fails

knet_handle_new can fail with ENAMETOOLONG if its privileged operations
fail, which can happen if we're running as a user process or in an
unprivileged container. Instead of failing to start, let's retry
without the privileged operations, which may result in a reduction in
performance, but at least it doesn't completely prevent us from starting.

Signed-off-by: Dan Streetman <ddstreet@canonical.com>