### PR TITLE
totemudpu: Don't block local socketpair

### DIFF
--- a/exec/totemudpu.c
+++ b/exec/totemudpu.c
@@ -540,6 +540,7 @@ static int net_deliver_fn (
 	}
 
 	if (instance->totem_config->block_unlisted_ips &&
+	    instance->netif_bind_state == BIND_STATE_REGULAR &&
 	    find_member_by_sockaddr(instance, (const struct sockaddr *)&system_from) == NULL) {
 		log_printf(instance->totemudpu_log_level_debug, "Packet rejected from %s",
 		    totemip_sa_print((const struct sockaddr *)&system_from));


### PR DESCRIPTION
Commit to drop packets from unlisted IPs made ifdown case not working
because msg_name is unset for socketpair.

solution is to drop packets from unlisted IPs only when bind state is
BIND_STATE_REGULAR.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>