### PR TITLE
build: Add explicit dependency for used libraries

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -55,8 +55,10 @@ testvotequorum1_LDADD	= $(LIBQB_LIBS) $(top_builddir)/lib/libvotequorum.la
 testvotequorum2_LDADD	= $(LIBQB_LIBS) $(top_builddir)/lib/libvotequorum.la
 cpgbound_LDADD		= $(LIBQB_LIBS) $(top_builddir)/lib/libcpg.la
 cpgbench_LDADD		= $(LIBQB_LIBS) $(top_builddir)/lib/libcpg.la
-cpgbenchzc_LDADD	= $(LIBQB_LIBS) $(top_builddir)/lib/libcpg.la
-testsam_LDADD		= $(LIBQB_LIBS) $(top_builddir)/lib/libsam.la
+cpgbenchzc_LDADD	= $(LIBQB_LIBS) $(top_builddir)/lib/libcpg.la \
+			  $(top_builddir)/common_lib/libcorosync_common.la
+testsam_LDADD		= $(LIBQB_LIBS) $(top_builddir)/lib/libsam.la \
+			  $(top_builddir)/lib/libcmap.la
 testcfg_LDADD		= $(LIBQB_LIBS) $(top_builddir)/lib/libcfg.la
 
 if HAVE_CRC32

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -62,25 +62,29 @@ corosync-xmlproc: corosync-xmlproc.sh
 corosync-blackbox: corosync-blackbox.sh
 	$(SED) -e 's#@''LOCALSTATEDIR@#${localstatedir}#g' $< > $@
 
-corosync_cmapctl_LDADD	= $(LIBQB_LIBS) $(top_builddir)/lib/libcmap.la
+corosync_cmapctl_LDADD	= $(LIBQB_LIBS) $(top_builddir)/common_lib/libcorosync_common.la $(top_builddir)/lib/libcmap.la
 
-corosync_cfgtool_LDADD	= $(LIBQB_LIBS) $(top_builddir)/lib/libcfg.la $(top_builddir)/lib/libcmap.la
+corosync_cfgtool_LDADD	= $(LIBQB_LIBS) $(top_builddir)/common_lib/libcorosync_common.la \
+			  $(top_builddir)/lib/libcfg.la $(top_builddir)/lib/libcmap.la
 
 corosync_cpgtool_LDADD	= $(LIBQB_LIBS) $(top_builddir)/lib/libcfg.la \
-			  $(top_builddir)/lib/libcpg.la
+			  $(top_builddir)/lib/libcpg.la \
+			  $(top_builddir)/common_lib/libcorosync_common.la
 
 corosync_quorumtool_LDADD = $(LIBQB_LIBS) \
 			    $(top_builddir)/lib/libcmap.la \
 			    $(top_builddir)/lib/libcfg.la \
 			    $(top_builddir)/lib/libquorum.la \
-			    $(top_builddir)/lib/libvotequorum.la
+			    $(top_builddir)/lib/libvotequorum.la \
+			    $(top_builddir)/common_lib/libcorosync_common.la
 
 corosync_notifyd_CFLAGS   = $(DBUS_CFLAGS) $(libsystemd_CFLAGS)
 corosync_notifyd_LDADD    = $(LIBQB_LIBS) $(DBUS_LIBS) $(SNMP_LIBS) \
 			    $(libsystemd_LIBS) \
 			    $(top_builddir)/lib/libcmap.la \
 			    $(top_builddir)/lib/libcfg.la \
-			    $(top_builddir)/lib/libquorum.la
+			    $(top_builddir)/lib/libquorum.la \
+			    $(top_builddir)/common_lib/libcorosync_common.la
 
 lint:
 	-splint $(LINT_FLAGS) $(DBUS_CFLAGS) $(CPPFLAGS) $(CFLAGS) *.c


### PR DESCRIPTION
Don't rely on implicit symbol finding (cs_strerror being most prominent example) but rather use explicit one.
    
This makes current debian experimental happy (compile source)
    
Signed-off-by: Jan Friesse <jfriesse@redhat.com>
