### PR TITLE
spec: Migrate to SPDX license

### DIFF
--- a/corosync.spec.in
+++ b/corosync.spec.in
@@ -23,7 +23,7 @@ Name: corosync
 Summary: The Corosync Cluster Engine and Application Programming Interfaces
 Version: @version@
 Release: 1%{?gitver}%{?dist}
-License: BSD
+License: BSD-3-Clause
 URL: http://corosync.github.io/corosync/
 Source0: http://build.clusterlabs.org/corosync/releases/%{name}-%{version}%{?gittarver}.tar.gz
 


### PR DESCRIPTION
Both Fedora and openSUSE now recommends to use SPDX shortname format for License.