### PR TITLE
Use knet_get_crypto_cipher_list and knet_get_crypto_hash_list

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,8 @@ AC_CHECK_LIB([knet],[knet_handle_setprio_dscp],
 	     [AC_DEFINE_UNQUOTED([HAVE_KNET_SETPRIO_DSCP], 1, [have knet dscp traffic prioritization])])
 AC_CHECK_LIB([knet],[knet_get_crypto_cipher_list],
 	     [AC_DEFINE_UNQUOTED([HAVE_KNET_GET_CRYPTO_CIPHER_LIST], 1, [have knet get crypto cipher list])])
+AC_CHECK_LIB([knet],[knet_get_crypto_hash_list],
+	     [AC_DEFINE_UNQUOTED([HAVE_KNET_GET_CRYPTO_HASH_LIST], 1, [have knet get crypto hash list])])
 LIBS="$OLDLIBS"
 
 # Checks for library functions.

--- a/configure.ac
+++ b/configure.ac
@@ -189,6 +189,8 @@ AC_CHECK_LIB([knet],[knet_handle_get_onwire_ver],
 	     [AC_DEFINE_UNQUOTED([HAVE_KNET_ONWIRE_VER], 1, [have knet onwire versioning])])
 AC_CHECK_LIB([knet],[knet_handle_setprio_dscp],
 	     [AC_DEFINE_UNQUOTED([HAVE_KNET_SETPRIO_DSCP], 1, [have knet dscp traffic prioritization])])
+AC_CHECK_LIB([knet],[knet_get_crypto_cipher_list],
+	     [AC_DEFINE_UNQUOTED([HAVE_KNET_GET_CRYPTO_CIPHER_LIST], 1, [have knet get crypto cipher list])])
 LIBS="$OLDLIBS"
 
 # Checks for library functions.

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -614,6 +614,18 @@ static int handle_crypto_model(const char *val, const char **error_string)
 	}
 }
 
+static int handle_crypto_cipher(const char *val, const char **error_string)
+{
+
+	if (util_is_valid_knet_crypto_cipher(val, NULL, 0,
+	    "Invalid cipher type. Should be ", error_string) == 1) {
+		return (0);
+	} else {
+		return (-1);
+	}
+}
+
+
 static int handle_compress_model(const char *val, const char **error_string)
 {
 
@@ -846,13 +858,7 @@ static int main_config_parser_cb(const char *path,
 			}
 
 			if (strcmp(path, "totem.crypto_cipher") == 0) {
-				if ((strcmp(value, "none") != 0) &&
-				    (strcmp(value, "aes256") != 0) &&
-				    (strcmp(value, "aes192") != 0) &&
-				    (strcmp(value, "aes128") != 0)) {
-					*error_string = "Invalid cipher type. "
-					    "Should be none, aes256, aes192 or aes128";
-
+				if (handle_crypto_cipher(value, error_string) != 0) {
 					return (0);
 				}
 			}

--- a/exec/coroparse.c
+++ b/exec/coroparse.c
@@ -625,6 +625,16 @@ static int handle_crypto_cipher(const char *val, const char **error_string)
 	}
 }
 
+static int handle_crypto_hash(const char *val, const char **error_string)
+{
+
+	if (util_is_valid_knet_crypto_hash(val, NULL, 0,
+	    "Invalid hash type. Should be ", error_string) == 1) {
+		return (0);
+	} else {
+		return (-1);
+	}
+}
 
 static int handle_compress_model(const char *val, const char **error_string)
 {
@@ -863,15 +873,7 @@ static int main_config_parser_cb(const char *path,
 				}
 			}
 			if (strcmp(path, "totem.crypto_hash") == 0) {
-				if ((strcmp(value, "none") != 0) &&
-				    (strcmp(value, "md5") != 0) &&
-				    (strcmp(value, "sha1") != 0) &&
-				    (strcmp(value, "sha256") != 0) &&
-				    (strcmp(value, "sha384") != 0) &&
-				    (strcmp(value, "sha512") != 0)) {
-					*error_string = "Invalid hash type. "
-					    "Should be none, md5, sha1, sha256, sha384 or sha512";
-
+				if (handle_crypto_hash(value, error_string) != 0) {
 					return (0);
 				}
 			}

--- a/exec/main.c
+++ b/exec/main.c
@@ -1255,6 +1255,12 @@ static void show_version_info_crypto(void)
 	} else {
 		perror(error_string);
 	}
+
+	if (util_is_valid_knet_crypto_cipher(NULL, &list_str, 1, "", &error_string) != -1) {
+		printf("Available crypto ciphers: %s\n", list_str);
+	} else {
+		perror(error_string);
+	}
 }
 
 static void show_version_info_compress(void)

