### PR TITLE
config: Remove hardcoded crypto models

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -555,6 +555,28 @@ static int str_to_ull(const char *str, unsigned long long int *res)
 	return (0);
 }
 
+static int handle_crypto_model(const char *val, const char **error_string)
+{
+
+	if (util_is_valid_knet_crypto_model(val, NULL, 0,
+	    "Invalid crypto model. Should be ", error_string) == 1) {
+		return (0);
+	} else {
+		return (-1);
+	}
+}
+
+static int handle_compress_model(const char *val, const char **error_string)
+{
+
+	if (util_is_valid_knet_compress_model(val, NULL, 0,
+	    "Invalid compression model. Should be ", error_string) == 1) {
+		return (0);
+	} else {
+		return (-1);
+	}
+}
+
 static int main_config_parser_cb(const char *path,
 			char *key,
 			char *value,
@@ -748,14 +770,11 @@ static int main_config_parser_cb(const char *path,
 				}
 			}
 			if (strcmp(path, "totem.crypto_model") == 0) {
-				if ((strcmp(value, "nss") != 0) &&
-				    (strcmp(value, "openssl") != 0)) {
-					*error_string = "Invalid crypto model. "
-					    "Should be nss or openssl";
-
+				if (handle_crypto_model(value, error_string) != 0) {
 					return (0);
 				}
 			}
+
 			if (strcmp(path, "totem.crypto_cipher") == 0) {
 				if ((strcmp(value, "none") != 0) &&
 				    (strcmp(value, "aes256") != 0) &&
@@ -780,6 +799,13 @@ static int main_config_parser_cb(const char *path,
 					return (0);
 				}
 			}
+
+			if (strcmp(path, "totem.knet_compression_model") == 0) {
+				if (handle_compress_model(value, error_string) != 0) {
+					return (0);
+				}
+			}
+
 			break;
 
 		case MAIN_CP_CB_DATA_STATE_SYSTEM:

--- a/exec/main.c
+++ b/exec/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2002-2006 MontaVista Software, Inc.
- * Copyright (c) 2006-2018 Red Hat, Inc.
+ * Copyright (c) 2006-2021 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -1214,6 +1214,41 @@ exit_res:
 	 return (res);
 }
 
+static void show_version_info_crypto(void)
+{
+	const char *error_string;
+	const char *list_str;
+
+	if (util_is_valid_knet_crypto_model(NULL, &list_str, 1, "", &error_string) != -1) {
+		printf("Available crypto models: %s\n", list_str);
+	} else {
+		perror(error_string);
+	}
+}
+
+static void show_version_info_compress(void)
+{
+	const char *error_string;
+	const char *list_str;
+
+	if (util_is_valid_knet_compress_model(NULL, &list_str, 1, "", &error_string) != -1) {
+		printf("Available compression models: %s\n", list_str);
+	} else {
+		perror(error_string);
+	}
+}
+
+static void show_version_info(void)
+{
+
+	printf ("Corosync Cluster Engine, version '%s'\n", VERSION);
+	printf ("Copyright (c) 2006-2021 Red Hat, Inc.\n");
+
+	printf ("\nBuilt-in features:" PACKAGE_FEATURES "\n");
+
+	show_version_info_crypto();
+	show_version_info_compress();
+}
 
 int main (int argc, char **argv, char **envp)
 {
@@ -1254,8 +1289,7 @@ int main (int argc, char **argv, char **envp)
 				testonly = 1;
 				break;
 			case 'v':
-				printf ("Corosync Cluster Engine, version '%s'\n", VERSION);
-				printf ("Copyright (c) 2006-2018 Red Hat, Inc.\n");
+				show_version_info();
 				logsys_system_fini();
 				return EXIT_SUCCESS;
 
@@ -1266,7 +1300,7 @@ int main (int argc, char **argv, char **envp)
 					"        -c     : Corosync config file path.\n"\
 					"        -f     : Start application in foreground.\n"\
 					"        -t     : Test configuration and exit.\n"\
-					"        -v     : Display version and SVN revision of Corosync and exit.\n");
+					"        -v     : Display version, git revision and some useful information about Corosync and exit.\n");
 				logsys_system_fini();
 				return EXIT_FAILURE;
 		}

