### PR TITLE
Coverity fixes 2024 08 30

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -827,7 +827,6 @@ static void message_handler_req_exec_cfg_reload_config (
 	/* Copy into live system */
 	totempg_put_config(&new_config);
 	totemconfig_commit_new_params(&new_config, temp_map);
-	free(new_config.interfaces);
 
 reload_fini:
 	/* All done - let clients know */
@@ -836,6 +835,7 @@ reload_fini:
 	icmap_set_uint8("config.reload_in_progress", 0);
 
 	/* Finished with the temporary storage */
+	free(new_config.interfaces);
 	free(new_config.orig_interfaces);
 
 reload_fini_nofree:

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -951,6 +951,8 @@ static int main_config_parser_cb(const char *path,
 				kv_item->key = strdup(key);
 				kv_item->value = strdup(value);
 				if (kv_item->key == NULL || kv_item->value == NULL) {
+					free(kv_item->key);
+					free(kv_item->value);
 					free(kv_item);
 					*error_string = "Can't alloc memory";
 
@@ -988,6 +990,8 @@ static int main_config_parser_cb(const char *path,
 				kv_item->key = strdup(key);
 				kv_item->value = strdup(value);
 				if (kv_item->key == NULL || kv_item->value == NULL) {
+					free(kv_item->key);
+					free(kv_item->value);
 					free(kv_item);
 					*error_string = "Can't alloc memory";
 
@@ -1046,6 +1050,8 @@ static int main_config_parser_cb(const char *path,
 			kv_item->key = strdup(key);
 			kv_item->value = strdup(value);
 			if (kv_item->key == NULL || kv_item->value == NULL) {
+				free(kv_item->key);
+				free(kv_item->value);
 				free(kv_item);
 				*error_string = "Can't alloc memory";
 

--- a/exec/icmap.c
+++ b/exec/icmap.c
@@ -201,6 +201,10 @@ cs_error_t icmap_init_r(icmap_map_t *result)
 	}
 
 	err = qb_map_notify_add((*result)->qb_map, NULL, icmap_map_free_cb, QB_MAP_NOTIFY_FREE, NULL);
+	if (err != 0) {
+		qb_map_destroy((*result)->qb_map);
+		free(*result);
+	}
 
 	return (qb_to_cs_error(err));
 }

--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -986,6 +986,7 @@ cs_error_t cpg_zcb_alloc (
 		sizeof (struct qb_ipc_response_header));
 
 	if (error != CS_OK) {
+		munmap (buf, map_size);
 		goto error_exit;
 	}
 


### PR DESCRIPTION
This should fix most of coverity reported errors.

Please double check especially first patch, because I'm still not sure if it doesn't free some memory where it shouldn't (I've tested quite some reloads of configuration with various transports and haven't found problem, still that code is complex).

There are 4 failures left which I'm not going to fix. NO_EFFECT one is harmless and safer when we suddenly decide to change variable from unsigned to signed int. All UNUSED_VALUE are IMHO rather style of good defensive coding - much safer when we add code somewhere in the middle.