### PR TITLE
man: corosync-cfgtool.8: use proper single quotes

### DIFF
--- a/man/corosync-cfgtool.8
+++ b/man/corosync-cfgtool.8
@@ -88,7 +88,7 @@ nodeid: 2 reachable   onwire (min/max/cur): 0, 1, 1
 .P
 Only reachable nodes are displayed so "reachable" should always be there.
 .br
-'onwire' versions are the knet on-wire versions that are supported/in use (where appropriate).
+\(oqonwire\(cq versions are the knet on-wire versions that are supported/in use (where appropriate).
 .br
 IP addresses are the local and remote IP addresses (for UDP[U] only the local IP address is shown)
 .br


### PR DESCRIPTION
Apostrophe as the first character of the input line indicates a
request, so groff complained: macro 'onwire'' not defined.

Signed-off-by: Ferenc Wágner <wferi@debian.org>