### PR TITLE
Fix time since token last received

### DIFF
--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -770,10 +770,9 @@ static int pause_flush (struct totemsrp_instance *instance)
 static int token_event_stats_collector (enum totem_callback_token_type type, const void *void_instance)
 {
 	struct totemsrp_instance *instance = (struct totemsrp_instance *)void_instance;
-	uint32_t time_now;
-	unsigned long long nano_secs = qb_util_nano_current_get ();
+	uint64_t time_now;
 
-	time_now = (nano_secs / QB_TIME_NS_IN_MSEC);
+	time_now = (qb_util_nano_current_get() / QB_TIME_NS_IN_MSEC);
 
 	if (type == TOTEM_CALLBACK_TOKEN_RECEIVED) {
 		/* incr latest token the index */

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -1750,7 +1750,7 @@ static void timer_function_orf_token_warning (void *data)
 		tv_diff = qb_util_nano_current_get () / QB_TIME_NS_IN_MSEC -
 			instance->stats.token[instance->stats.latest_token].rx;
 		log_printf (instance->totemsrp_log_level_notice,
-			"Token has not been received in %d ms ", (unsigned int) tv_diff);
+			"Token has not been received in %"PRIu64" ms", tv_diff);
 		reset_token_warning(instance);
         } else {
 		cancel_token_warning(instance);

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -3834,7 +3834,9 @@ static int check_token_hold_cancel_sanity(
  * Message Handlers
  */
 
-unsigned long long int tv_old;
+#ifdef GIVEINFO
+uint64_t tv_old;
+#endif
 /*
  * message handler called when TOKEN message type received
  */
@@ -3854,15 +3856,15 @@ static int message_handler_orf_token (
 	unsigned int last_aru;
 
 #ifdef GIVEINFO
-	unsigned long long tv_current;
-	unsigned long long tv_diff;
+	uint64_t tv_current;
+	uint64_t tv_diff;
 
 	tv_current = qb_util_nano_current_get ();
 	tv_diff = tv_current - tv_old;
 	tv_old = tv_current;
 
 	log_printf (instance->totemsrp_log_level_debug,
-	"Time since last token %0.4f ms", ((float)tv_diff) / 1000000.0);
+	    "Time since last token %0.4f ms", tv_diff / (float)QB_TIME_NS_IN_MSEC);
 #endif
 
 	if (check_orf_token_sanity(instance, msg, msg_len, endian_conversion_needed) == -1) {
@@ -4119,7 +4121,7 @@ printf ("token seq %d\n", token->seq);
 			tv_old = tv_current;
 			log_printf (instance->totemsrp_log_level_debug,
 				"I held %0.4f ms",
-				((float)tv_diff) / 1000000.0);
+				tv_diff / (float)QB_TIME_NS_IN_MSEC);
 #endif
 			if (instance->memb_state == MEMB_STATE_OPERATIONAL) {
 				messages_deliver_to_app (instance, 0,

--- a/include/corosync/totem/totemstats.h
+++ b/include/corosync/totem/totemstats.h
@@ -45,8 +45,8 @@ typedef struct {
 } totemnet_stats_t;
 
 typedef struct {
-	uint32_t rx;
-	uint32_t tx;
+	uint64_t rx;
+	uint64_t tx;
 	int backlog_calc;
 } totemsrp_token_stats_t;
 


### PR DESCRIPTION
Main patch is first one - 
stats: Store token rx and tx timestamps as 64-bit
    
Token rx and tx timestamps were computed and stored as 32-bit unsigned integer but substracted in other parts of code from 64-bit integer. Result was, that node with uptime larger than 49.71 days (2^32/(1000*60*60*24)) reported wrong numbers for stats.srp.time_since_token_last_received and in log message during long pause (function timer_function_orf_token_warning).
    
Solution is to store rx and tx data as 64-bit integer.
    
Fixes #761

Other two are not urgent, still it fixes problem I've hit when fixing main problem #761.

@chrissie-c Important is double check if change in totemsrp_token_stats_t doesn't break anything. I've checked code and these are never exposed directly but second look is welcomed.