--- a/exec/main.c
+++ b/exec/main.c
@@ -1045,6 +1045,7 @@ static void set_icmap_ro_keys_flag (void)
 	 */
 	icmap_set_ro_access("totem.crypto_cipher", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.crypto_hash", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.crypto_model", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.keyfile", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.key", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.secauth", CS_FALSE, CS_TRUE);

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -619,9 +619,14 @@ static int totem_get_crypto(struct totem_config *totem_config, icmap_map_t map, 
 		totem_config->crypto_changed = 1;
 	    }
 
-	strncpy(totem_config->crypto_cipher_type, tmp_cipher, CONFIG_STRING_LEN_MAX);
-	strncpy(totem_config->crypto_hash_type, tmp_hash, CONFIG_STRING_LEN_MAX);
-	strncpy(totem_config->crypto_model, tmp_model, CONFIG_STRING_LEN_MAX);
+	strncpy(totem_config->crypto_cipher_type, tmp_cipher, CONFIG_STRING_LEN_MAX - 1);
+	totem_config->crypto_cipher_type[CONFIG_STRING_LEN_MAX - 1] = '\0';
+
+	strncpy(totem_config->crypto_hash_type, tmp_hash, CONFIG_STRING_LEN_MAX - 1);
+	totem_config->crypto_hash_type[CONFIG_STRING_LEN_MAX - 1] = '\0';
+
+	strncpy(totem_config->crypto_model, tmp_model, CONFIG_STRING_LEN_MAX - 1);
+	totem_config->crypto_model[CONFIG_STRING_LEN_MAX - 1] = '\0';
 
 out_free_crypto_model_str:
 	free(crypto_model_str);

--- a/exec/util.h
+++ b/exec/util.h
@@ -87,4 +87,12 @@ const char * short_service_name_get(uint32_t service_id,
  */
 const char *get_state_dir(void);
 
+extern int util_is_valid_knet_crypto_model(const char *val,
+	const char **list_str, int machine_parseable_str,
+	const char *error_string_prefix, const char **error_string);
+
+extern int util_is_valid_knet_compress_model(const char *val,
+	const char **list_str, int machine_parseable_str,
+	const char *error_string_prefix, const char **error_string);
+
 #endif /* UTIL_H_DEFINED */

--- a/man/corosync.8
+++ b/man/corosync.8
@@ -1,5 +1,5 @@
 .\"/*
-.\" * Copyright (C) 2010-2018 Red Hat, Inc.
+.\" * Copyright (C) 2010-2021 Red Hat, Inc.
 .\" *
 .\" * All rights reserved.
 .\" *
@@ -31,7 +31,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC 8 2018-11-12
+.TH COROSYNC 8 2021-04-09
 .SH NAME
 corosync \- The Corosync Cluster Engine.
 .SH SYNOPSIS
@@ -54,7 +54,9 @@ Start application in foreground.
 Test configuration and then exit.
 .TP
 .B -v
-Display version and SVN revision of Corosync and exit.
+Display version, git revision, compiled features and available crypto and compression
+models and exit.
+
 .SH SEE ALSO
 .BR corosync_overview (7),
 .BR corosync.conf (5),

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC_CONF 5 2020-10-12 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH COROSYNC_CONF 5 2021-04-09 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 corosync.conf - corosync executive configuration file
 
@@ -204,8 +204,10 @@ a subset of the cluster (for example during a rolling upgrade).
 
 .TP
 crypto_model
-This specifies which cryptographic library should be used by knet. Options
-are nss and openssl.
+This specifies which cryptographic library should be used by knet.
+Supported values depend on the libknet build and on the installed
+cryptography libraries. Typically nss and openssl will be available
+but gcrypt and others could also be allowed.
 
 The default is nss.
 

--- a/vqsim/Makefile.am
+++ b/vqsim/Makefile.am
@@ -38,11 +38,14 @@ noinst_HEADERS			= vqsim.h
 
 bin_PROGRAMS			= corosync-vqsim
 
+corosync_vqsim_CFLAGS		= $(knet_CFLAGS)
+
 corosync_vqsim_LDADD		= $(top_builddir)/common_lib/libcorosync_common.la \
 				  ../exec/corosync-votequorum.o ../exec/corosync-icmap.o  \
 				  ../exec/corosync-coroparse.o ../exec/corosync-logconfig.o \
 				  ../exec/corosync-util.o ../exec/corosync-logsys.o \
-				$(LIBQB_LIBS)
+				$(LIBQB_LIBS) $(knet_LIBS)
+
 if VQSIM_READLINE
 corosync_vqsim_LDADD		+= -lreadline
 endif


### PR DESCRIPTION
Use knet_get_crypto_list to find knet supported crypto models and use
them instead of hardcoded list.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>