### PR TITLE
Fail to start if knet ping timers are invalid

### DIFF
--- a/exec/totemconfig.h
+++ b/exec/totemconfig.h
@@ -86,7 +86,7 @@ extern int totemconfig_configure_new_params(
 	icmap_map_t map,
 	const char **error_string);
 
-extern void totemconfig_commit_new_params(
+extern int totemconfig_commit_new_params(
 	struct totem_config *totem_config,
 	icmap_map_t map);
 

--- a/exec/totemknet.h
+++ b/exec/totemknet.h
@@ -51,13 +51,13 @@ extern int totemknet_initialize (
 	totemsrp_stats_t *stats,
 	void *context,
 
-	void (*deliver_fn) (
+	int (*deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from),
 
-	void (*iface_change_fn) (
+	int (*iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int ring_no),

--- a/exec/totemnet.c
+++ b/exec/totemnet.c
@@ -56,13 +56,13 @@ struct transport {
 		totemsrp_stats_t *stats,
 		void *context,
 
-		void (*deliver_fn) (
+		int (*deliver_fn) (
 			void *context,
 			const void *msg,
 			unsigned int msg_len,
 			const struct sockaddr_storage *system_from),
 
-		void (*iface_change_fn) (
+		int (*iface_change_fn) (
 			void *context,
 			const struct totem_ip_address *iface_address,
 			unsigned int ring_no),
@@ -321,13 +321,13 @@ int totemnet_initialize (
 	totemsrp_stats_t *stats,
 	void *context,
 
-	void (*deliver_fn) (
+	int (*deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from),
 
-	void (*iface_change_fn) (
+	int (*iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int ring_no),

--- a/exec/totemnet.h
+++ b/exec/totemnet.h
@@ -61,13 +61,13 @@ extern int totemnet_initialize (
 	totemsrp_stats_t *stats,
 	void *context,
 
-	void (*deliver_fn) (
+	int (*deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from),
 
-	void (*iface_change_fn) (
+	int (*iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int iface_no),

--- a/exec/totemudp.c
+++ b/exec/totemudp.c
@@ -110,13 +110,13 @@ struct totemudp_instance {
 
 	void *context;
 
-	void (*totemudp_deliver_fn) (
+	int (*totemudp_deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from);
 
-	void (*totemudp_iface_change_fn) (
+	int (*totemudp_iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int ring_no);
@@ -1136,13 +1136,13 @@ int totemudp_initialize (
 
 	void *context,
 
-	void (*deliver_fn) (
+	int (*deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from),
 
-	void (*iface_change_fn) (
+	int (*iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int ring_no),

--- a/exec/totemudp.h
+++ b/exec/totemudp.h
@@ -51,13 +51,13 @@ extern int totemudp_initialize (
 	totemsrp_stats_t *stats,
 	void *context,
 
-	void (*deliver_fn) (
+	int (*deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from),
 
-	void (*iface_change_fn) (
+	int (*iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int ring_no),

--- a/exec/totemudpu.c
+++ b/exec/totemudpu.c
@@ -100,13 +100,13 @@ struct totemudpu_instance {
 
 	void *context;
 
-	void (*totemudpu_deliver_fn) (
+	int (*totemudpu_deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from);
 
-	void (*totemudpu_iface_change_fn) (
+	int (*totemudpu_iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int ring_no);
@@ -957,13 +957,13 @@ int totemudpu_initialize (
 	totemsrp_stats_t *stats,
 	void *context,
 
-	void (*deliver_fn) (
+	int (*deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from),
 
-	void (*iface_change_fn) (
+        int (*iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int ring_no),

--- a/exec/totemudpu.h
+++ b/exec/totemudpu.h
@@ -51,13 +51,13 @@ extern int totemudpu_initialize (
 	totemsrp_stats_t *stats,
 	void *context,
 
-	void (*deliver_fn) (
+	int (*deliver_fn) (
 		void *context,
 		const void *msg,
 		unsigned int msg_len,
 		const struct sockaddr_storage *system_from),
 
-	void (*iface_change_fn) (
+	int (*iface_change_fn) (
 		void *context,
 		const struct totem_ip_address *iface_address,
 		unsigned int ring_no),


### PR DESCRIPTION
This required adding a lot of return values to two previously 'void' functions. I did two rather than just the one that was needed because it seemed to make sense to do them both together.

Although these functions now return errors, they are probably still ignored higher up. this really needs a comprehensive audit.