### PR TITLE
Coverity 2025.3 fixes without sam.c

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -1753,6 +1753,7 @@ static int read_uidgid_files_into_icmap(
 
 			goto error_exit;
 		}
+		// coverity[TOCTOU:SUPPRESS] not really problem
 		res = stat (filename, &stat_buf);
 		if (res == 0 && S_ISREG(stat_buf.st_mode)) {
 

--- a/exec/cpg.c
+++ b/exec/cpg.c
@@ -1770,7 +1770,7 @@ static inline int zcb_alloc (
 
 static inline int zcb_free (struct zcb_mapped *zcb_mapped)
 {
-	unsigned int res;
+	int res;
 
 	res = munmap (zcb_mapped->addr, zcb_mapped->size);
 	qb_list_del (&zcb_mapped->list);
@@ -1782,7 +1782,7 @@ static inline int zcb_by_addr_free (struct cpg_pd *cpd, void *addr)
 {
 	struct qb_list_head *list, *tmp_iter;
 	struct zcb_mapped *zcb_mapped;
-	unsigned int res = 0;
+	int res = 0;
 
 	qb_list_for_each_safe(list, tmp_iter, &(cpd->zcb_mapped_list_head)) {
 		zcb_mapped = qb_list_entry (list, struct zcb_mapped, list);

--- a/exec/logsys.c
+++ b/exec/logsys.c
@@ -122,7 +122,7 @@ static int logsys_blackbox_enabled = 1;
 
 static int _logsys_config_subsys_get_unlocked (const char *subsys)
 {
-	unsigned int i;
+	int i;
 
 	if (!subsys) {
 		return LOGSYS_MAX_SUBSYS_COUNT;
@@ -468,7 +468,7 @@ int _logsys_subsys_create (const char *subsys, const char *filename)
 
 int _logsys_config_subsys_get (const char *subsys)
 {
-	unsigned int i;
+	int i;
 
 	pthread_mutex_lock (&logsys_config_mutex);
 

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -405,6 +405,7 @@ int totem_volatile_config_validate (
 		goto parse_error;
 	}
 
+	// coverity[NO_EFFECT:SUPPRESS] clarify bounds of token_warning values and defensive programming
 	if (totem_config->token_warning > 100 || totem_config->token_warning < 0) {
 		snprintf (local_error_reason, sizeof(local_error_reason),
 			"The token warning parameter (%d%%) must be between 0 (disabled) and 100.",

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -1103,7 +1103,7 @@ int totempg_callback_token_create (
 	int (*callback_fn) (enum totem_callback_token_type type, const void *),
 	const void *data)
 {
-	unsigned int res;
+	int res;
 	if (totempg_threaded_mode == 1) {
 		pthread_mutex_lock (&callback_token_mutex);
 	}
@@ -1239,7 +1239,7 @@ int totempg_groups_mcast_joined (
 	unsigned short group_len[MAX_GROUPS_PER_MSG + 1];
 	struct iovec iovec_mcast[MAX_GROUPS_PER_MSG + 1 + MAX_IOVECS_FROM_APP];
 	int i;
-	unsigned int res;
+	int res;
 
 	if (totempg_threaded_mode == 1) {
 		pthread_mutex_lock (&totempg_mutex);
@@ -1368,7 +1368,7 @@ int totempg_groups_mcast_groups (
 	unsigned short group_len[MAX_GROUPS_PER_MSG + 1];
 	struct iovec iovec_mcast[MAX_GROUPS_PER_MSG + 1 + MAX_IOVECS_FROM_APP];
 	int i;
-	unsigned int res;
+	int res;
 
 	if (totempg_threaded_mode == 1) {
 		pthread_mutex_lock (&totempg_mutex);

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -942,6 +942,7 @@ static int mcast_msg (
 			fragment_size += copy_len;
 			mcast_packed_msg_lens[mcast_packed_msg_count] += copy_len;
 			next_fragment = 1;
+			// coverity[UNUSED_VALUE:SUPPRESS] defensive programming
 			copy_len = 0;
 			copy_base = 0;
 			i++;
@@ -1011,6 +1012,7 @@ static int mcast_msg (
 			 * If the iovec all fit, go to the next iovec
 			 */
 			if ((copy_base + copy_len) == iovec[i].iov_len) {
+				// coverity[UNUSED_VALUE:SUPPRESS] defensive programming
 				copy_len = 0;
 				copy_base = 0;
 				i++;

--- a/exec/totempg.c
+++ b/exec/totempg.c
@@ -857,6 +857,7 @@ void totempg_finalize (void)
 	if (totempg_threaded_mode == 1) {
 		pthread_mutex_lock (&totempg_mutex);
 	}
+	// coverity[SLEEP:SUPPRESS] sleep is not a problem because it is shutdown
 	totemsrp_finalize (totemsrp_context);
 	if (totempg_threaded_mode == 1) {
 		pthread_mutex_unlock (&totempg_mutex);

--- a/exec/totemsrp.c
+++ b/exec/totemsrp.c
@@ -3374,6 +3374,7 @@ static void memb_join_message_send (struct totemsrp_instance *instance)
 		sizeof (struct srp_addr);
 
 	if (instance->totem_config->send_join_timeout) {
+		// coverity[DC.WEAK_CRYPTO:SUPPRESS] random is not used in a security context
 		usleep (random() % (instance->totem_config->send_join_timeout * 1000));
 	}
 
@@ -3455,6 +3456,7 @@ static void memb_leave_message_send (struct totemsrp_instance *instance)
 
 
 	if (instance->totem_config->send_join_timeout) {
+		// coverity[DC.WEAK_CRYPTO:SUPPRESS] random is not used in a security context
 		usleep (random() % (instance->totem_config->send_join_timeout * 1000));
 	}
 	instance->stats.memb_join_tx++;

--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -527,12 +527,14 @@ cs_error_t cpg_dispatch (
 					assembly_data->assembly_buf_ptr += res_cpg_partial_deliver_callback->fraglen;
 
 					if (res_cpg_partial_deliver_callback->type == LIBCPG_PARTIAL_LAST) {
-						cpg_inst_copy.model_v1_data.cpg_deliver_fn (handle,
-							&group_name,
-							res_cpg_partial_deliver_callback->nodeid,
-							res_cpg_partial_deliver_callback->pid,
-							assembly_data->assembly_buf,
-							res_cpg_partial_deliver_callback->msglen);
+						if (cpg_inst_copy.model_v1_data.cpg_deliver_fn != NULL) {
+							cpg_inst_copy.model_v1_data.cpg_deliver_fn (handle,
+								&group_name,
+								res_cpg_partial_deliver_callback->nodeid,
+								res_cpg_partial_deliver_callback->pid,
+								assembly_data->assembly_buf,
+								res_cpg_partial_deliver_callback->msglen);
+						}
 
 						qb_list_del (&assembly_data->list);
 						free(assembly_data->assembly_buf);

--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -998,6 +998,15 @@ cs_error_t cpg_zcb_alloc (
 
 error_exit:
 	hdb_handle_put (&cpg_handle_t_db, handle);
+	/*
+	 * Coverity correctly reports an error here. We cannot safely munmap and unlink the file, because
+	 * the timing of the failure is the key issue: if a failure occurs before the IPC reply,
+	 * the file should be deleted.
+	 * However, if the failure happens during the IPC reply, Corosync has already deleted the file.
+	 * This means the cpg library could attempt to delete a non-existing file (not a problem) or,
+	 * in a theoretical race condition, delete a new file created by another application.
+	 * There are multiple possible solutions, but none of them are ready to be implemented yet.
+	 */
 	return (error);
 }
 

--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -499,6 +499,7 @@ cs_error_t cpg_dispatch (
 						qb_list_del (&assembly_data->list);
 						free(assembly_data->assembly_buf);
 						free(assembly_data);
+						// coverity[UNUSED_VALUE:SUPPRESS] defensive programming
 						assembly_data = NULL;
 					}
 

--- a/test/cpghum.c
+++ b/test/cpghum.c
@@ -355,6 +355,7 @@ static void set_packet(int write_size, int counter)
 
 	header->counter = counter;
 	for (i=0; i<(datalen/4); i++) {
+		// coverity[DC.WEAK_CRYPTO:SUPPRESS] rand is not used in a security context
 		dataint[i] = rand();
 	}
 	crc = crc32(0, NULL, 0);

--- a/test/cpgverify.c
+++ b/test/cpgverify.c
@@ -151,6 +151,7 @@ int main (int argc, char *argv[])
 	 */
 	i = 0;
 	do {
+		// coverity[DC.WEAK_CRYPTO:SUPPRESS] rand is not used in a security context
 		msg.msg_size = 100 + rand() % 100000;
 		iov[1].iov_len = msg.msg_size;
 		for (j = 0; j < msg.msg_size; j++) {

--- a/test/stress_cpgzc.c
+++ b/test/stress_cpgzc.c
@@ -107,6 +107,7 @@ int main (void)
 
 	for (j = 0; j < ITERATIONS; j++) {
 		for (i = 0; i < ALLOCATIONS; i++) {
+			// coverity[DC.WEAK_CRYPTO:SUPPRESS] random is not used in a security context
 			buffer_lens[i] = (random() % MAX_SIZE) + 1;
 			res = cpg_zcb_alloc (
 				handle,

--- a/tools/corosync-keygen.c
+++ b/tools/corosync-keygen.c
@@ -149,16 +149,23 @@ int main (int argc, char *argv[])
 	 */
 	bytes_read = 0;
 
-retry_read:
-	res = read (random_fd, &key[bytes_read], key_len - bytes_read);
-	if (res == -1) {
-		err (1, "Could not read /dev/random");
-	}
-	bytes_read += res;
-	if (bytes_read != key_len) {
-		printf ("Press keys on your keyboard to generate entropy (%d bits still needed).\n",
-		    (int)((key_len - bytes_read) * 8));
-		goto retry_read;
+	while (bytes_read < key_len) {
+		res = read (random_fd, &key[bytes_read], key_len - bytes_read);
+
+		if (res == -1) {
+			err (1, "Could not read %s", random_dev);
+		}
+
+		if (res == 0) {
+			errx (1, "Unexpected end of %s", random_dev);
+		}
+
+		bytes_read += res;
+
+		if (bytes_read != key_len) {
+			printf ("Press keys on your keyboard to generate entropy (%zu bits still needed).\n",
+			    (size_t)((key_len - bytes_read) * 8));
+		}
 	}
 	close (random_fd);
 


### PR DESCRIPTION
SUBJ

Some more information about patches:
- 1-3 - super simple, no risk
- 4 - I think again simple and mimics behavior of standard cpg_deliver so I see close to zero risk
- 5 - not only removes (false positive) coverity error, but makes code cleaner, close to zero risk
- 6-11 - just a comments and coverity specific comments, I hope reasoning for each suppress is good, but I'm open to discussion/improvements. zero risk.
- 12 this one is only one which is really risky. I've triple checked there should be no deadlock because of these added mutex lock, but another pair of eyes is welcomed

This removes all coverity errors but cpg.c one and all sam.c ones. sam.c is special case and I will send another PR just for that.

@chrissie-c if you don't like coverity specific comments just ignore them and I will rewrite them to standard comments (so it is not forgotten that issue was analyzed next time new coverity reports same problems again).