### PR TITLE
configure: Fix building of rust for release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,7 +46,7 @@ AC_ARG_ENABLE([rust-bindings],
 	[AS_HELP_STRING([--enable-rust-bindings],[rust bindings support])],,
 	[ enable_rust_bindings="no" ])
 AM_CONDITIONAL([BUILD_RUST_BINDINGS], [test x$enable_rust_bindings = xyes])
-corosyncrustver="`echo ${VERSION} | sed 's/\(.*\)\./\1-/'`"
+corosyncrustver=["`echo ${VERSION} | sed 's/\.\([^-\.]*-\)/-\1/'`"]
 AC_SUBST([corosyncrustver])
 
 dnl Fix default variables - "prefix" variable if not specified


### PR DESCRIPTION
Set rustver correctly for both release version string (for example 3.1.7) and git one (3.1.7.1-982f).

corosyncrustver must be escaped by '[]' because sed is using these two characters and m4 would remove them.