### PR TITLE
main: Add support for cgroup v2 and auto mode

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -828,7 +828,8 @@ static int main_config_parser_cb(const char *path,
 			}
 			if (strcmp(path, "system.move_to_root_cgroup") == 0) {
 				if ((strcmp(value, "yes") != 0) &&
-				    (strcmp(value, "no") != 0)) {
+				    (strcmp(value, "no") != 0) &&
+				    (strcmp(value, "auto") != 0)) {
 					*error_string = "Invalid system.move_to_root_cgroup";
 
 					return (0);

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -1,6 +1,6 @@
 .\"/*
 .\" * Copyright (c) 2005 MontaVista Software, Inc.
-.\" * Copyright (c) 2006-2020 Red Hat, Inc.
+.\" * Copyright (c) 2006-2021 Red Hat, Inc.
 .\" *
 .\" * All rights reserved.
 .\" *
@@ -32,7 +32,7 @@
 .\" * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 .\" * THE POSSIBILITY OF SUCH DAMAGE.
 .\" */
-.TH COROSYNC_CONF 5 2021-04-09 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
+.TH COROSYNC_CONF 5 2021-07-23 "corosync Man Page" "Corosync Cluster Engine Programmer's Manual"
 .SH NAME
 corosync.conf - corosync executive configuration file
 
@@ -799,9 +799,37 @@ meaning maximal / minimal priority (so minimal / maximal nice value).
 
 .TP
 move_to_root_cgroup
-Should be set to yes (default) if corosync should try to move itself to root
-cgroup. This feature is available only for systems with cgroups with RT
-sched enabled (Linux with CONFIG_RT_GROUP_SCHED kernel option).
+Can be one of
+.B yes
+(Corosync always moves itself to root cgroup),
+.B no
+(Corosync never tries to move itself to root cgroup) or
+.B auto
+(Corosync first checks if sched_rr is enabled, and if
+so, it tries to set round robin realtime scheduling with maximal priority to itself.
+If setting of priority fails, corosync tries to move itself to root
+cgroup and retries setting of priority).
+
+This feature is available only for systems with cgroups v1 with RT
+sched enabled (Linux with CONFIG_RT_GROUP_SCHED kernel option) and cgroups v2.
+
+It's worth noting that currently (May 3 2021) cgroup2 doesn’t yet
+support control of realtime processes and the cpu controller can only be
+enabled when all RT processes are in the root cgroup (applies only for kernel
+with CONFIG_RT_GROUP_SCHED enabled). So when move_to_root_cgroup
+is disabled, kernel is compiled with CONFIG_RT_GROUP_SCHED and systemd is used,
+it may be impossible to make systemd options
+like CPUQuota working correctly until corosync is stopped.
+
+Also when moving to root cgroup is enforced and used together with cgroup2 and systemd
+it makes impossible (most of the time) for journald to add systemd specific
+metadata (most importantly _SYSTEMD_UNIT) properly, because corosync is
+moved out of cgroup created by systemd. This means
+it is not possible to filter corosync logged messages based on these metadata
+(for example using -u or _SYSTEMD_UNIT=UNIT pattern) and also running
+systemctl status doesn't display (all) corosync log messages.
+The problem is even worse because journald caches pid for some time
+(approx. 5 sec) so initial corosync messages have correct metadata.
 
 .TP
 allow_knet_handle_fallback


### PR DESCRIPTION
Support for cgroup v2 is very similar to cgroup v1 just checking (and
writing) different file.

Because of all the problems described later with cgroup v2 new "auto"
mode (new default) is added. This mode first tries to set rr scheduling
and moves Corosync to root cgroup only if it fails.

Testing this feature is a bit harder than with cgroup v1 so it's
probably worh noting in this commit message.

1. Copy some service file (I've used httpd service) and set
   CPUQuota=30% in the [service] section.
2. Check /sys/fs/cgroup/cgroup.subtree_control - there should be no
   "cpu"
3. Start modified service
4. Check /sys/fs/cgroup/cgroup.subtree_control - there should be "cpu"
5. Start corosync - It should be able to get rt priority

When move_to_root_cgroup is disabled (applies only for kernels
with CONFIG_RT_GROUP_SCHED enabled), behavior differs:
- If corosync is started before modified service, so
  there is no "cpu" in /sys/fs/cgroup/cgroup.subtree_control
  corosync starts without problem and gets rt priority.
  Starting modified service later will never add "cpu" into
  /sys/fs/cgroup/cgroup.subtree_control (because corosync is holding
  rt priority and it is placed in the non-root cgroup by systemd).

- When corosync is started after modified service, so "cpu"
  is in /sys/fs/cgroup/cgroup.subtree_control, corosync is not
  able to get RT priority.

It's worth noting problems when cgroup v2 is used together with systemd
logging described in corosync.conf(5) man page.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>
Reviewed-by: Christine Caulfield <ccaulfie@redhat.com>