### PR TITLE
allow to use dscp for traffic prioritization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,8 @@ AC_CHECK_LIB([knet],[knet_handle_crypto_set_config],
 	     [AC_DEFINE_UNQUOTED([HAVE_KNET_CRYPTO_RECONF], 1, [have knet crypto reconfig support])])
 AC_CHECK_LIB([knet],[knet_handle_get_onwire_ver],
 	     [AC_DEFINE_UNQUOTED([HAVE_KNET_ONWIRE_VER], 1, [have knet onwire versioning])])
+AC_CHECK_LIB([knet],[knet_handle_setprio_dscp],
+	     [AC_DEFINE_UNQUOTED([HAVE_KNET_SETPRIO_DSCP], 1, [have knet dscp traffic prioritization])])
 LIBS="$OLDLIBS"
 
 # Checks for library functions.

--- a/exec/cfg.c
+++ b/exec/cfg.c
@@ -632,6 +632,7 @@ static void remove_ro_entries(icmap_map_t temp_map)
 	delete_and_notify_if_changed(temp_map, "totem.version");
 	delete_and_notify_if_changed(temp_map, "totem.threads");
 	delete_and_notify_if_changed(temp_map, "totem.ip_version");
+	delete_and_notify_if_changed(temp_map, "totem.ip_dscp");
 	delete_and_notify_if_changed(temp_map, "totem.netmtu");
 	delete_and_notify_if_changed(temp_map, "totem.interface.bindnetaddr");
 	delete_and_notify_if_changed(temp_map, "totem.interface.mcastaddr");

--- a/exec/main.c
+++ b/exec/main.c
@@ -1065,6 +1065,7 @@ static void set_icmap_ro_keys_flag (void)
 	icmap_set_ro_access("totem.key", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.secauth", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.ip_version", CS_FALSE, CS_TRUE);
+	icmap_set_ro_access("totem.ip_dscp", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.transport", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.cluster_name", CS_FALSE, CS_TRUE);
 	icmap_set_ro_access("totem.netmtu", CS_FALSE, CS_TRUE);

--- a/exec/totemconfig.c
+++ b/exec/totemconfig.c
@@ -1912,6 +1912,8 @@ extern int totem_config_read (
 			       "255.255.255.255", TOTEM_IP_VERSION_4);
 	}
 
+	totem_config->ip_dscp = 0;
+	(void)icmap_get_uint8("totem.ip_dscp", &totem_config->ip_dscp);
 
 	/*
 	 * Store automatically generated items back to icmap only for UDP

--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -1299,6 +1299,12 @@ int totemknet_initialize (
 	if (res) {
 		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_WARNING, "knet_handle_pmtud_set failed");
 	}
+#ifdef HAVE_KNET_SETPRIO_DSCP
+	res = knet_handle_setprio_dscp(instance->knet_handle, instance->totem_config->ip_dscp);
+	if (res) {
+		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_WARNING, "knet_handle_setprio_dscp failed");
+	}
+#endif
 	res = knet_handle_enable_filter(instance->knet_handle, instance, dst_host_filter_callback_fn);
 	if (res) {
 		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_WARNING, "knet_handle_enable_filter failed");

--- a/exec/totemudp.c
+++ b/exec/totemudp.c
@@ -783,6 +783,14 @@ static int totemudp_build_sockets_ip (
 		return (-1);
 	}
 
+	res = set_socket_dscp(sockets->mcast_send,
+		instance->totem_config->ip_dscp);
+	if (res == -1) {
+		LOGSYS_PERROR (errno, instance->totemudp_log_level_warning,
+			"Could not set IP_TOS bits");
+		return (-1);
+	}
+
 	totemip_totemip_to_sockaddr_convert(bound_to, instance->totem_interface->ip_port - 1,
 		&sockaddr, &addrlen);
 
@@ -832,6 +840,13 @@ static int totemudp_build_sockets_ip (
 	 if ( setsockopt(sockets->token, SOL_SOCKET, SO_REUSEADDR, (char *)&flag, sizeof (flag)) < 0) {
 		LOGSYS_PERROR (errno, instance->totemudp_log_level_warning,
 			"setsockopt(SO_REUSEADDR) failed");
+		return (-1);
+	}
+
+	res = set_socket_dscp(sockets->token, instance->totem_config->ip_dscp);
+	if (res == -1) {
+		LOGSYS_PERROR (errno, instance->totemudp_log_level_warning,
+			"Could not set IP_TOS bits");
 		return (-1);
 	}
 

--- a/exec/totemudpu.c
+++ b/exec/totemudpu.c
@@ -791,6 +791,13 @@ static int totemudpu_build_sockets_ip (
 			"Could not set recvbuf size");
 	}
 
+	res = set_socket_dscp(instance->token_socket,
+		instance->totem_config->ip_dscp);
+	if (res == -1) {
+		LOGSYS_PERROR (errno, instance->totemudpu_log_level_notice,
+			"Could not set IP_TOS bits");
+	}
+
 	return 0;
 }
 
@@ -1278,6 +1285,12 @@ static int totemudpu_create_sending_socket(
 		/*
 		 * Fail in setting sendbuf size is not fatal -> don't exit
 		 */
