### PR TITLE
Remove bashism from configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_ARG_ENABLE(interlib-deps,
     [enable_interlib_deps="yes"])
 
 AC_MSG_NOTICE([enable inter-library dependencies: $enable_interlib_deps])
-if test "${enable_interlib_deps}" == "yes"; then
+if test "x${enable_interlib_deps}" = "xyes"; then
     link_all_deplibs=yes
     link_all_deplibs_CXX=yes
 else


### PR DESCRIPTION
This was the real problem behind 384d168: Debian experimental now
sports a dash with LINENO support, so configure does not fall back to
using bash instead, choking on such bash-only constructs.  Unfortunately
this didn't bail out cleanly, just unexpectedly set link_all_deplibs to
no, and the error message

./configure: 13158: test: yes: unexpected operator

stayed unnoticed in the logs.  Actually, link_all_deplibs=no is the
default in Debian, reducing overlinking and causing confusion overall,
see https://debbugs.gnu.org/db/13/13920.html for example.

I think being explicit about used interfaces has its merit, so now that
Corosync has it, it might be advantageous to disable link_all_deplibs
by default across the board (after this patch re-enables it as a side
effect).