### PR TITLE
rust: fix fd_get() functions to dereference pointer correctly

### DIFF
--- a/bindings/rust/src/cfg.rs
+++ b/bindings/rust/src/cfg.rs
@@ -166,7 +166,7 @@ pub fn fd_get(handle: &Handle) -> Result<i32> {
     let c_fd: *mut c_int = &mut 0 as *mut _ as *mut c_int;
     let res = unsafe { ffi::corosync_cfg_fd_get(handle.cfg_handle, c_fd) };
     if res == ffi::CS_OK {
-        Ok(c_fd as i32)
+        Ok(unsafe { *c_fd })
     } else {
         Err(CsError::from_c(res))
     }

--- a/bindings/rust/src/cmap.rs
+++ b/bindings/rust/src/cmap.rs
@@ -149,7 +149,7 @@ pub fn fd_get(handle: &Handle) -> Result<i32> {
     let c_fd: *mut c_int = &mut 0 as *mut _ as *mut c_int;
     let res = unsafe { ffi::cmap_fd_get(handle.cmap_handle, c_fd) };
     if res == ffi::CS_OK {
-        Ok(c_fd as i32)
+        Ok(unsafe { *c_fd })
     } else {
         Err(CsError::from_c(res))
     }

--- a/bindings/rust/src/cpg.rs
+++ b/bindings/rust/src/cpg.rs
@@ -381,7 +381,7 @@ pub fn fd_get(handle: &Handle) -> Result<i32> {
     let c_fd: *mut c_int = &mut 0 as *mut _ as *mut c_int;
     let res = unsafe { ffi::cpg_fd_get(handle.cpg_handle, c_fd) };
     if res == ffi::CS_OK {
-        Ok(c_fd as i32)
+        Ok(unsafe { *c_fd })
     } else {
         Err(CsError::from_c(res))
     }

--- a/bindings/rust/src/quorum.rs
+++ b/bindings/rust/src/quorum.rs
@@ -235,7 +235,7 @@ pub fn fd_get(handle: &Handle) -> Result<i32> {
     let c_fd: *mut c_int = &mut 0 as *mut _ as *mut c_int;
     let res = unsafe { ffi::quorum_fd_get(handle.quorum_handle, c_fd) };
     if res == ffi::CS_OK {
-        Ok(c_fd as i32)
+        Ok(unsafe { *c_fd })
     } else {
         Err(CsError::from_c(res))
     }

--- a/bindings/rust/src/votequorum.rs
+++ b/bindings/rust/src/votequorum.rs
@@ -268,7 +268,7 @@ pub fn fd_get(handle: &Handle) -> Result<i32> {
     let c_fd: *mut c_int = &mut 0 as *mut _ as *mut c_int;
     let res = unsafe { ffi::votequorum_fd_get(handle.votequorum_handle, c_fd) };
     if res == ffi::CS_OK {
-        Ok(c_fd as i32)
+        Ok(unsafe { *c_fd })
     } else {
         Err(CsError::from_c(res))
     }


### PR DESCRIPTION
All fd_get() functions in the Rust bindings were returning the pointer address cast to i32 instead of dereferencing the pointer to retrieve the actual file descriptor value.

The C API signature is:
```c
  cs_error_t xxx_fd_get(xxx_handle_t handle, int *fd);
```
Where fd is an output parameter - the C library writes the file descriptor into the memory pointed to by fd. The Rust wrapper must dereference this pointer to get the value.

Before (WRONG):
```rust
  Ok(c_fd as i32)  // Returns pointer address, e.g. 0xe60d9018 = -435318760
```
After (CORRECT):
```rust
  Ok(unsafe { *c_fd })  // Returns actual fd value, e.g. 5
```
This bug caused "Bad file descriptor (os error 9)" errors when trying to register the returned "file descriptors" with event loops (epoll, tokio AsyncFd, etc.), as the values were actually stack addresses.

Affected functions:
- bindings/rust/src/cfg.rs:169 - corosync_cfg_fd_get
- bindings/rust/src/cmap.rs:152 - cmap_fd_get
- bindings/rust/src/cpg.rs:384 - cpg_fd_get
- bindings/rust/src/quorum.rs:238 - quorum_fd_get
- bindings/rust/src/votequorum.rs:271 - votequorum_fd_get
