### PR TITLE
totemconfig: fix integer underflow and logic bug

### DIFF
--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -651,11 +651,11 @@ static int nodelist_byname(icmap_map_t map, const char *find_name, int strip_dom
 			char *dot;
 			dot = strchr(name, '.');
 			if (dot) {
-				namelen = name - dot - 1;
+				namelen = dot - name;
 			}
 		}
 		if (strncmp(find_name, name, namelen) == 0 &&
-		    strlen(find_name) == strlen(name)) {
+		    strlen(find_name) == namelen) {
 			icmap_iter_finalize(iter);
 			return node_pos;
 		}


### PR DESCRIPTION
Fix integer underflow when computing `namelen` in `nodelist_byname`,
always use computed `namelen`.
Fixes #626.