### PR TITLE
rust: Fix warnings issued by newer rustc

### DIFF
--- a/bindings/rust/Makefile.am
+++ b/bindings/rust/Makefile.am
@@ -37,19 +37,19 @@ RUST_BUILT_SRCS		= \
 			  src/sys/cmap.rs
 
 src/sys/cpg.rs: cargo-tree-prep ../../include/corosync/cpg.h
-	$(top_srcdir)/build-aux/rust-regen.sh $(top_srcdir)/include/corosync/cpg.h $@ CPG --blocklist-function=inet6.* --blocklist-function==.*etsourcefilter -- -I$(top_srcdir)/include
+	$(top_srcdir)/build-aux/rust-regen.sh $(BINDGEN) $(top_srcdir)/include/corosync/cpg.h $@ cpg -- -I$(top_srcdir)/include
 
 src/sys/cfg.rs: cargo-tree-prep ../../include/corosync/cfg.h
-	$(top_srcdir)/build-aux/rust-regen.sh $(top_srcdir)/include/corosync/cfg.h $@ CFG --blocklist-function=inet6.* --blocklist-function=.*etsourcefilter -- -I$(top_srcdir)/include
+	$(top_srcdir)/build-aux/rust-regen.sh $(BINDGEN) $(top_srcdir)/include/corosync/cfg.h $@ corosync_cfg -- -I$(top_srcdir)/include
 
 src/sys/quorum.rs: cargo-tree-prep ../../include/corosync/quorum.h
-	$(top_srcdir)/build-aux/rust-regen.sh $(top_srcdir)/include/corosync/quorum.h $@ QUORUM -- -I$(top_srcdir)/include
+	$(top_srcdir)/build-aux/rust-regen.sh $(BINDGEN) $(top_srcdir)/include/corosync/quorum.h $@ quorum -- -I$(top_srcdir)/include
 
 src/sys/votequorum.rs: cargo-tree-prep ../../include/corosync/votequorum.h
-	$(top_srcdir)/build-aux/rust-regen.sh $(top_srcdir)/include/corosync/votequorum.h $@ VOTEQUORUM -- -I$(top_srcdir)/include
+	$(top_srcdir)/build-aux/rust-regen.sh $(BINDGEN) $(top_srcdir)/include/corosync/votequorum.h $@ votequorum -- -I$(top_srcdir)/include
 
 src/sys/cmap.rs: cargo-tree-prep ../../include/corosync/cmap.h
-	$(top_srcdir)/build-aux/rust-regen.sh $(top_srcdir)/include/corosync/cmap.h $@ CMAP -- -I$(top_srcdir)/include $(LIBQB_CFLAGS)
+	$(top_srcdir)/build-aux/rust-regen.sh $(BINDGEN) $(top_srcdir)/include/corosync/cmap.h $@ cmap -- -I$(top_srcdir)/include $(LIBQB_CFLAGS)
 
 all-local: target/$(RUST_TARGET_DIR)/cpg.rlib \
 	target/$(RUST_TARGET_DIR)/cfg.rlib \

--- a/build-aux/rust-regen.sh
+++ b/build-aux/rust-regen.sh
@@ -11,18 +11,18 @@
 # Regerate the FFI bindings in src/sys from the current headers
 #
 
-srcheader="$1"
-dstrs="$2"
-filter="$3"
-shift; shift; shift
+bindgen="$1"
+srcheader="$2"
+dstrs="$3"
+filter="$4"
+shift 4
 
-bindgen \
+"$bindgen" \
 	--no-prepend-enum-name \
 	--no-layout-tests \
 	--no-doc-comments \
 	--generate functions,types \
 	--fit-macro-constant-types \
-	--allowlist-var=$filter.*  \
-	--allowlist-type=.* \
-	--allowlist-function=.* \
-	$srcheader -o $dstrs "$@"
+	--allowlist-type="^(${filter}_.*)" \
+	--allowlist-function="^(${filter}_.*)" \
+	"$srcheader" -o "$dstrs" "$@"


### PR DESCRIPTION
Warnings were issued because bindgen generated prototypes for all functions, including standard ones like memcpy. The solution used in this patch is to narrow the number of generated prototypes to the bare minimum.

Variables were never generated, so the filter parameter in rust-regen.sh was basically a no-op. Instead, the filter is now used to allowlist types and functions. This results in generating only prototypes with a given prefix (luckily, all Corosync types/functions in headers are properly prefixed). This also means all blocklists could be removed.

Lastly (and most importantly), the ./configure detected bindgen path is now passed to rust-regen.sh, so it calls the correct binary instead of just the first one found in the $PATH.