### PR TITLE
totemsrp: Fix orf_token stats

### DIFF
--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -2933,6 +2933,7 @@ static int orf_token_rtr (
 
 static void token_retransmit (struct totemsrp_instance *instance)
 {
+	instance->stats.orf_token_tx++;
 	totemnet_token_send (instance->totemnet_context,
 		instance->orf_token_retransmit,
 		instance->orf_token_retransmit_size);
@@ -3017,6 +3018,7 @@ static int token_send (
 		return (0);
 	}
 
+	instance->stats.orf_token_tx++;
 	totemnet_token_send (instance->totemnet_context,
 		orf_token,
 		orf_token_size);
@@ -3071,7 +3073,6 @@ static int orf_token_send_initial (struct totemsrp_instance *instance)
 	orf_token.token_seq = SEQNO_START_TOKEN;
 	orf_token.retrans_flg = 1;
 	instance->my_set_retrans_flg = 1;
-	instance->stats.orf_token_tx++;
 
 	if (cs_queue_is_empty (&instance->retrans_message_queue) == 1) {
 		orf_token.retrans_flg = 0;


### PR DESCRIPTION
Previously, orf_token_tx was only incremented on initial send, this is obviously wrong and resulted in the TX count being significantly lower than any RX count. Now we increment it every time the ORF token is sent or resent.

As a quick test, on a single node system the RX and TX stats will now match.