### PR TITLE
pkgconfig: Export corosysconfdir

### DIFF
--- a/pkgconfig/Makefile.am
+++ b/pkgconfig/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright (c) 2009 Red Hat, Inc.
+# Copyright (c) 2009-2022 Red Hat, Inc.
 #
 # All rights reserved.
 #
@@ -63,6 +63,7 @@ lib%.pc: libtemplate.pc.in Makefile
 		-e 's#@''LIBDIR@#$(libdir)#g' \
 		-e 's#@''LIBVERSION@#$(VERSION)#g' \
 		-e 's#@''LOGDIR@#$(LOGDIR)#g' \
+		-e 's#@''COROSYSCONFDIR@#$(COROSYSCONFDIR)#g' \
 	    $< > $@-t
 	chmod a-w $@-t
 	mv $@-t $@

--- a/pkgconfig/corosync.pc.in
+++ b/pkgconfig/corosync.pc.in
@@ -3,6 +3,7 @@ exec_prefix=${prefix}
 libdir=@LIBDIR@
 includedir=${prefix}/include
 logdir=@LOGDIR@
+corosysconfdir=@COROSYSCONFDIR@
 
 Name: corosync
 Version: @LIBVERSION@


### PR DESCRIPTION
Useful for external code to easily tell where corosync.conf
is (in case someone configured it for /usr/local/etc, ...)

E.g. pacemaker's crm_report collects corosync.conf, and some
of its testing tools generate a corosync.conf for a test cluster.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>