### PR TITLE
rust: Update to latest standards

### DIFF
--- a/bindings/rust/Cargo.toml.in
+++ b/bindings/rust/Cargo.toml.in
@@ -13,4 +13,4 @@ keywords = ["cluster", "high-availability"]
 [dependencies]
 lazy_static = "1.4.0"
 num_enum = "0.5.4"
-bitflags = "1.3.2"
+bitflags = "2.6.0"

--- a/bindings/rust/src/cmap.rs
+++ b/bindings/rust/src/cmap.rs
@@ -716,7 +716,7 @@ extern "C" fn rust_notify_fn(
                 (cb)(
                     r_cmap_handle,
                     h,
-                    TrackType { bits: event },
+                    TrackType::from_bits(event).unwrap_or(TrackType::empty()),
                     &r_keyname,
                     &r_old,
                     &r_new,
@@ -757,7 +757,7 @@ pub fn track_add(
         ffi::cmap_track_add(
             handle.cmap_handle,
             c_name.as_ptr(),
-            track_type.bits,
+            track_type.bits(),
             Some(rust_notify_fn),
             user_data as *mut c_void,
             &mut c_trackhandle,

--- a/bindings/rust/src/votequorum.rs
+++ b/bindings/rust/src/votequorum.rs
@@ -302,7 +302,7 @@ pub fn get_info(handle: &Handle, nodeid: NodeId) -> Result<NodeInfo> {
             node_expected_votes: c_info.node_expected_votes,
             highest_expected: c_info.highest_expected,
             quorum: c_info.quorum,
-            flags: NodeInfoFlags { bits: c_info.flags },
+            flags: NodeInfoFlags::from_bits(c_info.flags).unwrap_or(NodeInfoFlags::empty()),
             qdevice_votes: c_info.qdevice_votes,
             qdevice_name: string_from_bytes(
                 c_info.qdevice_name.as_ptr(),


### PR DESCRIPTION
Updating to Rust 2021 is a no-op (but worth doing for future), I've also taken this opportunity to use the latest bitflags crate.