### PR TITLE
rust: Allow trailing nul in CPG names - alternative to 809

### DIFF
--- a/bindings/rust/src/cpg.rs
+++ b/bindings/rust/src/cpg.rs
@@ -14,7 +14,7 @@
 use crate::sys::cpg as ffi;
 
 use std::collections::HashMap;
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, CStr};
 use std::fmt;
 use std::os::raw::{c_int, c_void};
 use std::ptr::copy_nonoverlapping;
@@ -202,10 +202,6 @@ fn string_to_cpg_name(group: &str) -> Result<ffi::cpg_name> {
         return Err(CsError::CsErrInvalidParam);
     }
 
-    let c_name = match CString::new(group) {
-        Ok(n) => n,
-        Err(_) => return Err(CsError::CsErrLibrary),
-    };
     let mut c_group = ffi::cpg_name {
         length: group.len() as u32,
         value: [0; CPG_NAMELEN_MAX],
@@ -213,7 +209,11 @@ fn string_to_cpg_name(group: &str) -> Result<ffi::cpg_name> {
 
     unsafe {
         // NOTE param order is 'wrong-way round' from C
-        copy_nonoverlapping(c_name.as_ptr(), c_group.value.as_mut_ptr(), group.len());
+        copy_nonoverlapping(
+            group.as_ptr() as *const c_char,
+            c_group.value.as_mut_ptr(),
+            group.len(),
+        );
     }
 
     Ok(c_group)


### PR DESCRIPTION
A lot of programs (mentioning no Pacemakers) add a trailing nul to CPG names for some reason, despite the cpg_name struct having a member for name length.

To allow Rust to have compatibilty with this I've added some code to the Rust binding that allows strings with \0 be used as CPG names.

eg

cpg::join(&handle, "crmd\0");

will join the crmd group with Pacemaker.

Idea is to remove usage of CString and instead use string pointer directly.

Keep in mind I know almost nothing about Rust so no clue if this is really correct or completely wrong but seems to work just fine and allows multiple \0.