### PR TITLE
parser: Allow a non-breaking space as 'whitespace'

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -249,7 +249,7 @@ static char *strchr_rs (const char *haystack, int byte)
 	if (end_address) {
 		end_address += 1; /* skip past { or = */
 
-		while (*end_address == ' ' || *end_address == '\t')
+		while (*end_address == ' ' || *end_address == '\t' || (unsigned char)*end_address == 0xA0)
 			end_address++;
 	}
 
@@ -271,11 +271,11 @@ static char *remove_whitespace(char *string, int remove_colon_and_brace)
 	char *end;
 
 	start = string;
-	while (*start == ' ' || *start == '\t')
+	while (*start == ' ' || *start == '\t' || (unsigned char)*start == 0xA0)
 		start++;
 
 	end = start+(strlen(start))-1;
-	while ((*end == ' ' || *end == '\t' || (remove_colon_and_brace && (*end == ':' || *end == '{'))) && end > start)
+	while ((*end == ' ' || *end == '\t' || (unsigned char)*end == 0xA0 || (remove_colon_and_brace && (*end == ':' || *end == '{'))) && end > start)
 		end--;
 	if (*end != '\0')
 		*(end + 1) = '\0';
@@ -332,7 +332,7 @@ static int parse_section(FILE *fp,
 		 * Clear out white space and tabs
 		 */
 		for (i = strlen (line) - 1; i > -1; i--) {
-			if (line[i] == '\t' || line[i] == ' ') {
+			if (line[i] == '\t' || line[i] == ' ' || (unsigned char)line[i] == 0xA0) {
 				line[i] = '\0';
 			} else {
 				break;
@@ -341,7 +341,7 @@ static int parse_section(FILE *fp,
 
 		ignore_line = 1;
 		for (i = 0; i < strlen (line); i++) {
-			if (line[i] != '\t' && line[i] != ' ') {
+			if (line[i] != '\t' && line[i] != ' ' && (unsigned char)line[i] != 0xA0) {
 				if (line[i] != '#')
 					ignore_line = 0;
 


### PR DESCRIPTION
non-breaking spaces are depressingly easy to enter in some editors and can make a mess of a corosync.conf file, as the character can break keyword names and generate some very strange error messages.

So here we include it (0xA0) as a valid whitespace character. The (unsigned char) cast is for portability - Intel systems use signed chars so we'd need something there, but this should protect us against unsigned char systems too.

No attempt is made to protect against UTF-8 characters, that's very much out of scope for this project I suspect.

ref: https://github.com/corosync/corosync/issues/723