### PR TITLE
Cleanup dropped options

### DIFF
--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -628,9 +628,7 @@ static void remove_ro_entries(icmap_map_t temp_map)
 	delete_and_notify_if_changed(temp_map, "totem.version");
 	delete_and_notify_if_changed(temp_map, "totem.threads");
 	delete_and_notify_if_changed(temp_map, "totem.ip_version");
-	delete_and_notify_if_changed(temp_map, "totem.rrp_mode");
 	delete_and_notify_if_changed(temp_map, "totem.netmtu");
-	delete_and_notify_if_changed(temp_map, "totem.interface.ringnumber");
 	delete_and_notify_if_changed(temp_map, "totem.interface.bindnetaddr");
 	delete_and_notify_if_changed(temp_map, "totem.interface.mcastaddr");
 	delete_and_notify_if_changed(temp_map, "totem.interface.broadcast");

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -761,11 +761,6 @@ static int main_config_parser_cb(const char *path,
 			    (strcmp(path, "totem.downcheck") == 0) ||
 			    (strcmp(path, "totem.fail_recv_const") == 0) ||
 			    (strcmp(path, "totem.seqno_unchanged_const") == 0) ||
-			    (strcmp(path, "totem.rrp_token_expired_timeout") == 0) ||
-			    (strcmp(path, "totem.rrp_problem_count_timeout") == 0) ||
-			    (strcmp(path, "totem.rrp_problem_count_threshold") == 0) ||
-			    (strcmp(path, "totem.rrp_problem_count_mcast_threshold") == 0) ||
-			    (strcmp(path, "totem.rrp_autorecovery_check_timeout") == 0) ||
 			    (strcmp(path, "totem.heartbeat_failures_allowed") == 0) ||
 			    (strcmp(path, "totem.max_network_delay") == 0) ||
 			    (strcmp(path, "totem.window_size") == 0) ||

--- a/exec/main.c
+++ b/exec/main.c
@@ -1065,7 +1065,6 @@ static void set_icmap_ro_keys_flag (void)
 	icmap_set_ro_access("totem.key", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.secauth", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.ip_version", CS_FALSE, CS_TRUE);
-	icmap_set_ro_access("totem.rrp_mode", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.transport", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.cluster_name", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.netmtu", CS_FALSE, CS_TRUE);


### PR DESCRIPTION
Includes:
- totem.rrp_mode
- totem.interface.ringnumber
- totem.rrp_token_expired_timeout
- totem.rrp_problem_count_timeout
- totem.rrp_problem_count_threshold
- totem.rrp_problem_count_mcast_threshold
- totem.rrp_autorecovery_check_timeout