### PR TITLE
man: The consensus timeout is 1.2 * token_timeout, which has been cha…

### DIFF
--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -471,7 +471,7 @@ than token.  There is an increasing risk of odd membership changes, which still
 guarantee virtual synchrony,  as node count grows if consensus is less than
 token.
 
-The default is 1200 milliseconds.
+The default is 3600 milliseconds.
 
 .TP
 merge


### PR DESCRIPTION
The consensus timeout is 1.2 * token_timeout. The token_timeout default value has been changed from 1000 to 3000. So the consensus timeout should also be changed in (man 5 corosync.conf), accordingly.