### PR TITLE
totemknet: Warn if ip_dscp option is unsupported

### DIFF
--- a/exec/totemknet.c
+++ b/exec/totemknet.c
@@ -1271,6 +1271,11 @@ int totemknet_initialize (
 	if (res) {
 		KNET_LOGSYS_PERROR(errno, LOGSYS_LEVEL_WARNING, "knet_handle_setprio_dscp failed");
 	}
+#else
+	if (instance->totem_config->ip_dscp) {
+		knet_log_printf(LOGSYS_LEVEL_WARNING, "Ignoring 'ip_dscp' option: Corosync was"
+		  " compiled without knet_handle_setprio_dscp support.");
+	}
 #endif
 	res = knet_handle_enable_filter(instance->knet_handle, instance, dst_host_filter_callback_fn);
 	if (res) {


### PR DESCRIPTION
Follow up of #829 - should have really been part of original patch (mainly because its relevance will become smaller as corosync/knet gets updated by package maintainers) :(, but still nice to have.