### PR TITLE
Report crypto errors back to cfg reload

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -722,6 +722,9 @@ static void message_handler_req_exec_cfg_reload_config (
 
 	log_printf(LOGSYS_LEVEL_NOTICE, "Config reload requested by node " CS_PRI_NODE_ID, nodeid);
 
+	// Clear this out in case it all goes well
+	icmap_delete("config.reload_error_message");
+
 	icmap_set_uint8("config.totemconfig_reload_in_progress", 1);
 
 	/* Make sure there is no rubbish in this that might be checked, even on error */

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -2439,7 +2439,13 @@ int totemconfig_commit_new_params(
 	totempg_reconfigure();
 
 	free(new_interfaces);
-	return res; /* On a reload this is ignored */
+
+	/*
+	 * On a reload this return is ignored because it's too late to do anything about it,
+	 * but errors are reported back via cmap.
+	 */
+	return res;
+
 }
 
 static void add_totem_config_notification(struct totem_config *totem_config)


### PR DESCRIPTION
Because crypto changing happens in the 'commit' phase of the reload and we can't get sure that knet will allow the new parameters, the result gets ignored. This can happen in FIPS mode if a non-FIPS cipher
is requested.

This patch reports the errors back in a cmap key
so that the command-line can spot those errors
and report them back to the user.

It also invalidates the internal values for crypto so that subsequent attempts to change things have
predictable results. Otherwise further attempts can do nothing but not report any errors back.

I've also added some error reporting back for the
knet ping counters using this mechanism.

The alternative to all of this would be to check for FIPS in totemconfig.c and then exclude certain options, but this would be duplicating code that could easily get out of sync.

This system could also be a useful mechanism for reporting back other 'impossible' errors.