### PR TITLE
votequorum: make site aware

### DIFF
--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -744,7 +744,8 @@ static int main_config_parser_cb(const char *path,
 			    (strcmp(path, "quorum.allow_downscale") == 0) ||
 			    (strcmp(path, "quorum.wait_for_all") == 0) ||
 			    (strcmp(path, "quorum.auto_tie_breaker") == 0) ||
-			    (strcmp(path, "quorum.last_man_standing") == 0)) {
+			    (strcmp(path, "quorum.last_man_standing") == 0) ||
+			    (strcmp(path, "quorum.site_aware") == 0)) {
 				val_type = ICMAP_VALUETYPE_UINT8;
 				if (safe_atoq(value, &val, val_type) != 0) {
 					goto safe_atoq_error;
@@ -1179,7 +1180,8 @@ static int main_config_parser_cb(const char *path,
 			snprintf(key_name, ICMAP_KEYNAME_MAXLEN, "nodelist.node.%u.%s", data->node_number,
 			    path + strlen(path_prefix));
 			if ((strcmp(path, "nodelist.node.nodeid") == 0) ||
-			    (strcmp(path, "nodelist.node.quorum_votes") == 0)) {
+			    (strcmp(path, "nodelist.node.quorum_votes") == 0) ||
+			    (strcmp(path, "nodelist.node.site") == 0)) {
 				val_type = ICMAP_VALUETYPE_UINT32;
 				if (safe_atoq(value, &val, val_type) != 0) {
 					goto safe_atoq_error;


### PR DESCRIPTION
This is not foreseen to be pulled as is.

This is just a simple implementation that tries to make corosync aware of a cluster that is split over multiple sites.
Adopting the basic idea of two-node quorate state can be maintained in a partial cluster as long as it comprises a whole site although the number of actual cluster-nodes isn't > 1/2 of the overall number of cluster-nodes anymore.
For regaining quorate state nothing has changed.

configuration-wise the node-section in the nodelist gets an additional site entry:

<pre>
nodelist{

        node {
                ring0_addr: node2
                name: node2
                nodeid: 1
                site: 0
        }
...
}
</pre>

while the new behavior is switched on similarly as two-node:

<pre>
quorum {
        provider: corosync_votequorum
        site_aware: 1
}
</pre>

corosync-quorumtool is enabled to show site affiliation:

<pre>
Membership information
----------------------
    Nodeid      Votes Name                Site
         1          1 node2 (local)                                     0
         2          1 node3                                             0
         3          1 node4                                             1
</pre>