--- a/exec/main.c
+++ b/exec/main.c
@@ -1261,6 +1261,12 @@ static void show_version_info_crypto(void)
 	} else {
 		perror(error_string);
 	}
+
+	if (util_is_valid_knet_crypto_hash(NULL, &list_str, 1, "", &error_string) != -1) {
+		printf("Available crypto hashes: %s\n", list_str);
+	} else {
+		perror(error_string);
+	}
 }
 
 static void show_version_info_compress(void)

--- a/exec/util.c
+++ b/exec/util.c
@@ -215,6 +215,67 @@ static int safe_strcat(char *dst, size_t dst_len, const char *src)
 	return (0);
 }
 
+#define UTILS_IS_VALID_KNET_LIST_MAX_ITEMS		256
+
+/*
+ * val - string in items array to find
+ * items - array of const char * of items
+ * no_items - size of array
+ * list_str - string with concatenated list of items - can be NULL
+ * machine_parseable_str - 0 - split strings by space, 1 - use human form (split by "," and last item with "or")
+ * error_string_prefix - Prefix to add into error string
+ * error_string - Complete error string
+ */
+static int util_is_valid_knet_list_helper(const char *val,
+	const char **items, size_t no_items,
+	const char **list_str, int machine_parseable_str,
+	const char *error_string_prefix, const char **error_string)
+{
+	static char local_error_str[512];
+	static char local_list_str[256];
+	size_t zi;
+	int model_found = 0;
+
+	if (list_str != NULL) {
+		*list_str = local_list_str;
+	}
+
+	memset(local_error_str, 0, sizeof(local_error_str));
+	memset(local_list_str, 0, sizeof(local_list_str));
+
+	safe_strcat(local_error_str, sizeof(local_error_str), error_string_prefix);
+
+	for (zi = 0; zi < no_items; zi++) {
+		if (zi == 0) {
+		} else if (zi == no_items - 1) {
+			if (machine_parseable_str) {
+				(void)safe_strcat(local_list_str, sizeof(local_list_str), " ");
+			} else {
+				(void)safe_strcat(local_list_str, sizeof(local_list_str), " or ");
+			}
+		} else {
+			if (machine_parseable_str) {
+				(void)safe_strcat(local_list_str, sizeof(local_list_str), " ");
+			} else {
+				(void)safe_strcat(local_list_str, sizeof(local_list_str), ", ");
+			}
+		}
+
+		(void)safe_strcat(local_list_str, sizeof(local_list_str), items[zi]);
+
+		if (val != NULL && strcmp(val, items[zi]) == 0) {
+			model_found = 1;
+		}
+	}
+
+	if (!model_found) {
+		(void)safe_strcat(local_error_str, sizeof(local_error_str), local_list_str);
+		*error_string = local_error_str;
+	}
+
+	return (model_found);
+}
+
 /*
  * val - knet crypto model to find
  * crypto_list_str - string with concatenated list of available crypto models - can be NULL
@@ -227,20 +288,9 @@ int util_is_valid_knet_crypto_model(const char *val,
 	const char *error_string_prefix, const char **error_string)
 {
 	size_t entries;
-	struct knet_crypto_info crypto_list[16];
+	struct knet_crypto_info crypto_list[UTILS_IS_VALID_KNET_LIST_MAX_ITEMS];
+	const char *items[UTILS_IS_VALID_KNET_LIST_MAX_ITEMS];
 	size_t zi;
-	static char local_error_str[512];
-	static char local_list_str[256];
-	int model_found = 0;
-
-	if (list_str != NULL) {
-		*list_str = local_list_str;
-	}
-
-	memset(local_error_str, 0, sizeof(local_error_str));
-	memset(local_list_str, 0, sizeof(local_list_str));
-
-	safe_strcat(local_error_str, sizeof(local_error_str), error_string_prefix);
 
 	if (knet_get_crypto_list(NULL, &entries) != 0) {
 		*error_string = "internal error - cannot get knet crypto list";
@@ -258,55 +308,24 @@ int util_is_valid_knet_crypto_model(const char *val,
 	}
 
 	for (zi = 0; zi < entries; zi++) {
-		if (zi == 0) {
-		} else if (zi == entries - 1) {
-			if (machine_parseable_str) {
-				(void)safe_strcat(local_list_str, sizeof(local_list_str), " ");
-			} else {
-				(void)safe_strcat(local_list_str, sizeof(local_list_str), " or ");
-			}
-		} else {
-			if (machine_parseable_str) {
-				(void)safe_strcat(local_list_str, sizeof(local_list_str), " ");
-			} else {
-				(void)safe_strcat(local_list_str, sizeof(local_list_str), ", ");
-			}
-		}
-
-		(void)safe_strcat(local_list_str, sizeof(local_list_str), crypto_list[zi].name);
-
-		if (val != NULL && strcmp(val, crypto_list[zi].name) == 0) {
-			model_found = 1;
-		}
+		items[zi] = crypto_list[zi].name;
 	}
 
-	if (!model_found) {
-		(void)safe_strcat(local_error_str, sizeof(local_error_str), local_list_str);
-		*error_string = local_error_str;
-	}
-
-	return (model_found);
+	return (util_is_valid_knet_list_helper(val, items, entries, list_str,
+	    machine_parseable_str, error_string_prefix, error_string));
 }
 
+/*
+ * Similar to util_is_valid_knet_crypto_model
+ */
 int util_is_valid_knet_compress_model(const char *val,
 	const char **list_str, int machine_parseable_str,
 	const char *error_string_prefix, const char **error_string)
 {
 	size_t entries;
-	struct knet_compress_info compress_list[16];
+	struct knet_compress_info compress_list[UTILS_IS_VALID_KNET_LIST_MAX_ITEMS];
+	const char *items[UTILS_IS_VALID_KNET_LIST_MAX_ITEMS];
 	size_t zi;
-	static char local_error_str[512];
-	static char local_list_str[256];
-	int model_found = 0;
-
-	if (list_str != NULL) {
-		*list_str = local_list_str;
-	}
-
-	memset(local_error_str, 0, sizeof(local_error_str));
-	memset(local_list_str, 0, sizeof(local_list_str));
-
-	safe_strcat(local_error_str, sizeof(local_error_str), error_string_prefix);
 
 	if (knet_get_compress_list(NULL, &entries) != 0) {
 		*error_string = "internal error - cannot get knet compress list";
@@ -324,34 +343,11 @@ int util_is_valid_knet_compress_model(const char *val,
 	}
 
 	for (zi = 0; zi < entries; zi++) {
-		if (zi == 0) {
-		} else if (zi == entries - 1) {
-			if (machine_parseable_str) {
-				(void)safe_strcat(local_list_str, sizeof(local_list_str), " ");
-			} else {
-				(void)safe_strcat(local_list_str, sizeof(local_list_str), " or ");
-			}
-		} else {
-			if (machine_parseable_str) {
-				(void)safe_strcat(local_list_str, sizeof(local_list_str), " ");
-			} else {
-				(void)safe_strcat(local_list_str, sizeof(local_list_str), ", ");
-			}
-		}
-
-		(void)safe_strcat(local_list_str, sizeof(local_list_str), compress_list[zi].name);
-
-		if (val != NULL && strcmp(val, compress_list[zi].name) == 0) {
-			model_found = 1;
-		}
+		items[zi] = compress_list[zi].name;
 	}
 
-	if (!model_found) {
-		(void)safe_strcat(local_error_str, sizeof(local_error_str), local_list_str);
-		*error_string = local_error_str;
-	}
-
-	return (model_found);
+	return (util_is_valid_knet_list_helper(val, items, entries, list_str,
+	    machine_parseable_str, error_string_prefix, error_string));
 }
 
 int

--- a/exec/util.c
+++ b/exec/util.c
@@ -398,6 +398,56 @@ int util_is_valid_knet_crypto_cipher(const char *val,
 	    machine_parseable_str, error_string_prefix, error_string));
 }
 
