### PR TITLE
coroparse: properly handle trailing comments

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -327,6 +327,16 @@ static int parse_section(FILE *fp,
 			if (strlen (line) > 0 && line[strlen(line) - 1] == '\r')
 				line[strlen(line) - 1] = '\0';
 		}
+		/*
+		 * Clear out white space and tabs
+		 */
+		for (i = strlen (line) - 1; i > -1; i--) {
+			if (line[i] == '\t' || line[i] == ' ') {
+				line[i] = '\0';
+			} else {
+				break;
+			}
+		}
 
 		ignore_line = 1;
 		for (i = 0; i < strlen (line); i++) {
@@ -342,27 +352,6 @@ static int parse_section(FILE *fp,
 		 */
 		if (ignore_line) {
 			continue;
-		}
-
-		/*
-		 * Remove trailing comments
-		 */
-		for (i = 0; i < strlen (line) - 1; i++) {
-			if (line[i] == '#') {
-				line[i] = '\0';
-				break;
-			}
-		}
-
-		/*
-		 * Clear out trailing white space and tabs
-		 */
-		for (i = strlen (line) - 1; i > -1; i--) {
-			if (line[i] == '\t' || line[i] == ' ') {
-				line[i] = '\0';
-			} else {
-				break;
-			}
 		}
 
 		/* New section ? */

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -327,16 +327,6 @@ static int parse_section(FILE *fp,
 			if (strlen (line) > 0 && line[strlen(line) - 1] == '\r')
 				line[strlen(line) - 1] = '\0';
 		}
-		/*
-		 * Clear out white space and tabs
-		 */
-		for (i = strlen (line) - 1; i > -1; i--) {
-			if (line[i] == '\t' || line[i] == ' ') {
-				line[i] = '\0';
-			} else {
-				break;
-			}
-		}
 
 		ignore_line = 1;
 		for (i = 0; i < strlen (line); i++) {
@@ -352,6 +342,27 @@ static int parse_section(FILE *fp,
 		 */
 		if (ignore_line) {
 			continue;
+		}
+
+		/*
+		 * Remove trailing comments
+		 */
+		for (i = 0; i < strlen (line) - 1; i++) {
+			if (line[i] == '#') {
+				line[i] = '\0';
+				break;
+			}
+		}
+
+		/*
+		 * Clear out trailing white space and tabs
+		 */
+		for (i = strlen (line) - 1; i > -1; i--) {
+			if (line[i] == '\t' || line[i] == ' ') {
+				line[i] = '\0';
+			} else {
+				break;
+			}
 		}
 
 		/* New section ? */

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -282,7 +282,20 @@ static char *remove_whitespace(char *string, int remove_colon_and_brace)
 	return start;
 }
 
+static char *remove_comment(char *string)
+{
+	char *start;
+	int i;
 
+	start = string;
+	for (i = 0; i <= strlen (start) - 1; i++) {
+		if(start[i] == '#') {
+			start[i] = '\0';
+			break;
+		}
+	}
+	return start;
+}
 
 static int parse_section(FILE *fp,
 			const char *fname,
@@ -405,7 +418,16 @@ static int parse_section(FILE *fp,
 
 			*(loc-1) = '\0';
 			key = remove_whitespace(line, 1);
-			value = remove_whitespace(loc, 0);
+
+			/* remove trailing comments from values unless the key is cluster_name
+			 * which can ligitimately have a '#' as part of the name
+			 */
+			if(strcmp(key, "cluster_name") == 0) {
+				value = remove_whitespace(loc, 0);
+			} else {
+				value = remove_comment(loc);
+				value = remove_whitespace(value, 0);
+			}
 
 			if (strlen(path) + strlen(key) + 1 >= ICMAP_KEYNAME_MAXLEN) {
 				tmp_error_string = "New key makes total cmap path too long";


### PR DESCRIPTION
config lines ending in a comment can lead to the comment being
unexpectedly included as part of a value. trailing comments should
be removed early in the parsing process