### PR TITLE
Coverity 2025.3 fixes - mostly sam.c

### DIFF
--- a/test/testsam.c
+++ b/test/testsam.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011 Red Hat, Inc.
+ * Copyright (c) 2009-2025 Red Hat, Inc.
  *
  * All rights reserved.
  *
@@ -38,9 +38,11 @@
 
 #include <config.h>
 
+#include <sys/types.h>
+#include <sys/resource.h>
+
 #include <limits.h>
 #include <pthread.h>
-#include <sys/types.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -238,12 +240,20 @@ static int test2 (void) {
 }
 
 /*
- * Smoke test. Better to turn off coredump ;) This has no time limit, just restart process
+ * Smoke test. This has no time limit, just restart process
  * when it dies.
  */
 static int test3 (void) {
 	cs_error_t error;
 	unsigned int instance_id;
+	struct rlimit lim;
+
+	lim.rlim_cur = lim.rlim_max = 0;
+
+	/*
+	 * Try to turn off core creation
+	 */
+	setrlimit(RLIMIT_CORE, &lim);
 
 	printf ("%s: initialize\n", __FUNCTION__);
 	error = sam_initialize (0, SAM_RECOVERY_POLICY_RESTART);
@@ -1238,6 +1248,8 @@ int main(int argc, char *argv[])
 	int stat;
 	int all_passed = 1;
 	int no_skipped = 0;
+
+	setlinebuf(stdout);
 
 	pid = fork ();
 

--- a/test/testsam.c
+++ b/test/testsam.c
@@ -764,6 +764,7 @@ static int test7 (void) {
 	unsigned int instance_id;
 	pthread_t kill_thread;
 	char *str;
+	uint32_t expected_votes;
 
 	err = cmap_initialize (&cmap_handle);
 	if (err != CS_OK) {
@@ -776,17 +777,27 @@ static int test7 (void) {
 		printf ("Could not get \"provider\" key: %d. Test skipped\n", err);
 		return (1);
 	}
-        if (strcmp(str, "testquorum") != 0) {
-		printf ("Provider is not testquorum. Test skipped\n");
+        if (strcmp(str, "corosync_votequorum") != 0) {
+		printf ("Provider is not corosync_votequorum. Test skipped\n");
 		free(str);
 		return (1);
         }
 	free(str);
 
+	if (cmap_get_uint32(cmap_handle, "quorum.expected_votes", &expected_votes) != CS_OK) {
+		printf ("Could not get \"expected_votes\" key: %d. Test skipped\n", err);
+		return (1);
+	}
+
+	if (expected_votes != 1) {
+		printf ("Expected_votes is not 1. Test skipped\n");
+		return (1);
+	}
+
 	/*
 	 * Set to not quorate
 	 */
-	err = cmap_set_uint8(cmap_handle, "quorum.quorate", 0);
+	err = cmap_set_uint32(cmap_handle, "quorum.expected_votes", 2);
 	if (err != CS_OK) {
 		printf ("Can't set map key. Error %d\n", err);
 		return (2);
@@ -827,7 +838,7 @@ static int test7 (void) {
 		/*
 		 * Set to quorate
 		 */
-		err = cmap_set_uint8(cmap_handle, "quorum.quorate", 1);
+		err = cmap_set_uint32(cmap_handle, "quorum.expected_votes", 1);
 		if (err != CS_OK) {
 			printf ("Can't set map key. Error %d\n", err);
 			return (2);
@@ -843,7 +854,7 @@ static int test7 (void) {
 		/*
 		 * Set corosync unquorate
 		 */
-		err = cmap_set_uint8(cmap_handle, "quorum.quorate", 0);
+		err = cmap_set_uint32(cmap_handle, "quorum.expected_votes", 2);
 		if (err != CS_OK) {
 			printf ("Can't set map key. Error %d\n", err);
 			return (2);

--- a/tools/corosync-cmapctl.c
+++ b/tools/corosync-cmapctl.c
@@ -802,9 +802,16 @@ static void read_in_config_file(cmap_handle_t handle, char * filename)
 static void clear_stats(cmap_handle_t handle, char *clear_opt)
 {
 	char key_name[CMAP_KEYNAME_MAXLEN + 1];
+	cs_error_t err;
 
 	sprintf(key_name, "stats.clear.%s", clear_opt);
-	cmap_set_uint32(handle, key_name, 1);
+
+	if ((err = cmap_set_uint32(handle, key_name, 1)) != CS_OK) {
+		fprintf(stderr, "Can't set cmap stats clear key %s. Error %s\n",
+		    key_name, cs_strerror(err));
+
+		exit (EXIT_FAILURE);
+	}
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This is second (hopefully last) batch of fixes of errors found by Coverity 2025.3.

It's all sam related with exception of last one which I guess is pretty easy to review and just good to go.

Sam is different story. Honestly, I'm not expecting too deep review, because it is almost unbelievable. Locking is reworked completely and same applies to testsam. I don't think there is any sam user, still we ship it so good to have it fixed.