+/*
+ * Similar to util_is_valid_knet_crypto_model
+ */
+int util_is_valid_knet_crypto_hash(const char *val,
+	const char **list_str, int machine_parseable_str,
+	const char *error_string_prefix, const char **error_string)
+{
+	const char *items[UTILS_IS_VALID_KNET_LIST_MAX_ITEMS];
+	size_t items_out_idx = 0;
+#ifdef HAVE_KNET_GET_CRYPTO_HASH_LIST
+	size_t entries;
+	size_t zi;
+	struct knet_crypto_hash_info crypto_hash_list[UTILS_IS_VALID_KNET_LIST_MAX_ITEMS];
+#endif
+
+#ifdef ENABLE_UNENCRYPTED
+	items[items_out_idx++] = "none";
+#endif
+
+#ifdef HAVE_KNET_GET_CRYPTO_HASH_LIST
+	if (knet_get_crypto_hash_list(NULL, &entries) != 0) {
+		*error_string = "internal error - cannot get crypto hash list";
+		return (-1);
+	}
+
+	if (entries > (sizeof(crypto_hash_list) / sizeof(crypto_hash_list[0])) - items_out_idx) {
+		*error_string = "internal error - too many knet crypto hash list entries";
+		return (-1);
+	}
+
+	if (knet_get_crypto_hash_list(crypto_hash_list, &entries) != 0) {
+		*error_string = "internal error - cannot get knet crypto hash list";
+		return (-1);
+	}
+
+	for (zi = 0; zi < entries; zi++) {
+		items[items_out_idx++] = crypto_hash_list[zi].name;
+	}
+#else
+	items[items_out_idx++] = "md5";
+	items[items_out_idx++] = "sha1";
+	items[items_out_idx++] = "sha256";
+	items[items_out_idx++] = "sha384";
+	items[items_out_idx++] = "sha512";
+#endif
+
+	return (util_is_valid_knet_list_helper(val, items, items_out_idx, list_str,
+	    machine_parseable_str, error_string_prefix, error_string));
+}
+
 int
 set_socket_dscp(int socket, unsigned char dscp)
 {

--- a/exec/util.c
+++ b/exec/util.c
@@ -350,6 +350,54 @@ int util_is_valid_knet_compress_model(const char *val,
 	    machine_parseable_str, error_string_prefix, error_string));
 }
 
