### PR TITLE
cpg: fix permanent stale group members after a node joins and dies during sync

### DIFF
--- a/exec/sync.c
+++ b/exec/sync.c
@@ -537,6 +537,16 @@ void sync_abort (void)
 	ENTER();
 	if (my_state == SYNC_PROCESS) {
 		schedwrk_destroy (my_schedwrk_handle);
+	}
+
+	/*
+	 * A service waiting for the barrier already ran its process phase,
+	 * so its abort callback must run too or per-round state leaks into
+	 * the next round. Skip when no service is being synchronized, which
+	 * is the case before the first and after a completed round.
+	 */
+	if ((my_state == SYNC_PROCESS || my_state == SYNC_BARRIER) &&
+	    my_processing_idx < my_service_list_entries) {
 		if (my_sync_callbacks_retrieve(my_service_list[my_processing_idx].service_id, NULL) != -1) {
 			my_service_list[my_processing_idx].sync_abort ();
 		}


### PR DESCRIPTION
When a node joins the totem ring and its corosync exits again during the same sync round (for example on the `totem.config_version` mismatch check), its already multicast cpg joinlist survives the aborted round, as `sync_abort()` calls no service abort callback while waiting on the barrier.
The next round replays it as a join for a node that is no longer a member, neither the downlist nor the zombie cleanup catches it, and no confchg ever removes the resulting ghost group member.
cpg clients that gather state from all members after a confchg then hang forever - observed with Proxmox VE's pmxcfs, where the cluster filesystem froze on all nodes until the whole cluster got watchdog-fenced.

The first commit drops stale joinlist messages when a new sync round starts, the second makes `sync_abort()` run the abort callback in the barrier phase too.

Reproducer, which triggered this within a few tries on a 15-node cluster:
keep one node's corosync.conf at an older `config_version` and restart corosync there - it joins the ring and exits during sync.
The survivors then log a cpg confchg that still contains the dead node's client pid, `corosync-cpgtool` keeps listing it as a group member while quorum only reports the remaining nodes, and no leave ever follows. With both patches applied the hang did not reproduce in 50 attempts, while CPG debug logging confirmed the stale joinlist still arrived in the aborted rounds and no ghost entry appeared.

This might also be the actual root cause of, or an additional fix for, #660 (similar symptom; the improvements made back then were never really confirmed to address the root cause).