### PR TITLE
[needle] man: corosync.conf: adjust description about interface section

### DIFF
--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -68,8 +68,18 @@ This top level directive contains configuration options for resources.
 .PP
 Within the
 .B totem
-directive, an interface directive is required.  There is also one configuration
-option which is required:
+directive, for UDP transport, an
+.B interface
+section is required.
+
+.PP
+.PP
+For UDPU transport, an
+.B interface
+section is not needed and it is recommended that the
+.B nodelist
+is used to define cluster nodes.
+
 .PP
 .PP
 Within the


### PR DESCRIPTION
Since `interface` section was not required on udpu mode