### PR TITLE
main: support lock pid file arg

### DIFF
--- a/exec/main.c
+++ b/exec/main.c
@@ -163,7 +163,7 @@ struct sched_param global_sched_param;
 
 static corosync_timer_handle_t corosync_stats_timer_handle;
 
-static const char *corosync_lock_file = LOCALSTATEDIR"/run/corosync.pid";
+static char corosync_lock_file[PATH_MAX + 1] = LOCALSTATEDIR"/run/corosync.pid";
 
 static char corosync_config_file[PATH_MAX + 1] = COROSYSCONFDIR "/corosync.conf";
 
@@ -1302,7 +1302,7 @@ int main (int argc, char **argv, char **envp)
 	background = 1;
 	testonly = 0;
 
-	while ((ch = getopt (argc, argv, "c:ftv")) != EOF) {
+	while ((ch = getopt (argc, argv, "c:l:ftv")) != EOF) {
 
 		switch (ch) {
 			case 'c':
@@ -1310,6 +1310,16 @@ int main (int argc, char **argv, char **envp)
 				if (res >= sizeof(corosync_config_file)) {
 					fprintf (stderr, "Config file path too long.\n");
 					syslog (LOGSYS_LEVEL_ERROR, "Config file path too long.");
+
+					logsys_system_fini();
+					return EXIT_FAILURE;
+				}
+				break;
+			case 'l':
+				res = snprintf(corosync_lock_file, sizeof(corosync_lock_file), "%s", optarg);
+				if (res >= sizeof(corosync_lock_file)) {
+					fprintf (stderr, "PID lock file path too long.\n");
+					syslog (LOGSYS_LEVEL_ERROR, "PID lock file path too long.");
 
 					logsys_system_fini();
 					return EXIT_FAILURE;
@@ -1331,6 +1341,7 @@ int main (int argc, char **argv, char **envp)
 				fprintf(stderr, \
 					"usage:\n"\
 					"        -c     : Corosync config file path.\n"\
+					"        -l     : Corosync pid lock file path.\n"\
 					"        -f     : Start application in foreground.\n"\
 					"        -t     : Test configuration and exit.\n"\
 					"        -v     : Display version, git revision and some useful information about Corosync and exit.\n");

--- a/man/corosync.8
+++ b/man/corosync.8
@@ -47,6 +47,11 @@ as a base directory for uidgid files.
 
 The default is /etc/corosync/corosync.conf.
 .TP
+.B -l
+This specifies the fully qualified path to the corosync pid lock file.
+
+The default is /var/run/corosync.pid.
+.TP
 .B -f
 Start application in foreground.
 .TP


### PR DESCRIPTION
This patch adds support to change the default corosync pid file lock path. This is useful to run corosync net namespace environment only and since the pid lock file cannot be clarified over the conf because the pid lock file exists before config parsing we allow the user to specify it over the command line.