+/*
+ * Similar to util_is_valid_knet_crypto_model
+ */
+int util_is_valid_knet_crypto_cipher(const char *val,
+	const char **list_str, int machine_parseable_str,
+	const char *error_string_prefix, const char **error_string)
+{
+	const char *items[UTILS_IS_VALID_KNET_LIST_MAX_ITEMS];
+	size_t items_out_idx = 0;
+#ifdef HAVE_KNET_GET_CRYPTO_CIPHER_LIST
+	size_t entries;
+	size_t zi;
+	struct knet_crypto_cipher_info crypto_cipher_list[UTILS_IS_VALID_KNET_LIST_MAX_ITEMS];
+#endif
+
+#ifdef ENABLE_UNENCRYPTED
+	items[items_out_idx++] = "none";
+#endif
+
+#ifdef HAVE_KNET_GET_CRYPTO_CIPHER_LIST
+	if (knet_get_crypto_cipher_list(NULL, &entries) != 0) {
+		*error_string = "internal error - cannot get crypto cipher list";
+		return (-1);
+	}
+
+	if (entries > (sizeof(crypto_cipher_list) / sizeof(crypto_cipher_list[0])) - items_out_idx) {
+		*error_string = "internal error - too many knet crypto cipher list entries";
+		return (-1);
+	}
+
+	if (knet_get_crypto_cipher_list(crypto_cipher_list, &entries) != 0) {
+		*error_string = "internal error - cannot get knet crypto cipher list";
+		return (-1);
+	}
+
+	for (zi = 0; zi < entries; zi++) {
+		items[items_out_idx++] = crypto_cipher_list[zi].name;
+	}
+#else
+	items[items_out_idx++] = "aes256";
+	items[items_out_idx++] = "aes192";
+	items[items_out_idx++] = "aes128";
+#endif
+
+	return (util_is_valid_knet_list_helper(val, items, items_out_idx, list_str,
+	    machine_parseable_str, error_string_prefix, error_string));
+}
+
 int
 set_socket_dscp(int socket, unsigned char dscp)
 {

--- a/exec/util.h
+++ b/exec/util.h
@@ -95,6 +95,10 @@ extern int util_is_valid_knet_compress_model(const char *val,
 	const char **list_str, int machine_parseable_str,
 	const char *error_string_prefix, const char **error_string);
 
+extern int util_is_valid_knet_crypto_cipher(const char *val,
+	const char **list_str, int machine_parseable_str,
+	const char *error_string_prefix, const char **error_string);
+
 int set_socket_dscp(int socket, unsigned char dscp);
 
 #endif /* UTIL_H_DEFINED */

--- a/exec/util.h
+++ b/exec/util.h
@@ -99,6 +99,10 @@ extern int util_is_valid_knet_crypto_cipher(const char *val,
 	const char **list_str, int machine_parseable_str,
 	const char *error_string_prefix, const char **error_string);
 
+extern int util_is_valid_knet_crypto_hash(const char *val,
+	const char **list_str, int machine_parseable_str,
+	const char *error_string_prefix, const char **error_string);
+
 int set_socket_dscp(int socket, unsigned char dscp);
 
 #endif /* UTIL_H_DEFINED */


### PR DESCRIPTION
Honestly, I would really like to squeeze code even more but I was unable to find some portable clean way how to do so (without using some hacks like "name is always first field" or offsetof or whatever) other than this solution. I'm open to the ideas, but really like to keep compiler ability to do proper type checking.