### PR TITLE
cfg: corosync_cfg_trackstop blocks forever

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -1106,9 +1106,17 @@ static void message_handler_req_lib_cfg_trackstop (
 	const void *msg)
 {
 	struct cfg_info *ci = (struct cfg_info *)api->ipc_private_data_get (conn);
+	struct res_lib_cfg_trackstop res_lib_cfg_trackstop;
 
 	ENTER();
 	remove_ci_from_shutdown(ci);
+
+	res_lib_cfg_trackstop.header.size = sizeof(struct res_lib_cfg_trackstop);
+	res_lib_cfg_trackstop.header.id = MESSAGE_RES_CFG_STATETRACKSTOP;
+	res_lib_cfg_trackstop.header.error = CS_OK;
+
+	api->ipc_response_send(conn, &res_lib_cfg_trackstop,
+				    sizeof(res_lib_cfg_trackstop));
 	LEAVE();
 }
 

--- a/test/testcfg.c
+++ b/test/testcfg.c
@@ -145,5 +145,15 @@ int main (int argc, char *argv[]) {
 		fprintf(stderr, "corosync_cfg_try_shutdown failed: %d\n", res);
 		return 1;
 	}
+
+	/*
+	 * Test bug presented in 3.1.1 and 3.1.2 that makes trackstop blocks forever
+	 */
+	res = corosync_cfg_trackstop(cfg_handle1);
+	if (res != CS_OK) {
+		fprintf(stderr, "corosync_cfg_trackstop failed: %d\n", res);
+		return 1;
+	}
+
 	return 0;
 }


### PR DESCRIPTION
corosync_cfg_trackstop expects reply but that was never sent. Make sure
to send reply so corosync_cfg_trackstop works.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>