+	}
+
+	res = set_socket_dscp(fd, instance->totem_config->ip_dscp);
+	if (res == -1) {
+		LOGSYS_PERROR (errno, instance->totemudpu_log_level_notice,
+			"Could not set IP_TOS bits");
 	}
 
 	/*

--- a/exec/util.c
+++ b/exec/util.c
@@ -42,6 +42,7 @@
 #include <errno.h>
 #include <sys/time.h>
 #include <assert.h>
+#include <sys/socket.h>
 
 #include <libknet.h>
 
@@ -351,4 +352,19 @@ int util_is_valid_knet_compress_model(const char *val,
 	}
 
 	return (model_found);
+}
+
+int
+set_socket_dscp(int socket, unsigned char dscp)
+{
+	int res = 0;
+	int tos;
+
+	if (dscp) {
+		/* dscp is the upper 6 bits of TOS IP header field, RFC 2474 */
+		tos = (dscp & 0x3f) << 2;
+		res = setsockopt(socket, IPPROTO_IP, IP_TOS, &tos, sizeof(tos));
+	}
+
+	return res;
 }

--- a/exec/util.h
+++ b/exec/util.h
@@ -95,4 +95,6 @@ extern int util_is_valid_knet_compress_model(const char *val,
 	const char **list_str, int machine_parseable_str,
 	const char *error_string_prefix, const char **error_string);
 
+int set_socket_dscp(int socket, unsigned char dscp);
+
 #endif /* UTIL_H_DEFINED */

--- a/include/corosync/totem/totem.h
+++ b/include/corosync/totem/totem.h
@@ -247,6 +247,8 @@ struct totem_config {
 
 	unsigned int cancel_token_hold_on_retransmit;
 
+	unsigned char ip_dscp;
+
 	void (*totem_memb_ring_id_create_or_load) (
 	    struct memb_ring_id *memb_ring_id,
 	    unsigned int nodeid);

--- a/man/corosync.conf.5
+++ b/man/corosync.conf.5
@@ -372,6 +372,20 @@ for UDP transport.
 The KNET transport supports IPv4 and IPv6 addresses concurrently,
 provided they are consistent on each link.
 
+.TP
+ip_dscp
+This specifies the dscp (differentiated services code point) value to be
+used in the IP header's type of service (TOS) field according to RFC 2474.
+Allowed values are 0-63 and symbolic dscp names cs0, cs1, cs2, cs3, cs4, cs5,
+cs6, cs7, af11, af12, af13, af21, af22, af23, af31, af32, af33, af41, af42,
+af43 and ef.
+Value 0 disables the dscp support. Use of TOS field then depends on the
+used transport.
+If ip_dscp is set to a value not equal to zero, and an appropriate
+socket option (IP_TOS) is available, the value is put into the upper
+six bits of the TOS header field.
+
+.PP
 Within the
 .B totem
 directive, there are several configuration options which are used to control


### PR DESCRIPTION
This is the corosync part corresponding to commit 00f1635 in kronosnet. It makes dscp available in config file.