### PR TITLE
New improved rust api

### DIFF
--- a/bindings/rust/tests/src/bin/cmap-test.rs
+++ b/bindings/rust/tests/src/bin/cmap-test.rs
@@ -31,47 +31,47 @@ fn main() {
     };
 
     // Test some SETs
-    if let Err(e) = cmap::set_u32(handle, "test.test_uint32", 456) {
+    if let Err(e) = cmap::set_u32(&handle, "test.test_uint32", 456) {
         println!("Error in CMAP set_u32: {e}");
         return;
     };
 
-    if let Err(e) = cmap::set_i16(handle, "test.test_int16", -789) {
+    if let Err(e) = cmap::set_i16(&handle, "test.test_int16", -789) {
         println!("Error in CMAP set_i16: {e}");
         return;
     };
 
-    if let Err(e) = cmap::set_number(handle, "test.test_num_1", 6809u32) {
+    if let Err(e) = cmap::set_number(&handle, "test.test_num_1", 6809u32) {
         println!("Error in CMAP set_number(u32): {e}");
         return;
     };
 
     // NOT PI (just to avoid clippy whingeing)
-    if let Err(e) = cmap::set_number(handle, "test.test_num_2", 3.24159265) {
+    if let Err(e) = cmap::set_number(&handle, "test.test_num_2", 3.24159265) {
         println!("Error in CMAP set_number(f32): {e}");
         return;
     };
 
-    if let Err(e) = cmap::set_string(handle, "test.test_string", "Hello from Rust") {
+    if let Err(e) = cmap::set_string(&handle, "test.test_string", "Hello from Rust") {
         println!("Error in CMAP set_string: {e}");
         return;
     };
 
     let test_d = cmap::Data::UInt64(0xdeadbeefbacecafe);
-    if let Err(e) = cmap::set(handle, "test.test_data", &test_d) {
+    if let Err(e) = cmap::set(&handle, "test.test_data", &test_d) {
         println!("Error in CMAP set_data: {e}");
         return;
     };
 
     //    let test_d2 = cmap::Data::UInt32(6809);
     let test_d2 = cmap::Data::String("Test string in data 12345".to_string());
-    if let Err(e) = cmap::set(handle, "test.test_again", &test_d2) {
+    if let Err(e) = cmap::set(&handle, "test.test_again", &test_d2) {
         println!("Error in CMAP set_data2: {e}");
         return;
     };
 
     // get them back again
-    match cmap::get(handle, "test.test_uint32") {
+    match cmap::get(&handle, "test.test_uint32") {
         Ok(v) => {
             println!("GOT uint32 {v}");
         }
@@ -81,7 +81,7 @@ fn main() {
             return;
         }
     };
-    match cmap::get(handle, "test.test_int16") {
+    match cmap::get(&handle, "test.test_int16") {
         Ok(v) => {
             println!("GOT uint16 {v}");
         }
@@ -92,7 +92,7 @@ fn main() {
         }
     };
 
-    match cmap::get(handle, "test.test_num_1") {
+    match cmap::get(&handle, "test.test_num_1") {
         Ok(v) => {
             println!("GOT num {v}");
         }
@@ -102,7 +102,7 @@ fn main() {
             return;
         }
     };
-    match cmap::get(handle, "test.test_num_2") {
+    match cmap::get(&handle, "test.test_num_2") {
         Ok(v) => {
             println!("GOT num {v}");
         }
@@ -112,7 +112,7 @@ fn main() {
             return;
         }
     };
-    match cmap::get(handle, "test.test_string") {
+    match cmap::get(&handle, "test.test_string") {
         Ok(v) => {
             println!("GOT string {v}");
         }
@@ -123,7 +123,7 @@ fn main() {
         }
     };
 
-    match cmap::get(handle, "test.test_data") {
+    match cmap::get(&handle, "test.test_data") {
         Ok(v) => match v {
             cmap::Data::UInt64(u) => println!("GOT data value {u:x}"),
             _ => println!("ERROR type was not UInt64, got {v}"),
@@ -136,7 +136,7 @@ fn main() {
     };
 
     // Test an iterator
-    match cmap::CmapIterStart::new(handle, "totem.") {
+    match cmap::CmapIterStart::new(&handle, "totem.") {
         Ok(cmap_iter) => {
             for i in cmap_iter {
                 println!("ITER: {i:?}");
@@ -149,7 +149,7 @@ fn main() {
     }
 
     // Close this handle
-    if let Err(e) = cmap::finalize(handle) {
+    if let Err(e) = cmap::finalize(&handle) {
         println!("Error in CMAP get: {e}");
         return;
     };
@@ -167,7 +167,7 @@ fn main() {
         notify_fn: Some(track_notify_fn),
     };
     let _track_handle = match cmap::track_add(
-        handle,
+        &handle,
         "stats.srp.memb_merge_detect_tx",
         cmap::TrackType::MODIFY | cmap::TrackType::ADD | cmap::TrackType::DELETE,
         &cb,
@@ -183,7 +183,7 @@ fn main() {
     // Wait for events
     let mut event_num = 0;
     loop {
-        if let Err(e) = cmap::dispatch(handle, corosync::DispatchFlags::One) {
+        if let Err(e) = cmap::dispatch(&handle, corosync::DispatchFlags::One) {
             println!("Error from CMAP dispatch: {e}");
         }
         // Just do 5

--- a/bindings/rust/tests/src/bin/cmap-test.rs
+++ b/bindings/rust/tests/src/bin/cmap-test.rs
@@ -18,7 +18,7 @@ fn track_notify_fn(
     println!("   New value: {new_value}");
 }
 
-fn main() {
+fn main() -> Result<(), corosync::CsError> {
     let handle = match cmap::initialize(cmap::Map::Icmap) {
         Ok(h) => {
             println!("cmap initialized.");
@@ -26,48 +26,48 @@ fn main() {
         }
         Err(e) => {
             println!("Error in CMAP (Icmap) init: {e}");
-            return;
+            return Err(e);
         }
     };
 
     // Test some SETs
     if let Err(e) = cmap::set_u32(&handle, "test.test_uint32", 456) {
         println!("Error in CMAP set_u32: {e}");
-        return;
+        return Err(e);
     };
 
     if let Err(e) = cmap::set_i16(&handle, "test.test_int16", -789) {
         println!("Error in CMAP set_i16: {e}");
-        return;
+        return Err(e);
     };
 
     if let Err(e) = cmap::set_number(&handle, "test.test_num_1", 6809u32) {
         println!("Error in CMAP set_number(u32): {e}");
-        return;
+        return Err(e);
     };
 
     // NOT PI (just to avoid clippy whingeing)
     if let Err(e) = cmap::set_number(&handle, "test.test_num_2", 3.24159265) {
         println!("Error in CMAP set_number(f32): {e}");
-        return;
+        return Err(e);
     };
 
     if let Err(e) = cmap::set_string(&handle, "test.test_string", "Hello from Rust") {
         println!("Error in CMAP set_string: {e}");
-        return;
+        return Err(e);
     };
 
     let test_d = cmap::Data::UInt64(0xdeadbeefbacecafe);
     if let Err(e) = cmap::set(&handle, "test.test_data", &test_d) {
         println!("Error in CMAP set_data: {e}");
-        return;
+        return Err(e);
     };
 
     //    let test_d2 = cmap::Data::UInt32(6809);
     let test_d2 = cmap::Data::String("Test string in data 12345".to_string());
     if let Err(e) = cmap::set(&handle, "test.test_again", &test_d2) {
         println!("Error in CMAP set_data2: {e}");
-        return;
+        return Err(e);
     };
 
     // get them back again
@@ -78,7 +78,7 @@ fn main() {
 
         Err(e) => {
             println!("Error in CMAP get: {e}");
-            return;
+            return Err(e);
         }
     };
     match cmap::get(&handle, "test.test_int16") {
@@ -88,7 +88,7 @@ fn main() {
 
         Err(e) => {
             println!("Error in CMAP get: {e}");
-            return;
+            return Err(e);
         }
     };
 
@@ -99,7 +99,7 @@ fn main() {
 
         Err(e) => {
             println!("Error in CMAP get: {e}");
-            return;
+            return Err(e);
         }
     };
     match cmap::get(&handle, "test.test_num_2") {
@@ -109,7 +109,7 @@ fn main() {
 
         Err(e) => {
             println!("Error in CMAP get: {e}");
-            return;
+            return Err(e);
         }
     };
     match cmap::get(&handle, "test.test_string") {
@@ -119,7 +119,7 @@ fn main() {
 
         Err(e) => {
             println!("Error in CMAP get: {e}");
-            return;
+            return Err(e);
         }
     };
 
@@ -131,7 +131,7 @@ fn main() {
 
         Err(e) => {
             println!("Error in CMAP get: {e}");
-            return;
+            return Err(e);
         }
     };
 
@@ -151,7 +151,7 @@ fn main() {
     // Close this handle
     if let Err(e) = cmap::finalize(&handle) {
         println!("Error in CMAP get: {e}");
-        return;
+        return Err(e);
     };
 
     // Test notifications on the stats map
@@ -159,7 +159,7 @@ fn main() {
         Ok(h) => h,
         Err(e) => {
             println!("Error in CMAP (Stats) init: {e}");
-            return;
+            return Err(e);
         }
     };
 
@@ -176,11 +176,11 @@ fn main() {
         Ok(th) => th,
         Err(e) => {
             println!("Error in CMAP track_add {e}");
-            return;
+            return Err(e);
         }
     };
 
-    // Wait for events
+    // Wait for some events
     let mut event_num = 0;
     loop {
         if let Err(e) = cmap::dispatch(&handle, corosync::DispatchFlags::One) {
@@ -192,4 +192,5 @@ fn main() {
             break;
         }
     }
+    Ok(())
 }

--- a/bindings/rust/tests/src/bin/cpg-test.rs
+++ b/bindings/rust/tests/src/bin/cpg-test.rs
@@ -66,12 +66,12 @@ fn main() {
         }
     };
 
-    if let Err(e) = cpg::join(handle, "TEST") {
+    if let Err(e) = cpg::join(&handle, "TEST") {
         println!("Error in CPG join: {e}");
         return;
     }
 
-    match cpg::local_get(handle) {
+    match cpg::local_get(&handle) {
         Ok(n) => {
             println!("Local nodeid is {n}");
         }
@@ -81,7 +81,7 @@ fn main() {
     }
 
     // Test membership_get()
-    match cpg::membership_get(handle, "TEST") {
+    match cpg::membership_get(&handle, "TEST") {
         Ok(m) => {
             println!("  members: {m:?}");
             println!();
@@ -93,13 +93,13 @@ fn main() {
 
     // Test context APIs
     let set_context: u64 = 0xabcdbeefcafe;
-    if let Err(e) = cpg::context_set(handle, set_context) {
+    if let Err(e) = cpg::context_set(&handle, set_context) {
         println!("Error in CPG context_set: {e}");
         return;
     }
 
     // NOTE This will fail on 32 bit systems because void* is not u64
-    match cpg::context_get(handle) {
+    match cpg::context_get(&handle) {
         Ok(c) => {
             if c != set_context {
                 println!("Error: context_get() returned {c:x}, context should be {set_context:x}");
@@ -111,7 +111,7 @@ fn main() {
     }
 
     // Test iterator
-    match cpg::CpgIterStart::new(handle, "", cpg::CpgIterType::All) {
+    match cpg::CpgIterStart::new(&handle, "", cpg::CpgIterType::All) {
         Ok(cpg_iter) => {
             for i in cpg_iter {
                 println!("ITER: {i:?}");
@@ -125,7 +125,7 @@ fn main() {
 
     // We should receive our own message (at least) in the event loop
     if let Err(e) = cpg::mcast_joined(
-        handle,
+        &handle,
         cpg::Guarantee::TypeAgreed,
         &"This is a test".to_string().into_bytes(),
     ) {
@@ -134,7 +134,7 @@ fn main() {
 
     // Wait for events
     loop {
-        if cpg::dispatch(handle, corosync::DispatchFlags::One).is_err() {
+        if cpg::dispatch(&handle, corosync::DispatchFlags::One).is_err() {
             break;
         }
     }

--- a/bindings/rust/tests/src/bin/quorum-test.rs
+++ b/bindings/rust/tests/src/bin/quorum-test.rs
@@ -51,13 +51,13 @@ fn main() {
 
     // Test context APIs
     let set_context: u64 = 0xabcdbeefcafe;
-    if let Err(e) = quorum::context_set(handle, set_context) {
+    if let Err(e) = quorum::context_set(&handle, set_context) {
         println!("Error in QUORUM context_set: {e}");
         return;
     }
 
     // NOTE This will fail on 32 bit systems because void* is not u64
-    match quorum::context_get(handle) {
+    match quorum::context_get(&handle) {
         Ok(c) => {
             if c != set_context {
                 println!("Error: context_get() returned {c:x}, context should be {set_context:x}");
@@ -68,14 +68,14 @@ fn main() {
         }
     }
 
-    if let Err(e) = quorum::trackstart(handle, corosync::TrackFlags::Changes) {
+    if let Err(e) = quorum::trackstart(&handle, corosync::TrackFlags::Changes) {
         println!("Error in QUORUM trackstart: {e}");
         return;
     }
 
     // Wait for events
     loop {
-        if quorum::dispatch(handle, corosync::DispatchFlags::One).is_err() {
+        if quorum::dispatch(&handle, corosync::DispatchFlags::One).is_err() {
             break;
         }
     }

--- a/bindings/rust/tests/src/bin/votequorum-test.rs
+++ b/bindings/rust/tests/src/bin/votequorum-test.rs
@@ -30,7 +30,7 @@ fn expectedvotes_fn(_handle: &votequorum::Handle, _context: u64, expected_votes:
     println!("TEST expected_votes_fn called: value is {expected_votes}");
 }
 
-fn main() {
+fn main() -> Result<(), corosync::CsError> {
     // Initialise the model data
     let cb = votequorum::Callbacks {
         quorum_notification_fn: Some(quorum_fn),
@@ -45,7 +45,7 @@ fn main() {
         }
         Err(e) => {
             println!("Error in VOTEQUORUM init: {e}");
-            return;
+            return Err(e);
         }
     };
 
@@ -53,6 +53,7 @@ fn main() {
     let set_context: u64 = 0xabcdbeefcafe;
     if let Err(e) = votequorum::context_set(&handle, set_context) {
         println!("Error in VOTEQUORUM context_set: {e}");
+        return Err(e);
     }
 
     // NOTE This will fail on 32 bit systems because void* is not u64
@@ -64,6 +65,7 @@ fn main() {
         }
         Err(e) => {
             println!("Error in VOTEQUORUM context_get: {e}");
+            return Err(e);
         }
     }
 
@@ -71,6 +73,7 @@ fn main() {
 
     if let Err(e) = votequorum::qdevice_register(&handle, QDEVICE_NAME) {
         println!("Error in VOTEQUORUM qdevice_register: {e}");
+        return Err(e);
     }
 
     match votequorum::get_info(&handle, corosync::NodeId::from(1u32)) {
@@ -91,27 +94,29 @@ fn main() {
                     "qdevice names do not match: s/b: \"{}\"  is: \"{}\"",
                     QDEVICE_NAME, i.qdevice_name
                 );
+                return Err(corosync::CsError::CsErrRustCompat);
             }
         }
         Err(e) => {
             println!("Error in VOTEQUORUM get_info: {e} (check nodeid 1 has been online)");
+            return Err(e);
         }
     }
 
     if let Err(e) = votequorum::qdevice_unregister(&handle, QDEVICE_NAME) {
         println!("Error in VOTEQUORUM qdevice_unregister: {e}");
+        return Err(e);
     }
 
     if let Err(e) = votequorum::trackstart(&handle, 99_u64, corosync::TrackFlags::Changes) {
         println!("Error in VOTEQUORUM trackstart: {e}");
-        return;
+        return Err(e);
     }
 
-    // Wait for events
-    loop {
-        if votequorum::dispatch(&handle, corosync::DispatchFlags::One).is_err() {
-            break;
-        }
+    // Quick test of dispatch
+    if let Err(e) = votequorum::dispatch(&handle, corosync::DispatchFlags::OneNonblocking) {
+        println!("Error in VOTEUORUM dispatch: {e}");
+        return Err(e);
     }
-    println!("ERROR: Corosync quit");
+    Ok(())
 }

--- a/bindings/rust/tests/src/bin/votequorum-test.rs
+++ b/bindings/rust/tests/src/bin/votequorum-test.rs
@@ -51,12 +51,12 @@ fn main() {
 
     // Test context APIs
     let set_context: u64 = 0xabcdbeefcafe;
-    if let Err(e) = votequorum::context_set(handle, set_context) {
+    if let Err(e) = votequorum::context_set(&handle, set_context) {
         println!("Error in VOTEQUORUM context_set: {e}");
     }
 
     // NOTE This will fail on 32 bit systems because void* is not u64
-    match votequorum::context_get(handle) {
+    match votequorum::context_get(&handle) {
         Ok(c) => {
             if c != set_context {
                 println!("Error: context_get() returned {c:x}, context should be {set_context:x}");
@@ -69,11 +69,11 @@ fn main() {
 
     const QDEVICE_NAME: &str = "RustQdevice";
 
-    if let Err(e) = votequorum::qdevice_register(handle, QDEVICE_NAME) {
+    if let Err(e) = votequorum::qdevice_register(&handle, QDEVICE_NAME) {
         println!("Error in VOTEQUORUM qdevice_register: {e}");
     }
 
-    match votequorum::get_info(handle, corosync::NodeId::from(1u32)) {
+    match votequorum::get_info(&handle, corosync::NodeId::from(1u32)) {
         Ok(i) => {
             println!("Node info for nodeid 1");
             println!("  nodeid: {}", i.node_id);
@@ -98,18 +98,18 @@ fn main() {
         }
     }
 
-    if let Err(e) = votequorum::qdevice_unregister(handle, QDEVICE_NAME) {
+    if let Err(e) = votequorum::qdevice_unregister(&handle, QDEVICE_NAME) {
         println!("Error in VOTEQUORUM qdevice_unregister: {e}");
     }
 
-    if let Err(e) = votequorum::trackstart(handle, 99_u64, corosync::TrackFlags::Changes) {
+    if let Err(e) = votequorum::trackstart(&handle, 99_u64, corosync::TrackFlags::Changes) {
         println!("Error in VOTEQUORUM trackstart: {e}");
         return;
     }
 
     // Wait for events
     loop {
-        if votequorum::dispatch(handle, corosync::DispatchFlags::One).is_err() {
+        if votequorum::dispatch(&handle, corosync::DispatchFlags::One).is_err() {
             break;
         }
     }


### PR DESCRIPTION
rust: Improve Rust bindings
    
The big change here is that all API calls now take a &Handle
rather than making a copy. This, apart from being more sensible
and efficient, allows us to implment Drop on the handle so that
it will call _free() when it goes out of scope.
    
There's some jiggery-pokery with a clone flag in there now
because of callbacks that can return a valid handle, and we
want those to be Drop'ed sensibly.

Also adjust the tests to return errors and not hang so they can maybe used for testing (they need corosync running though, of course)