### PR TITLE
Fix rest of new issues found by Coverity 202603

### DIFF
--- a/lib/cpg.c
+++ b/lib/cpg.c
@@ -88,8 +88,8 @@ struct cpg_inst {
 	qb_ipcc_connection_t *c;
 	int finalize;
 	void *context;
+	cpg_model_t model;
 	union {
-		cpg_model_data_t model_data;
 		cpg_model_v1_data_t model_v1_data;
 	};
 	struct qb_list_head iteration_list_head;
@@ -222,7 +222,7 @@ cs_error_t cpg_model_initialize (
 
 	/* Allow space for corosync internal headers */
 	cpg_inst->max_msg_size = IPC_REQUEST_SIZE - 1024;
-	cpg_inst->model_data.model = model;
+	cpg_inst->model = model;
 	cpg_inst->context = context;
 
 	qb_list_init(&cpg_inst->iteration_list_head);
@@ -439,7 +439,7 @@ cs_error_t cpg_dispatch (
 		 * operate at the same time that cpgFinalize has been called.
 		 */
 		memcpy (&cpg_inst_copy, cpg_inst, sizeof (struct cpg_inst));
-		switch (cpg_inst_copy.model_data.model) {
+		switch (cpg_inst_copy.model) {
 		case CPG_MODEL_V1:
 			/*
 			 * Dispatch incoming message
@@ -615,7 +615,7 @@ cs_error_t cpg_dispatch (
 				break;
 			} /* - switch (dispatch_data->id) */
 			break; /* case CPG_MODEL_V1 */
-		} /* - switch (cpg_inst_copy.model_data.model) */
+		} /* - switch (cpg_inst_copy.model) */
 
 		if (cpg_inst_copy.finalize || cpg_inst->finalize) {
 			/*
@@ -664,7 +664,7 @@ cs_error_t cpg_join (
 	req_lib_cpg_join.pid = getpid();
 	req_lib_cpg_join.flags = 0;
 
-	switch (cpg_inst->model_data.model) {
+	switch (cpg_inst->model) {
 	case CPG_MODEL_V1:
 		req_lib_cpg_join.flags = cpg_inst->model_v1_data.flags;
 		break;

--- a/lib/quorum.c
+++ b/lib/quorum.c
@@ -59,8 +59,8 @@ struct quorum_inst {
 	qb_ipcc_connection_t *c;
 	int finalize;
 	const void *context;
+	quorum_model_t model;
 	union {
-		quorum_model_data_t model_data;
 		quorum_model_v0_data_t model_v0_data;
 		quorum_model_v1_data_t model_v1_data;
 	};
@@ -185,7 +185,7 @@ cs_error_t quorum_model_initialize (
 		}
 	}
 
-	quorum_inst->model_data.model = model;
+	quorum_inst->model = model;
 	quorum_inst->context = context;
 
 	(void)hdb_handle_put (&quorum_handle_t_db, *handle);
@@ -490,7 +490,7 @@ cs_error_t quorum_dispatch (
 		 * operate at the same time that quorum_finalize has been called in another thread.
 		 */
 		memcpy (&quorum_inst_copy, quorum_inst, sizeof(quorum_inst_copy));
-		switch (quorum_inst_copy.model_data.model) {
+		switch (quorum_inst_copy.model) {
 		case QUORUM_MODEL_V0:
 			/*
 			 * Dispatch incoming message


### PR DESCRIPTION
The union access was valid, because all models data always contains model enum as a first field "super class" (cpg_model_data_t) included.

But to make code a bit more cleaner, "super class" is removed from internal data union and instead explicit model enum is added outside of union.

This, together with cpg zcb removal makes coverity report 0 problems.